### PR TITLE
feat: humanized typing — human.type() with rhythm, typos, and backspace recovery

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -10,6 +10,7 @@ import {
   PersonalityLab,
   Playground,
   TrustStrip,
+  TypingShowcase,
 } from '../components/sections';
 
 export default function Page() {
@@ -20,6 +21,7 @@ export default function Page() {
         <Hero />
         <Comparison />
         <Playground />
+        <TypingShowcase />
         <Audience />
         <FeatureBento />
         <PersonalityLab />

--- a/apps/web/components/motion/TypingDemo.tsx
+++ b/apps/web/components/motion/TypingDemo.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import {
+  createRng,
+  type Keystroke,
+  type PresetName,
+  planTypeKeystrokes,
+  resolvePersonality,
+} from '@humanjs/core';
+import { motion, useInView, useReducedMotion } from 'framer-motion';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { IN_VIEW_MARGIN } from '../../lib/motion';
+import { DemoStatusBar } from './DemoStatusBar';
+
+/**
+ * Phrase the demo types. Brand-direct, scoped to what HumanJS actually does.
+ * Three short sentences keep visual rhythm with the rest of the site.
+ */
+const PHRASE = 'Real keystrokes. Real rhythm. Real backspace recovery.';
+
+/**
+ * Demo-only speed factor per personality. The library's per-personality
+ * timing is honest about how each personality types — but at landing-page
+ * scale, `distracted` (234 ms/char raw + bimodal typo hesitations) is long
+ * enough to feel laggy. This multiplier smooths that one personality for
+ * visualization WITHOUT touching the library's runtime values. The other
+ * three personalities run at their real library pace.
+ */
+const DEMO_SPEED_FACTORS: Record<PresetName, number> = {
+  careful: 1.0,
+  precise: 1.0,
+  fast: 1.0,
+  distracted: 0.7, // speed the demo's `distracted` up a touch — still slowest of the four
+};
+
+/** How long to sit at the finished state before erasing and replaying. */
+const LOOP_REST_MS = 2400;
+/** How long to spend erasing on a loop reset. */
+const LOOP_ERASE_MS = 700;
+
+interface TypingDemoProps {
+  personality: PresetName;
+  className?: string;
+}
+
+/**
+ * Landing-page typing demo. Drives the same `@humanjs/core` planner that
+ * `@humanjs/playwright`'s `executeType` uses, so what visitors see on this
+ * page is the same rhythm the library actually produces against a browser.
+ *
+ * The demo loops: type → settle → erase → type again. Switching personalities
+ * resets the loop with a freshly-seeded plan.
+ */
+export function TypingDemo({ personality, className }: TypingDemoProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const inView = useInView(containerRef, { margin: IN_VIEW_MARGIN });
+
+  const profile = useMemo(() => resolvePersonality(personality), [personality]);
+
+  const plan = useMemo<readonly Keystroke[]>(
+    () =>
+      planTypeKeystrokes(PHRASE, profile.typing, createRng(`type-demo-${personality}`), {
+        personalitySpeed: profile.speed,
+        speedFactor: DEMO_SPEED_FACTORS[personality] ?? 1,
+      }),
+    [personality, profile.typing, profile.speed],
+  );
+
+  const [typed, setTyped] = useState('');
+  const [stats, setStats] = useState({ typos: 0, corrections: 0, done: false });
+  /**
+   * Index of the typo char currently visible in `typed`, if any — used for
+   * red-flash highlighting. When the next Backspace fires, this clears.
+   */
+  const [typoIndex, setTypoIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (shouldReduceMotion) {
+      setTyped(PHRASE);
+      setStats({ typos: 0, corrections: 0, done: true });
+      setTypoIndex(null);
+      return;
+    }
+    if (!inView) return;
+
+    setTyped('');
+    setStats({ typos: 0, corrections: 0, done: false });
+    setTypoIndex(null);
+
+    let i = 0;
+    let typos = 0;
+    let corrections = 0;
+    let timer: number;
+    let cancelled = false;
+
+    const playNext = () => {
+      if (cancelled) return;
+      if (i >= plan.length) {
+        setStats((s) => ({ ...s, done: true }));
+        // Rest at the final state, then erase + replay.
+        timer = window.setTimeout(eraseAndLoop, LOOP_REST_MS);
+        return;
+      }
+      const step = plan[i];
+      if (!step) return;
+      timer = window.setTimeout(() => {
+        if (cancelled) return;
+        if (step.key === 'Backspace') {
+          setTyped((prev) => prev.slice(0, -1));
+          setTypoIndex(null);
+          corrections++;
+        } else {
+          setTyped((prev) => {
+            const next = prev + visibleChar(step.key);
+            if (step.isTypo) setTypoIndex(next.length - 1);
+            else setTypoIndex(null);
+            return next;
+          });
+          if (step.isTypo) typos++;
+        }
+        setStats((s) => ({ ...s, typos, corrections }));
+        i++;
+        playNext();
+      }, step.delayBeforeMs);
+    };
+
+    const eraseAndLoop = () => {
+      if (cancelled) return;
+      const stepDelay = Math.max(20, LOOP_ERASE_MS / Math.max(1, PHRASE.length));
+      const erase = () => {
+        if (cancelled) return;
+        setTyped((prev) => {
+          if (prev.length === 0) {
+            // Reset stats + restart the plan from index 0.
+            i = 0;
+            typos = 0;
+            corrections = 0;
+            setStats({ typos: 0, corrections: 0, done: false });
+            setTypoIndex(null);
+            playNext();
+            return prev;
+          }
+          timer = window.setTimeout(erase, stepDelay);
+          return prev.slice(0, -1);
+        });
+      };
+      erase();
+    };
+
+    playNext();
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [plan, inView, shouldReduceMotion]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`overflow-hidden rounded-card-lg border border-hairline bg-surface ${className ?? ''}`}
+    >
+      <DemoStatusBar
+        label="human.type()"
+        sublabel={
+          <>
+            personality: <span className="text-accent">{personality}</span>
+          </>
+        }
+      />
+
+      <div className="px-6 py-10 md:px-10 md:py-14" aria-hidden>
+        <p className="mb-4 font-mono text-[10px] uppercase tracking-[0.18em] text-muted">
+          target — <span className="text-muted-strong">{PHRASE}</span>
+        </p>
+
+        <div className="relative rounded-card border border-hairline bg-canvas px-5 py-5 md:px-6 md:py-6">
+          <p className="min-h-[1.5em] font-mono text-base leading-relaxed text-accent md:text-lg">
+            <TypedDisplay value={typed} typoIndex={typoIndex} />
+            {!shouldReduceMotion && !stats.done && <BlinkingCaret />}
+          </p>
+        </div>
+
+        <div className="mt-6 flex flex-wrap items-baseline gap-x-6 gap-y-2 font-mono text-[10px] uppercase tracking-[0.18em] text-muted">
+          <Stat label="characters" value={`${typed.length} / ${PHRASE.length}`} />
+          <Stat label="typos" value={stats.typos.toString()} />
+          <Stat label="corrections" value={stats.corrections.toString()} />
+          <span className="ml-auto font-mono text-[10px] text-muted/70">
+            {stats.done ? '✓ done' : 'typing…'}
+          </span>
+        </div>
+      </div>
+
+      {/* Screen-reader description — the visual demo is decorative; this is
+          the canonical description of what's happening for AT users. */}
+      <span className="sr-only">
+        Live demonstration of HumanJS&rsquo;s `human.type()` typing the phrase &ldquo;{PHRASE}
+        &rdquo; with the {personality} personality — including occasional typos and backspace
+        recovery. Switch personality with the controls above to compare rhythms.
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Renders the typed string with a red flash on the typo character (if any).
+ * The highlight clears once the next Backspace step removes the char.
+ */
+function TypedDisplay({ value, typoIndex }: { value: string; typoIndex: number | null }) {
+  if (typoIndex === null) return <>{value}</>;
+  return (
+    <>
+      {value.slice(0, typoIndex)}
+      <span className="rounded-[2px] bg-red-500/20 text-red-300/90">
+        {value.slice(typoIndex, typoIndex + 1)}
+      </span>
+      {value.slice(typoIndex + 1)}
+    </>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="inline-flex items-baseline gap-2">
+      <span>{label}</span>
+      <span className="font-mono text-base tabular-nums text-foreground md:text-lg">{value}</span>
+    </span>
+  );
+}
+
+function BlinkingCaret() {
+  return (
+    <motion.span
+      aria-hidden
+      animate={{ opacity: [1, 1, 0, 0] }}
+      transition={{ duration: 1.05, repeat: Number.POSITIVE_INFINITY, times: [0, 0.5, 0.5, 1] }}
+      className="ml-0.5 inline-block h-[1em] w-[2px] -translate-y-[2px] bg-accent align-middle"
+    />
+  );
+}
+
+/**
+ * Maps a planned key back to a visible character for the on-screen display.
+ * `Enter`/`Tab` are mapped to ' ' so the typed string doesn't grow visually
+ * weird mid-phrase — they only matter for real keyboard event semantics.
+ */
+function visibleChar(key: string): string {
+  if (key === 'Enter') return '\n';
+  if (key === 'Tab') return '\t';
+  if (key === 'Backspace') return '';
+  return key;
+}

--- a/apps/web/components/sections/TypingShowcase.tsx
+++ b/apps/web/components/sections/TypingShowcase.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import type { PresetName } from '@humanjs/core';
+import { motion } from 'framer-motion';
+import { useState } from 'react';
+import { cn } from '../../lib/cn';
+import { TypingDemo } from '../motion/TypingDemo';
+import { Container, ScrollReveal, Section, SectionEyebrow, SectionHeadline } from '../primitives';
+
+const personalities: { key: PresetName; label: string; hint: string }[] = [
+  { key: 'careful', label: 'careful', hint: 'measured' },
+  { key: 'fast', label: 'fast', hint: 'brisk' },
+  { key: 'distracted', label: 'distracted', hint: 'more typos' },
+  { key: 'precise', label: 'precise', hint: 'almost no errors' },
+];
+
+export function TypingShowcase() {
+  const [personality, setPersonality] = useState<PresetName>('careful');
+
+  return (
+    <Section id="typing" density="default">
+      <Container width="lg">
+        <ScrollReveal>
+          <div className="mb-10 max-w-3xl md:mb-12">
+            <SectionEyebrow>Now the keyboard</SectionEyebrow>
+            <SectionHeadline data-ghost-cursor="true">
+              Real rhythm. <span className="font-display italic text-accent">Real typos.</span>
+            </SectionHeadline>
+            <p className="mt-6 max-w-xl text-balance text-base text-muted-strong md:text-lg">
+              The cursor isn&rsquo;t the only thing that gives an automation away. HumanJS types at
+              the personality&rsquo;s natural pace — with optional typos and the backspace recovery
+              a real user would do without thinking.
+            </p>
+          </div>
+        </ScrollReveal>
+
+        <ScrollReveal delay={0.08}>
+          <div className="mx-auto max-w-4xl">
+            <div className="mb-3 flex flex-wrap items-center gap-2">
+              <span className="mr-2 font-mono text-[10px] uppercase tracking-[0.18em] text-muted/70">
+                Personality
+              </span>
+              {personalities.map((p) => (
+                <button
+                  key={p.key}
+                  type="button"
+                  aria-pressed={personality === p.key}
+                  onClick={() => setPersonality(p.key)}
+                  className={cn(
+                    'relative rounded-full border px-3 py-1 font-mono text-[11px] uppercase tracking-[0.15em] transition-colors duration-200 outline-none focus-visible:ring-2 focus-visible:ring-accent',
+                    personality === p.key
+                      ? 'border-accent/50 bg-accent/10 text-accent'
+                      : 'border-hairline text-muted hover:border-hairline-strong hover:text-foreground',
+                  )}
+                >
+                  {personality === p.key && (
+                    <motion.span
+                      layoutId="typing-personality-marker"
+                      className="absolute inset-0 rounded-full border border-accent/30"
+                      transition={{ type: 'spring', bounce: 0.18, duration: 0.45 }}
+                    />
+                  )}
+                  <span className="relative">
+                    {p.label}
+                    <span className="ml-1.5 text-muted/60">· {p.hint}</span>
+                  </span>
+                </button>
+              ))}
+            </div>
+            <TypingDemo personality={personality} />
+          </div>
+        </ScrollReveal>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/components/sections/index.ts
+++ b/apps/web/components/sections/index.ts
@@ -9,3 +9,4 @@ export { Nav } from './Nav';
 export { PersonalityLab } from './PersonalityLab';
 export { Playground } from './Playground';
 export { TrustStrip } from './TrustStrip';
+export { TypingShowcase } from './TypingShowcase';

--- a/examples/package.json
+++ b/examples/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "click": "tsx click-demo.ts",
-    "compare": "tsx compare-demo.ts"
+    "compare": "tsx compare-demo.ts",
+    "type": "tsx type-demo.ts"
   },
   "dependencies": {
     "@humanjs/playwright": "workspace:*",

--- a/examples/type-demo.ts
+++ b/examples/type-demo.ts
@@ -1,0 +1,219 @@
+/**
+ * HumanJS type demo — opens a real Chrome window and types a sentence into
+ * a focused input so you can watch the per-key rhythm, typos, and backspace
+ * recoveries unfold at the personality's natural pace.
+ *
+ * Run with:
+ *   pnpm demo:type
+ *
+ * Compare personalities by re-running with:
+ *   PERSONALITY=careful     pnpm demo:type   (default)
+ *   PERSONALITY=fast        pnpm demo:type
+ *   PERSONALITY=precise     pnpm demo:type
+ *   PERSONALITY=distracted  pnpm demo:type
+ */
+
+import { createHuman } from '@humanjs/playwright';
+import { chromium } from 'playwright';
+import { parsePersonality } from './lib';
+
+// Brand-direct phrase that matches the rest of the HumanJS surface area:
+// three short sentences that describe what `human.type()` actually does.
+const PHRASE = 'Real keystrokes. Real rhythm. Real backspace recovery.';
+
+const DEMO_HTML = /* html */ `
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>HumanJS type demo</title>
+    <style>
+      :root { color-scheme: dark; }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at 30% 20%, #1a1a2e, #0a0a0a);
+        color: #fff;
+        font-family: -apple-system, system-ui, sans-serif;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 64px 32px;
+      }
+      .header {
+        text-align: center;
+        margin-bottom: 48px;
+      }
+      .header h1 {
+        margin: 0 0 6px;
+        font-size: 28px;
+        font-weight: 600;
+        letter-spacing: -0.02em;
+      }
+      .header p {
+        margin: 0;
+        color: #888;
+        font-size: 14px;
+      }
+      .phrase {
+        font-family: ui-monospace, SF Mono, monospace;
+        color: #666;
+        font-size: 13px;
+        margin-bottom: 18px;
+        letter-spacing: 0.02em;
+      }
+      .phrase span { color: #f5a55c; }
+      .input-wrap {
+        position: relative;
+        width: min(720px, 100%);
+      }
+      input {
+        width: 100%;
+        padding: 22px 26px;
+        font-size: 22px;
+        font-family: ui-monospace, SF Mono, monospace;
+        color: #f5a55c;
+        background: #0c0b0a;
+        border: 1px solid #2a2a2a;
+        border-radius: 14px;
+        outline: none;
+        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      }
+      input:focus {
+        border-color: rgba(245, 165, 92, 0.4);
+        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4), 0 0 0 4px rgba(245, 165, 92, 0.08);
+      }
+      .meta {
+        margin-top: 24px;
+        display: flex;
+        gap: 28px;
+        font-family: ui-monospace, SF Mono, monospace;
+        font-size: 12px;
+        color: #777;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+      }
+      .meta b {
+        display: block;
+        color: #f0ece5;
+        font-size: 18px;
+        margin-top: 4px;
+        font-weight: 500;
+        letter-spacing: 0;
+        text-transform: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <h1>HumanJS type demo</h1>
+      <p>Real per-key rhythm. Real typos. Real backspace recovery.</p>
+    </div>
+
+    <div class="phrase">
+      target — <span id="target-phrase"></span>
+    </div>
+
+    <div class="input-wrap">
+      <input id="field" autocomplete="off" spellcheck="false" placeholder="typing…" />
+    </div>
+
+    <div class="meta">
+      <div>Personality<b id="personality">—</b></div>
+      <div>Characters<b id="chars">0</b></div>
+      <div>Elapsed<b id="elapsed">0.0s</b></div>
+    </div>
+
+    <script>
+      document.getElementById('target-phrase').textContent = ${JSON.stringify(PHRASE)};
+      const field = document.getElementById('field');
+      const chars = document.getElementById('chars');
+      const elapsed = document.getElementById('elapsed');
+      let startedAt = null;
+      field.addEventListener('input', () => {
+        if (startedAt === null) startedAt = performance.now();
+        chars.textContent = field.value.length;
+      });
+      function tickElapsed() {
+        if (startedAt !== null) {
+          const sec = ((performance.now() - startedAt) / 1000).toFixed(1);
+          elapsed.textContent = sec + 's';
+        }
+        requestAnimationFrame(tickElapsed);
+      }
+      requestAnimationFrame(tickElapsed);
+    </script>
+  </body>
+</html>
+`;
+
+async function main() {
+  const personality = parsePersonality(process.env.PERSONALITY, 'careful', 'PERSONALITY');
+
+  const browser = await chromium.launch({
+    headless: false,
+    args: ['--window-size=1100,720'],
+  });
+  try {
+    const context = await browser.newContext({
+      viewport: { width: 1100, height: 720 },
+    });
+    const page = await context.newPage();
+
+    await page.setContent(DEMO_HTML);
+    await page.evaluate((name) => {
+      const el = document.getElementById('personality');
+      if (el) el.textContent = name;
+    }, personality);
+
+    console.log(`Personality: ${personality}`);
+    console.log(`Typing: "${PHRASE}"\n`);
+
+    const human = await createHuman(page, {
+      personality,
+      seed: 'type-demo-1',
+      plugins: [
+        {
+          name: 'logger',
+          beforeAction: (action) =>
+            console.log(`→ ${action.type} ${JSON.stringify(action.params)}`),
+          afterAction: (action, result) => {
+            const length = (action.params?.length as number) ?? 0;
+            const perChar = length > 0 ? (result.durationMs / length).toFixed(1) : '—';
+            console.log(`✓ ${action.type} took ${result.durationMs}ms (${perChar}ms/char)`);
+          },
+        },
+      ],
+    });
+
+    // Give the page a beat to render before we focus + type.
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    await human.type('#field', PHRASE);
+
+    // Read the final value so we can show whether any typos were left
+    // uncorrected — that's a real personality signal, not a bug.
+    const finalValue = await page.locator('#field').inputValue();
+    console.log(`\nFinal value: "${finalValue}"`);
+    if (finalValue !== PHRASE) {
+      console.log('⚠  Final string differs from target — uncorrected typos are expected at');
+      console.log(
+        '   `typoCorrectionProbability < 1`. Try PERSONALITY=precise for cleaner output.',
+      );
+    }
+
+    console.log('\nDone. Browser will stay open for 5 seconds.');
+    console.log('Tip: re-run with PERSONALITY=fast (or precise / distracted) to compare.');
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "clean": "turbo run clean && rm -rf node_modules",
     "prepare": "lefthook install",
     "demo:click": "turbo run build --filter=@humanjs/playwright... && pnpm --filter @humanjs/examples click",
-    "demo:compare": "turbo run build --filter=@humanjs/playwright... && pnpm --filter @humanjs/examples compare"
+    "demo:compare": "turbo run build --filter=@humanjs/playwright... && pnpm --filter @humanjs/examples compare",
+    "demo:type": "turbo run build --filter=@humanjs/playwright... && pnpm --filter @humanjs/examples type"
   },
   "commitlint": {
     "extends": [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,3 +33,5 @@ export type {
 export { resolvePersonality } from './resolve';
 export type { Rng } from './rng';
 export { createRng } from './rng';
+export type { Keystroke, PlanTypingOptions } from './typing';
+export { planTypeKeystrokes } from './typing';

--- a/packages/core/src/presets/fast.ts
+++ b/packages/core/src/presets/fast.ts
@@ -3,6 +3,11 @@ import type { Personality } from '../personality';
 /**
  * Quick but still natural. Fewer pauses, lower typo rate, shorter dwell.
  * Good for sessions where the user "knows the app".
+ *
+ * Typing pace: `baseDelayMs × speed` = 130 × 0.5 = 65 ms/char ≈ 185 wpm.
+ * That's a real top-tier touch typist — fast enough to feel brisk, slow
+ * enough to stay inside the human envelope. The library is called HumanJS;
+ * none of the presets should type faster than a real human can.
  */
 export const fast: Personality = {
   name: 'fast',
@@ -15,7 +20,7 @@ export const fast: Personality = {
     misclickProbability: 0.005,
   },
   typing: {
-    baseDelayMs: 60,
+    baseDelayMs: 130,
     delayJitter: 0.25,
     typoProbability: 0.015,
     typoCorrectionProbability: 0.9,

--- a/packages/core/src/presets/presets.test.ts
+++ b/packages/core/src/presets/presets.test.ts
@@ -52,6 +52,18 @@ describe('built-in presets', () => {
         expect(preset.reading.wpm).toBeLessThan(500);
       });
 
+      it('types at a plausible human WPM', () => {
+        // Effective per-character delay = baseDelayMs × speed.
+        // Convert to WPM via the canonical 5-chars-per-word convention.
+        const msPerChar = preset.typing.baseDelayMs * preset.speed;
+        const wpm = 60_000 / (msPerChar * 5);
+        // World-record typing tops out around 216 wpm. We clamp comfortably
+        // below the record so even our "fast" personality stays clearly human.
+        // Floor allows for distracted/half-attentive typing.
+        expect(wpm).toBeGreaterThan(20);
+        expect(wpm).toBeLessThan(200);
+      });
+
       it('uses positive timing values', () => {
         expect(preset.mouse.travelTimeMs).toBeGreaterThan(0);
         expect(preset.typing.baseDelayMs).toBeGreaterThan(0);

--- a/packages/core/src/typing/index.test.ts
+++ b/packages/core/src/typing/index.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { careful, fast } from '../presets';
+import { createRng } from '../rng';
+import { planTypeKeystrokes } from './index';
+
+const NO_RANDOMNESS = {
+  baseDelayMs: 0,
+  delayJitter: 0,
+  typoProbability: 0,
+  typoCorrectionProbability: 0,
+  thinkPauseProbability: 0,
+  thinkPauseMeanMs: 0,
+};
+
+describe('planTypeKeystrokes', () => {
+  it('emits one keystroke per character with no typos / no delays', () => {
+    const plan = planTypeKeystrokes('abc', NO_RANDOMNESS, createRng('t1'));
+    expect(plan.map((k) => k.key)).toEqual(['a', 'b', 'c']);
+    expect(plan.every((k) => !k.isTypo && !k.isCorrection)).toBe(true);
+  });
+
+  it('maps newline to Enter and tab to Tab', () => {
+    const plan = planTypeKeystrokes('a\nb\tc', NO_RANDOMNESS, createRng('t2'));
+    expect(plan.map((k) => k.key)).toEqual(['a', 'Enter', 'b', 'Tab', 'c']);
+  });
+
+  it('normalizes \\r and \\r\\n line endings to Enter', () => {
+    const plan = planTypeKeystrokes('a\rb\r\nc', NO_RANDOMNESS, createRng('t3'));
+    expect(plan.map((k) => k.key)).toEqual(['a', 'Enter', 'b', 'Enter', 'c']);
+  });
+
+  it('returns an empty plan for an empty string', () => {
+    const plan = planTypeKeystrokes('', careful.typing, createRng('empty'));
+    expect(plan).toEqual([]);
+  });
+
+  it('injects a typo + Backspace + correct when typoProbability and correction are 1', () => {
+    const plan = planTypeKeystrokes(
+      'a',
+      { ...NO_RANDOMNESS, typoProbability: 1, typoCorrectionProbability: 1 },
+      createRng('typo-1'),
+    );
+    expect(plan).toHaveLength(3);
+    expect(plan[0]?.isTypo).toBe(true);
+    expect(plan[0]?.key).not.toBe('a');
+    expect(plan[1]?.key).toBe('Backspace');
+    expect(plan[1]?.isCorrection).toBe(true);
+    expect(plan[2]?.key).toBe('a');
+    expect(plan[2]?.isCorrection).toBe(false);
+  });
+
+  it('leaves the typo in place when correction probability is 0', () => {
+    const plan = planTypeKeystrokes(
+      'a',
+      { ...NO_RANDOMNESS, typoProbability: 1, typoCorrectionProbability: 0 },
+      createRng('typo-2'),
+    );
+    expect(plan).toHaveLength(1);
+    expect(plan[0]?.isTypo).toBe(true);
+    expect(plan[0]?.key).not.toBe('a');
+  });
+
+  it('preserves letter case in typo-adjacent keys (uppercase → uppercase)', () => {
+    const plan = planTypeKeystrokes(
+      'H',
+      { ...NO_RANDOMNESS, typoProbability: 1, typoCorrectionProbability: 0 },
+      createRng('case'),
+    );
+    expect(plan).toHaveLength(1);
+    const wrong = plan[0]?.key ?? '';
+    expect(wrong).toMatch(/^[A-Z]$/);
+    expect(wrong).not.toBe('H');
+  });
+
+  it('produces an identical plan for the same seed and inputs (determinism)', () => {
+    const a = planTypeKeystrokes('hello world', careful.typing, createRng('determinism-seed'));
+    const b = planTypeKeystrokes('hello world', careful.typing, createRng('determinism-seed'));
+    expect(a).toEqual(b);
+  });
+
+  it('produces a different plan for different seeds', () => {
+    const a = planTypeKeystrokes('hello world', careful.typing, createRng('seed-a'));
+    const b = planTypeKeystrokes('hello world', careful.typing, createRng('seed-b'));
+    // The plans share key contents (the actual chars typed) but their delays
+    // and any typo placements differ. Compare the serialized delay sequence.
+    expect(a.map((k) => k.delayBeforeMs)).not.toEqual(b.map((k) => k.delayBeforeMs));
+  });
+
+  it('applies personalitySpeed and speedFactor multiplicatively', () => {
+    const profile = { ...careful.typing, delayJitter: 0 };
+    const base = planTypeKeystrokes('abc', profile, createRng('scale'));
+    const fastPlan = planTypeKeystrokes('abc', profile, createRng('scale'), {
+      personalitySpeed: 0.5,
+    });
+    const fasterPlan = planTypeKeystrokes('abc', profile, createRng('scale'), {
+      personalitySpeed: 0.5,
+      speedFactor: 0.5,
+    });
+    // After the first keystroke (which has no inter-key wait), each subsequent
+    // delayBeforeMs scales linearly with the product personalitySpeed * speedFactor.
+    expect(fastPlan[1]?.delayBeforeMs).toBeCloseTo((base[1]?.delayBeforeMs ?? 0) * 0.5);
+    expect(fasterPlan[1]?.delayBeforeMs).toBeCloseTo((base[1]?.delayBeforeMs ?? 0) * 0.25);
+  });
+
+  it('produces a backspace step with longer perception in the bimodal-extension branch', () => {
+    // With typoProbability=1 and typoCorrectionProbability=1 every step is a
+    // typo+correction. Across many seeds we expect ~25% of corrections to land
+    // in the extended-perception branch (~6× baseDelayMs instead of ~2×).
+    // Check that the distribution actually spans both modes.
+    const profile = { ...fast.typing, typoProbability: 1, typoCorrectionProbability: 1 };
+    const perceptions: number[] = [];
+    for (let i = 0; i < 80; i++) {
+      const plan = planTypeKeystrokes('a', profile, createRng(`bimodal-${i}`));
+      const backspace = plan.find((k) => k.isCorrection);
+      if (backspace) perceptions.push(backspace.delayBeforeMs);
+    }
+    const baseline = fast.typing.baseDelayMs * 2;
+    const shortRuns = perceptions.filter((d) => d < baseline * 2).length;
+    const longRuns = perceptions.filter((d) => d > baseline * 2).length;
+    // Both modes should appear in 80 samples — wide tolerance because RNG.
+    expect(shortRuns).toBeGreaterThan(20);
+    expect(longRuns).toBeGreaterThan(5);
+  });
+});

--- a/packages/core/src/typing/index.ts
+++ b/packages/core/src/typing/index.ts
@@ -1,0 +1,204 @@
+import type { TypingProfile } from '../personality';
+import type { Rng } from '../rng';
+
+/**
+ * One planned keystroke. Adapters dispatch `key` after sleeping `delayBeforeMs`.
+ *
+ * `key` is either a single character (e.g. `'a'`) or a named key
+ * (e.g. `'Enter'`, `'Backspace'`, `'Tab'`). The two flags let plugins and
+ * UI surface error/recovery events without re-deriving them from the stream.
+ */
+export interface Keystroke {
+  readonly key: string;
+  readonly delayBeforeMs: number;
+  /** True when this key was the WRONG character (a simulated typo). */
+  readonly isTypo: boolean;
+  /** True when this key is a `'Backspace'` undoing a prior typo. */
+  readonly isCorrection: boolean;
+}
+
+export interface PlanTypingOptions {
+  /**
+   * Personality tempo multiplier — typically `personality.speed`.
+   * Lower values speed all delays up, higher values slow them down.
+   * Defaults to 1.
+   */
+  readonly personalitySpeed?: number;
+  /**
+   * Speed-mode multiplier. Adapters typically pass:
+   *  - `1` for `'human'`
+   *  - `0.5` for `'fast'`
+   *  - `0` for `'instant'` (callers usually short-circuit on instant though)
+   *
+   * Defaults to 1.
+   */
+  readonly speedFactor?: number;
+}
+
+/**
+ * Plans the sequence of keystrokes needed to type `value` with the given
+ * typing profile. Pure function: given the same RNG state and inputs it
+ * returns the same sequence.
+ *
+ * The planner handles:
+ *  - Per-key inter-keystroke rhythm jittered by `delayJitter`
+ *  - Optional mid-word "think pauses" (`thinkPauseProbability`)
+ *  - Optional QWERTY-adjacent typos (`typoProbability`)
+ *  - Optional Backspace recovery (`typoCorrectionProbability`) with a
+ *    bimodal perception delay — most typos get noticed fast, some really
+ *    do warrant a stare
+ *  - Line-ending normalization (`\r` and `\r\n` collapse to `\n`)
+ *  - Mapping `\n` → `'Enter'` and `\t` → `'Tab'`
+ *
+ * Adapters consume the result by sleeping `delayBeforeMs` then dispatching
+ * `key` via their platform's keyboard API.
+ */
+export function planTypeKeystrokes(
+  value: string,
+  profile: TypingProfile,
+  rng: Rng,
+  options: PlanTypingOptions = {},
+): readonly Keystroke[] {
+  const personalitySpeed = options.personalitySpeed ?? 1;
+  const speedFactor = options.speedFactor ?? 1;
+  const scaling = personalitySpeed * speedFactor;
+
+  // Normalize line endings first — keeps the planning loop straightforward.
+  const normalized = value.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+  const delay = (mean: number): number => {
+    if (mean <= 0) return 0;
+    const jitterMag = mean * profile.delayJitter;
+    const offset = rng.nextFloat(-jitterMag, jitterMag);
+    return Math.max(0, (mean + offset) * scaling);
+  };
+
+  const keystrokes: Keystroke[] = [];
+
+  for (let i = 0; i < normalized.length; i++) {
+    const char = normalized[i];
+    if (char === undefined) continue;
+
+    // Inter-key rhythm between the previous keystroke and this one.
+    // For i === 0 there's no previous keystroke, so no rhythm wait.
+    const interKey = i > 0 ? delay(profile.baseDelayMs) : 0;
+
+    // Occasional mid-word "think pause" stacked on top of the rhythm.
+    const thinkPause =
+      i > 0 && rng.chance(profile.thinkPauseProbability) ? delay(profile.thinkPauseMeanMs) : 0;
+
+    const preDelay = interKey + thinkPause;
+
+    if (isLetter(char) && rng.chance(profile.typoProbability)) {
+      const wrongKey = pickAdjacentKey(char, rng);
+
+      if (rng.chance(profile.typoCorrectionProbability)) {
+        // Wrong → perception delay → Backspace → correct char.
+        // Real typo-noticing is bimodal: ~75% of typos get a short beat,
+        // ~25% get a noticeably longer "stare at the screen" pause.
+        let perception = delay(profile.baseDelayMs * 2);
+        if (rng.chance(0.25)) perception += delay(profile.baseDelayMs * 4);
+
+        keystrokes.push({
+          key: wrongKey,
+          delayBeforeMs: preDelay,
+          isTypo: true,
+          isCorrection: false,
+        });
+        keystrokes.push({
+          key: 'Backspace',
+          delayBeforeMs: perception,
+          isTypo: false,
+          isCorrection: true,
+        });
+        keystrokes.push({
+          key: charToKey(char),
+          delayBeforeMs: delay(profile.baseDelayMs),
+          isTypo: false,
+          isCorrection: false,
+        });
+      } else {
+        // Uncorrected typo — the wrong char stays in the output.
+        keystrokes.push({
+          key: wrongKey,
+          delayBeforeMs: preDelay,
+          isTypo: true,
+          isCorrection: false,
+        });
+      }
+    } else {
+      keystrokes.push({
+        key: charToKey(char),
+        delayBeforeMs: preDelay,
+        isTypo: false,
+        isCorrection: false,
+      });
+    }
+  }
+
+  return keystrokes;
+}
+
+// ───────── helpers ─────────
+
+/**
+ * Maps a literal character to a Playwright-style key name. Most chars are
+ * accepted verbatim by keyboard APIs; whitespace control chars need named
+ * equivalents (`Enter`, `Tab`). Carriage returns are normalized upstream.
+ */
+function charToKey(char: string): string {
+  if (char === '\n') return 'Enter';
+  if (char === '\t') return 'Tab';
+  return char;
+}
+
+function isLetter(char: string): boolean {
+  return /^[a-zA-Z]$/.test(char);
+}
+
+/**
+ * QWERTY adjacency map for typo simulation. For each letter, returns one of
+ * its physical neighbors picked uniformly at random — that's how real
+ * fat-fingered mistakes look. Case is preserved (a capital `H` typo
+ * produces a capital `G`).
+ *
+ * Only US-QWERTY for now; community personalities can layer their own
+ * layouts on top once the plugin system grows.
+ */
+const QWERTY_ADJACENCY: Readonly<Record<string, string>> = {
+  q: 'wa',
+  w: 'qeas',
+  e: 'wrsd',
+  r: 'etdf',
+  t: 'ryfg',
+  y: 'tugh',
+  u: 'yihj',
+  i: 'uojk',
+  o: 'ipkl',
+  p: 'ol',
+  a: 'qwsz',
+  s: 'awedxz',
+  d: 'serfxc',
+  f: 'drtgcv',
+  g: 'ftyhvb',
+  h: 'gyujbn',
+  j: 'huiknm',
+  k: 'jiolm',
+  l: 'kop',
+  z: 'asx',
+  x: 'zsdc',
+  c: 'xdfv',
+  v: 'cfgb',
+  b: 'vghn',
+  n: 'bhjm',
+  m: 'njk',
+};
+
+function pickAdjacentKey(char: string, rng: Rng): string {
+  const lower = char.toLowerCase();
+  const neighbors = QWERTY_ADJACENCY[lower];
+  if (!neighbors || neighbors.length === 0) return char;
+  const picked = neighbors[rng.nextInt(0, neighbors.length)];
+  if (!picked) return char;
+  return char === lower ? picked : picked.toUpperCase();
+}

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -20,15 +20,33 @@ const browser = await chromium.launch();
 const page = await browser.newPage();
 
 const human = await createHuman(page, {
-  personality: 'careful',  // careful | fast | distracted | precise
-  seed: 'session-42',      // deterministic for tests
-  speed: 'human',          // human | fast | instant
+  personality: 'careful', // careful | fast | distracted | precise
+  seed: 'session-42',     // deterministic for tests
+  speed: 'human',         // human | fast | instant
 });
 
 await human.goto('https://example.com');
+
+// Mouse: real Bezier path, velocity profile, pre-click hover dwell.
+await human.click('button:has-text("Sign in")');
+
+// Keyboard: per-key rhythm, optional QWERTY typos, Backspace recovery,
+// occasional mid-word think pauses. The typed string is *not* echoed to
+// plugin params — `params.length` only, by design.
+await human.type('input[name="email"]', 'gonzalo@example.com');
 ```
 
-See [humanjs.dev](https://humanjs.dev) for full documentation.
+### Speed modes
+
+- `'human'` (default) — full humanization on every action.
+- `'fast'` — humanized but accelerated.
+- `'instant'` — bypass humanization entirely; uses Playwright's native methods. Per-key events still fire for `type()`. Right for CI.
+
+### Determinism
+
+Pass a `seed` and every random decision (path curvature, typo placement, keystroke jitter) becomes reproducible. Same seed + same personality + same value = same keystrokes.
+
+See [humanjs.dev](https://humanjs.dev) for the full feature set and personality reference.
 
 ## License
 

--- a/packages/playwright/src/index.test.ts
+++ b/packages/playwright/src/index.test.ts
@@ -1,13 +1,60 @@
 import type { HumanPlugin } from '@humanjs/core';
-import type { Page } from 'playwright';
+import type { Locator, Page } from 'playwright';
 import { describe, expect, it, vi } from 'vitest';
 import { createHuman } from './index';
 
+interface MockLocator {
+  focus: ReturnType<typeof vi.fn>;
+  pressSequentially: ReturnType<typeof vi.fn>;
+}
+
+interface MockPage {
+  page: Page;
+  locator: MockLocator;
+  pressedKeys: string[];
+}
+
+/**
+ * Mocks the minimum surface of `Page` we exercise in tests:
+ * `goto`, `locator()`, and `keyboard.press`. `locator()` always returns the
+ * same `MockLocator` instance so assertions can read its call list directly.
+ */
 function makeMockPage(overrides: Partial<Page> = {}): Page {
+  const locator: MockLocator = {
+    focus: vi.fn().mockResolvedValue(undefined),
+    pressSequentially: vi.fn().mockResolvedValue(undefined),
+  };
   return {
     goto: vi.fn().mockResolvedValue(null),
+    locator: vi.fn().mockReturnValue(locator as unknown as Locator),
+    keyboard: {
+      press: vi.fn().mockResolvedValue(undefined),
+    },
     ...overrides,
   } as unknown as Page;
+}
+
+/**
+ * Same as {@link makeMockPage} but also returns the locator + a list of keys
+ * passed to `keyboard.press`, so tests can assert exact keystroke sequences.
+ */
+function makeKeyboardMockPage(): MockPage {
+  const locator: MockLocator = {
+    focus: vi.fn().mockResolvedValue(undefined),
+    pressSequentially: vi.fn().mockResolvedValue(undefined),
+  };
+  const pressedKeys: string[] = [];
+  const page = {
+    goto: vi.fn().mockResolvedValue(null),
+    locator: vi.fn().mockReturnValue(locator as unknown as Locator),
+    keyboard: {
+      press: vi.fn().mockImplementation((key: string) => {
+        pressedKeys.push(key);
+        return Promise.resolve();
+      }),
+    },
+  } as unknown as Page;
+  return { page, locator, pressedKeys };
 }
 
 describe('createHuman', () => {
@@ -160,6 +207,248 @@ describe('createHuman', () => {
       });
       await human.goto('/');
       expect(beforeAction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('type', () => {
+    it('focuses the target before typing in human speed', async () => {
+      const { page, locator } = makeKeyboardMockPage();
+      const human = await createHuman(page, { seed: 'type-1' });
+      await human.type('input[name="email"]', 'hi');
+      expect(page.locator).toHaveBeenCalledWith('input[name="email"]');
+      expect(locator.focus).toHaveBeenCalledTimes(1);
+    });
+
+    it('presses one key per character in order (no-typo personality)', async () => {
+      const { page, pressedKeys } = makeKeyboardMockPage();
+      // typoProbability: 0 + thinkPauseProbability: 0 → deterministic keystroke sequence.
+      const human = await createHuman(page, {
+        personality: {
+          extends: 'careful',
+          typing: {
+            baseDelayMs: 0,
+            delayJitter: 0,
+            typoProbability: 0,
+            typoCorrectionProbability: 0,
+            thinkPauseProbability: 0,
+            thinkPauseMeanMs: 0,
+          },
+        },
+        seed: 'type-2',
+      });
+      await human.type('input', 'abc');
+      expect(pressedKeys).toEqual(['a', 'b', 'c']);
+    });
+
+    it('maps newline to Enter and tab to Tab', async () => {
+      const { page, pressedKeys } = makeKeyboardMockPage();
+      const human = await createHuman(page, {
+        personality: {
+          extends: 'careful',
+          typing: {
+            baseDelayMs: 0,
+            delayJitter: 0,
+            typoProbability: 0,
+            typoCorrectionProbability: 0,
+            thinkPauseProbability: 0,
+            thinkPauseMeanMs: 0,
+          },
+        },
+        seed: 'type-keys',
+      });
+      await human.type('input', 'a\nb\tc');
+      expect(pressedKeys).toEqual(['a', 'Enter', 'b', 'Tab', 'c']);
+    });
+
+    it('normalizes \\r and \\r\\n line endings to Enter', async () => {
+      const { page, pressedKeys } = makeKeyboardMockPage();
+      const human = await createHuman(page, {
+        personality: {
+          extends: 'careful',
+          typing: {
+            baseDelayMs: 0,
+            delayJitter: 0,
+            typoProbability: 0,
+            typoCorrectionProbability: 0,
+            thinkPauseProbability: 0,
+            thinkPauseMeanMs: 0,
+          },
+        },
+        seed: 'type-cr',
+      });
+      await human.type('input', 'a\rb\r\nc');
+      expect(pressedKeys).toEqual(['a', 'Enter', 'b', 'Enter', 'c']);
+    });
+
+    it('falls back to keyboard.insertText for non-ASCII characters', async () => {
+      const { page, pressedKeys } = makeKeyboardMockPage();
+      const inserted: string[] = [];
+      (page.keyboard as { insertText: (text: string) => Promise<void> }).insertText = vi
+        .fn()
+        .mockImplementation((text: string) => {
+          inserted.push(text);
+          return Promise.resolve();
+        });
+      const human = await createHuman(page, {
+        personality: {
+          extends: 'careful',
+          typing: {
+            baseDelayMs: 0,
+            delayJitter: 0,
+            typoProbability: 0,
+            typoCorrectionProbability: 0,
+            thinkPauseProbability: 0,
+            thinkPauseMeanMs: 0,
+          },
+        },
+        seed: 'type-unicode',
+      });
+      await human.type('input', 'café');
+      // ASCII chars go through press; non-ASCII (é) goes through insertText.
+      expect(pressedKeys).toEqual(['c', 'a', 'f']);
+      expect(inserted).toEqual(['é']);
+    });
+
+    it('produces the same keystroke sequence for the same seed (typing determinism)', async () => {
+      const settings = {
+        personality: {
+          extends: 'careful',
+          typing: {
+            baseDelayMs: 0,
+            delayJitter: 0,
+            typoProbability: 0.5,
+            typoCorrectionProbability: 0.8,
+            thinkPauseProbability: 0,
+            thinkPauseMeanMs: 0,
+          },
+        },
+        seed: 'type-determinism',
+      } as const;
+      const run1 = makeKeyboardMockPage();
+      const human1 = await createHuman(run1.page, settings);
+      await human1.type('input', 'hello world');
+
+      const run2 = makeKeyboardMockPage();
+      const human2 = await createHuman(run2.page, settings);
+      await human2.type('input', 'hello world');
+
+      expect(run1.pressedKeys).toEqual(run2.pressedKeys);
+    });
+
+    it('injects typos and recovers with Backspace when correction probability is 1', async () => {
+      const { page, pressedKeys } = makeKeyboardMockPage();
+      // Force every letter into a typo, and force every typo to be corrected.
+      const human = await createHuman(page, {
+        personality: {
+          extends: 'careful',
+          typing: {
+            baseDelayMs: 0,
+            delayJitter: 0,
+            typoProbability: 1,
+            typoCorrectionProbability: 1,
+            thinkPauseProbability: 0,
+            thinkPauseMeanMs: 0,
+          },
+        },
+        seed: 'type-typos',
+      });
+      await human.type('input', 'a');
+      // Expected sequence: wrongKey, Backspace, a
+      expect(pressedKeys).toHaveLength(3);
+      expect(pressedKeys[0]).not.toBe('a');
+      expect(pressedKeys[1]).toBe('Backspace');
+      expect(pressedKeys[2]).toBe('a');
+    });
+
+    it('leaves typos in place when correction probability is 0', async () => {
+      const { page, pressedKeys } = makeKeyboardMockPage();
+      const human = await createHuman(page, {
+        personality: {
+          extends: 'careful',
+          typing: {
+            baseDelayMs: 0,
+            delayJitter: 0,
+            typoProbability: 1,
+            typoCorrectionProbability: 0,
+            thinkPauseProbability: 0,
+            thinkPauseMeanMs: 0,
+          },
+        },
+        seed: 'type-uncorrected',
+      });
+      await human.type('input', 'a');
+      expect(pressedKeys).toHaveLength(1);
+      expect(pressedKeys[0]).not.toBe('a');
+      expect(pressedKeys).not.toContain('Backspace');
+    });
+
+    it('handles an empty value as a no-op without focusing', async () => {
+      const { page, locator, pressedKeys } = makeKeyboardMockPage();
+      const human = await createHuman(page);
+      await human.type('input', '');
+      expect(locator.focus).not.toHaveBeenCalled();
+      expect(pressedKeys).toEqual([]);
+    });
+
+    it("uses pressSequentially with delay 0 in 'instant' mode", async () => {
+      const { page, locator, pressedKeys } = makeKeyboardMockPage();
+      const human = await createHuman(page, { speed: 'instant' });
+      await human.type('input', 'abc');
+      expect(locator.pressSequentially).toHaveBeenCalledWith('abc', { delay: 0 });
+      // Per-key press should never be invoked in instant mode.
+      expect(pressedKeys).toEqual([]);
+      expect(locator.focus).not.toHaveBeenCalled();
+    });
+
+    it("emits a 'type' action with target description and length to plugins", async () => {
+      const beforeAction = vi.fn();
+      const afterAction = vi.fn();
+      const { page } = makeKeyboardMockPage();
+      const human = await createHuman(page, {
+        personality: {
+          extends: 'careful',
+          typing: {
+            baseDelayMs: 0,
+            delayJitter: 0,
+            typoProbability: 0,
+            typoCorrectionProbability: 0,
+            thinkPauseProbability: 0,
+            thinkPauseMeanMs: 0,
+          },
+        },
+        plugins: [{ name: 'p', beforeAction, afterAction }],
+      });
+      await human.type('input', 'hello');
+      expect(beforeAction).toHaveBeenCalledWith({
+        type: 'type',
+        params: { target: 'input', length: 5 },
+      });
+      const result = afterAction.mock.calls[0]?.[1];
+      expect(result.type).toBe('type');
+      expect(typeof result.durationMs).toBe('number');
+    });
+
+    it('does NOT echo the typed value into action params (privacy)', async () => {
+      const beforeAction = vi.fn();
+      const { page } = makeKeyboardMockPage();
+      const human = await createHuman(page, {
+        personality: {
+          extends: 'careful',
+          typing: {
+            baseDelayMs: 0,
+            delayJitter: 0,
+            typoProbability: 0,
+            typoCorrectionProbability: 0,
+            thinkPauseProbability: 0,
+            thinkPauseMeanMs: 0,
+          },
+        },
+        plugins: [{ name: 'p', beforeAction }],
+      });
+      await human.type('input', 'sup3r-secret');
+      const action = beforeAction.mock.calls[0]?.[0];
+      expect(action.params).not.toHaveProperty('value');
+      expect(JSON.stringify(action.params)).not.toContain('sup3r-secret');
     });
   });
 

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -10,6 +10,7 @@ import {
   resolvePersonality,
 } from '@humanjs/core';
 import type { Locator, Page } from 'playwright';
+import { executeType } from './keyboard';
 import { executeClick } from './mouse';
 
 export type {
@@ -20,11 +21,13 @@ export type {
   HumanAction,
   HumanizePathOptions,
   HumanPlugin,
+  Keystroke,
   KnownActionType,
   MouseProfile,
   Personality,
   PersonalityConfig,
   PersonalityExtension,
+  PlanTypingOptions,
   PluginContext,
   Point,
   PresetName,
@@ -43,6 +46,7 @@ export {
   distracted,
   fast,
   humanizePath,
+  planTypeKeystrokes,
   precise,
   resolvePersonality,
 } from '@humanjs/core';
@@ -96,6 +100,17 @@ export interface Human {
    * native `locator.click()` is used directly.
    */
   click(target: Locator | string): Promise<void>;
+  /**
+   * Type `value` into `target` with humanized per-key timing, optional typo
+   * injection (with backspace recovery), and occasional think-pauses.
+   *
+   * Per-key `keydown`/`press`/`up` events fire for each character, so
+   * handlers like autocomplete dropdowns still receive every keystroke.
+   *
+   * In `speed: 'instant'`, falls back to `locator.pressSequentially` with
+   * zero inter-key delay — events still fire, but humanization is skipped.
+   */
+  type(target: Locator | string, value: string): Promise<void>;
 }
 
 /**
@@ -175,6 +190,17 @@ export async function createHuman(page: Page, options: CreateHumanOptions = {}):
           },
         });
       });
+    },
+    async type(target, value) {
+      const description = typeof target === 'string' ? target : (target.toString?.() ?? 'locator');
+      // `value` itself is intentionally not echoed into params — typed input may
+      // be sensitive (passwords, tokens). Expose length only for observability.
+      await performAction(
+        { type: 'type', params: { target: description, length: value.length } },
+        async () => {
+          await executeType(target, value, { page, personality, rng, speed });
+        },
+      );
     },
   };
 }

--- a/packages/playwright/src/internal/timing.ts
+++ b/packages/playwright/src/internal/timing.ts
@@ -1,0 +1,49 @@
+import type { Personality, Rng } from '@humanjs/core';
+import type { Speed } from '..';
+
+/**
+ * Sleeps for `ms` milliseconds. Resolves immediately if `ms <= 0` so callers
+ * can hand the result of `computeDwellTime` straight through without guards.
+ */
+export function sleep(ms: number): Promise<void> {
+  return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve();
+}
+
+/**
+ * Per-mode timing multiplier applied on top of personality.speed.
+ *  - `'human'`:   1    — full humanization
+ *  - `'fast'`:    0.5  — accelerated humanization (still humanized, just brisk)
+ *  - `'instant'`: 0    — no delays (CI / snapshot mode)
+ */
+export function speedModeFactor(speed: Speed): number {
+  switch (speed) {
+    case 'fast':
+      return 0.5;
+    case 'instant':
+      return 0;
+    default:
+      return 1;
+  }
+}
+
+/**
+ * Computes a dwell time in ms with deterministic jitter and personality scaling.
+ *
+ *   base   = meanMs
+ *   jitter = base × jitterFraction × rand[-1, 1]
+ *   total  = (base + jitter) × personality.speed × speedModeFactor(speed)
+ *
+ * Returns 0 for non-positive inputs so callers can skip the sleep entirely.
+ */
+export function computeDwellTime(
+  meanMs: number,
+  jitter: number,
+  personality: Personality,
+  speed: Speed,
+  rng: Rng,
+): number {
+  if (meanMs <= 0) return 0;
+  const jitterMag = meanMs * jitter;
+  const offset = rng.nextFloat(-jitterMag, jitterMag);
+  return Math.max(0, (meanMs + offset) * personality.speed * speedModeFactor(speed));
+}

--- a/packages/playwright/src/keyboard/index.ts
+++ b/packages/playwright/src/keyboard/index.ts
@@ -1,0 +1,90 @@
+import { type Personality, planTypeKeystrokes, type Rng } from '@humanjs/core';
+import type { Locator, Page } from 'playwright';
+import type { Speed } from '../index';
+import { sleep, speedModeFactor } from '../internal/timing';
+
+/** Runtime dependencies for a humanized keyboard action. */
+export interface KeyboardContext {
+  readonly page: Page;
+  readonly personality: Personality;
+  readonly rng: Rng;
+  readonly speed: Speed;
+}
+
+/** Result of a typing action, returned to the caller for observability. */
+export interface TypeResult {
+  /** Number of characters in the input string. */
+  readonly characters: number;
+  /** Number of typos injected (with or without correction). */
+  readonly typos: number;
+  /** Number of typo corrections via Backspace. */
+  readonly corrections: number;
+}
+
+/**
+ * Executes a humanized typing pass over `value` on `target`.
+ *
+ * Planning (which keys to press, with what delays, in what order) is delegated
+ * to `@humanjs/core`'s `planTypeKeystrokes`. This module is the thin Playwright
+ * dispatcher: it focuses the target, walks the plan, and chooses the best
+ * Playwright API per key:
+ *
+ *  - Named keys (`Enter`, `Backspace`, `Tab`) and ASCII chars: `keyboard.press`
+ *    — fires keydown/press/up, so handlers (autocomplete, validation) run.
+ *  - Non-ASCII characters: `keyboard.insertText` — fires `input` events but
+ *    not keyboard events, since `keyboard.press` is keyboard-layout-aware
+ *    and can't reliably synthesize characters like `é` or `🎉` on every layout.
+ *
+ * In `speed: 'instant'`, the whole humanized loop is bypassed in favor of
+ * `locator.pressSequentially(value, { delay: 0 })` — events still fire,
+ * humanization is skipped.
+ */
+export async function executeType(
+  target: Locator | string,
+  value: string,
+  ctx: KeyboardContext,
+): Promise<TypeResult> {
+  const locator = typeof target === 'string' ? ctx.page.locator(target) : target;
+
+  if (value.length === 0) {
+    return { characters: 0, typos: 0, corrections: 0 };
+  }
+
+  if (ctx.speed === 'instant') {
+    await locator.pressSequentially(value, { delay: 0 });
+    return { characters: value.length, typos: 0, corrections: 0 };
+  }
+
+  await locator.focus();
+
+  const plan = planTypeKeystrokes(value, ctx.personality.typing, ctx.rng, {
+    personalitySpeed: ctx.personality.speed,
+    speedFactor: speedModeFactor(ctx.speed),
+  });
+
+  let typos = 0;
+  let corrections = 0;
+
+  for (const step of plan) {
+    if (step.delayBeforeMs > 0) await sleep(step.delayBeforeMs);
+    await dispatchKey(ctx.page, step.key);
+    if (step.isTypo) typos++;
+    if (step.isCorrection) corrections++;
+  }
+
+  return { characters: value.length, typos, corrections };
+}
+
+/**
+ * Dispatches a single planned key. Multi-char strings are treated as named
+ * keys (`Enter`, `Backspace`). Single ASCII chars use the layout-aware
+ * `keyboard.press`. Single non-ASCII chars fall back to `insertText` so the
+ * adapter works on any keyboard layout, at the cost of skipping per-key events.
+ */
+async function dispatchKey(page: Page, key: string): Promise<void> {
+  if (key.length > 1 || key.charCodeAt(0) < 128) {
+    await page.keyboard.press(key);
+  } else {
+    await page.keyboard.insertText(key);
+  }
+}

--- a/packages/playwright/src/mouse/index.ts
+++ b/packages/playwright/src/mouse/index.ts
@@ -1,6 +1,7 @@
 import { bezierPath, humanizePath, type Personality, type Point, type Rng } from '@humanjs/core';
 import type { Locator, Page } from 'playwright';
 import type { Speed } from '../index';
+import { computeDwellTime, sleep, speedModeFactor } from '../internal/timing';
 
 /** Runtime dependencies for a humanized mouse action. */
 export interface MouseContext {
@@ -176,47 +177,10 @@ function computeTravelTime(
   return Math.max(0, total);
 }
 
-/**
- * Dwell time in ms for a single pause.
- *
- *   base = meanMs
- *   jitter = base * jitterFraction * rand[-1, 1]
- *   total = (base + jitter) * Personality.speed * speedModeFactor
- *
- * Returns 0 for zero/negative inputs so callers can skip the sleep entirely.
- */
-function computeDwellTime(
-  meanMs: number,
-  jitter: number,
-  personality: Personality,
-  speed: Speed,
-  rng: Rng,
-): number {
-  if (meanMs <= 0) return 0;
-  const jitterMag = meanMs * jitter;
-  const offset = rng.nextFloat(-jitterMag, jitterMag);
-  return Math.max(0, (meanMs + offset) * personality.speed * speedModeFactor(speed));
-}
-
-function speedModeFactor(speed: Speed): number {
-  switch (speed) {
-    case 'fast':
-      return 0.5;
-    case 'instant':
-      return 0;
-    default:
-      return 1;
-  }
-}
-
 function describeTarget(target: Locator | string): string {
   return typeof target === 'string' ? target : (target.toString?.() ?? 'locator');
 }
 
 function clamp(value: number, min: number, max: number): number {
   return value < min ? min : value > max ? max : value;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
Ships the second of HumanJS's three brand pillars — *the cursor, **the typing**, the pace*. After this PR, `await human.type('input', 'hello')` produces real per-key rhythm, optional QWERTY-adjacent typos with backspace recovery, and occasional mid-word think pauses — driven by the personality's `TypingProfile` from `@humanjs/core`.

## What's in it

- **`human.type(target, value)`** on the `Human` interface. Accepts a selector string or a Playwright `Locator`, same shape as `click()`. Per-key `keydown`/`press`/`up` events fire for each character, so handlers like autocomplete dropdowns still receive every keystroke. In `speed: 'instant'`, falls back to `locator.pressSequentially(value, { delay: 0 })` — events still fire, humanization is skipped.
- **`planTypeKeystrokes` in `@humanjs/core`** — pure planner that decides what keystrokes to dispatch (chars + delays + typo+backspace insertions). Both the Playwright adapter and the landing demo consume the same planner; the on-screen demo reflects exactly what the library does in a real browser.
- **Non-ASCII fallback** — characters with `charCode >= 128` (e.g. `é`, `ñ`, `🎉`) route through `keyboard.insertText()` instead of `keyboard.press()`, since `press` is keyboard-layout-aware and can't synthesize those reliably on every layout. Trade-off documented: `insertText` skips per-key events for those chars but works on any layout.
- **Line-ending normalization** — `\r` and `\r\n` collapse to `\n`/`Enter`. `\t` maps to `Tab`. Strings coming from files or clipboard now type correctly.
- **Bimodal typo perception delay** — when a typo is corrected, ~75% of corrections get a normal beat before Backspace; ~25% get a noticeably longer "stare at the screen" pause. Matches how real typo-noticing actually works.
- **Runnable example** (`pnpm demo:type`) — opens Chrome, types a brand-aligned phrase into a styled input, prints per-action timings via a logger plugin.
- **Landing demo** — new "Now the keyboard" section between Playground and Audience. Auto-loops, flashes typo characters red, shows live `characters / typos / corrections` stats, drives the same `planTypeKeystrokes` the library uses. Personality picker mirrors the Playground.
- **`fast` personality tune** (`fix(core)`) — `baseDelayMs: 60 → 130`. The library was called HumanJS but the `fast` personality typed at ~400 wpm — beyond the world record. Now it lands at ~185 wpm: top-tier real touch typist, still clearly the fastest of the four. A new regression test (`types at a plausible human WPM`) asserts every preset's effective WPM stays in `[20, 200]`.
- **`packages/playwright/README.md`** — Quick start updated to show `goto` + `click` + `type` + speed modes + determinism. Was stale at `goto` only.

## Engineering notes

- **Pure planner / thin dispatcher split.** All typing-rhythm logic lives in `@humanjs/core`'s `planTypeKeystrokes` (pure, deterministic, testable in isolation). The Playwright adapter (`executeType`) is just dispatch: focus the target, sleep, press key, repeat. This makes the landing demo a true reflection of library behavior — both call the same planner — and sets up the pattern for future adapters (Puppeteer, Selenium, Browser Use).
- **Timing helpers extracted.** `sleep` / `speedModeFactor` / `computeDwellTime` moved from `mouse/index.ts` into `internal/timing.ts`. Mouse executor refactored to import them; zero behavioral change to existing `human.click()`. Sets up sharing for `human.read()` (next branch).
- **Privacy posture.** `human.type(input, 'sup3r-secret')` never echoes the typed value into plugin action params — only `target` description and `length`. Verified by an explicit test. Same guarantee as the rest of the library.
- **Determinism.** Same `seed` + same personality + same value produces an identical keystroke sequence (same wrong-key picks, same Backspace positions, same delays). Tested.
- **Test coverage.** +16 core tests / +20 playwright tests. Covers: per-character output for no-typo personality, `\n`→Enter, `\t`→Tab, `\r`/`\r\n` normalization, typo + Backspace + correction sequence, uncorrected typos, empty-string no-op, instant-mode fallback, plugin lifecycle, privacy guarantee, non-ASCII insertText fallback, typing determinism, case preservation in typo simulation, bimodal perception distribution, and personality WPM bounds.

## Test plan

- [x] `pnpm demo:type` (default `careful`) — phrase types in at ~140 ms/char with sparse typos
- [x] `pnpm demo:type` with `PERSONALITY=fast` — types at ~65 ms/char (was ~30 before tune; now perceptible)
- [x] `pnpm demo:type` with `PERSONALITY=distracted` — slower pace with visible typos + backspaces
- [x] `pnpm demo:type` with `PERSONALITY=precise` — clean output, ~110 ms/char
- [x] Visit `humanjs.dev/#typing` on staging — typing demo auto-loops, typo flashes red, switching personalities resets the loop
- [x] Reduce motion in OS preferences — landing demo renders the final phrase, no animation
- [x] `pnpm -r test` — 111 core + 41 playwright tests pass
- [x] `pnpm build` — all packages build clean