### PR TITLE
feat(scroll): humanized scrolling, multi-axis, with overshoot

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -10,6 +10,7 @@ import {
   PersonalityLab,
   Playground,
   ReadingShowcase,
+  ScrollShowcase,
   TrustStrip,
   TypingShowcase,
 } from '../components/sections';
@@ -24,6 +25,7 @@ export default function Page() {
         <Playground />
         <TypingShowcase />
         <ReadingShowcase />
+        <ScrollShowcase />
         <Audience />
         <FeatureBento />
         <PersonalityLab />

--- a/apps/web/components/motion/ScrollDemo.tsx
+++ b/apps/web/components/motion/ScrollDemo.tsx
@@ -136,8 +136,8 @@ export function ScrollDemo({ personality, className }: ScrollDemoProps) {
         const prevTime = cumTimes[cumTimes.length - 1] ?? 0;
         const prevPos = cumPositions[cumPositions.length - 1] ?? scroller.scrollTop;
         cumTimes.push(prevTime + seg.delayBeforeMs);
-        cumPositions.push(prevPos + seg.deltaY);
-        if (seg.deltaY !== 0) segCount++;
+        cumPositions.push(prevPos + seg.delta);
+        if (seg.delta !== 0) segCount++;
         else pauseCount++;
       }
       segments += segCount;
@@ -201,10 +201,10 @@ export function ScrollDemo({ personality, className }: ScrollDemoProps) {
       });
       // Overshoot signature: a plan contains segments moving opposite to
       // the overall scroll direction (the correction phase). Ordinary
-      // mid-scroll micro-pauses are `deltaY === 0` and don't trip this,
+      // mid-scroll micro-pauses are `delta === 0` and don't trip this,
       // unlike a "any zero-delta segment" heuristic which over-counts.
       const direction = target >= fromY ? 1 : -1;
-      const hasOvershoot = plan.some((s) => s.deltaY * direction < 0);
+      const hasOvershoot = plan.some((s) => s.delta * direction < 0);
       if (hasOvershoot) overshoots++;
       setActiveSection(index);
       walk(plan, onDone);

--- a/apps/web/components/motion/ScrollDemo.tsx
+++ b/apps/web/components/motion/ScrollDemo.tsx
@@ -194,8 +194,8 @@ export function ScrollDemo({ personality, className }: ScrollDemoProps) {
       }
       const target = section.offsetTop;
       const rng = createRng(`scroll-showcase-${personality}-${loopId}-s${index}`);
-      const fromY = scroller.scrollTop;
-      const plan = planScroll(fromY, target, profile.scroll, rng, {
+      const from = scroller.scrollTop;
+      const plan = planScroll(from, target, profile.scroll, rng, {
         personalitySpeed: profile.speed,
         speedFactor: 1,
       });
@@ -203,7 +203,7 @@ export function ScrollDemo({ personality, className }: ScrollDemoProps) {
       // the overall scroll direction (the correction phase). Ordinary
       // mid-scroll micro-pauses are `delta === 0` and don't trip this,
       // unlike a "any zero-delta segment" heuristic which over-counts.
-      const direction = target >= fromY ? 1 : -1;
+      const direction = target >= from ? 1 : -1;
       const hasOvershoot = plan.some((s) => s.delta * direction < 0);
       if (hasOvershoot) overshoots++;
       setActiveSection(index);

--- a/apps/web/components/motion/ScrollDemo.tsx
+++ b/apps/web/components/motion/ScrollDemo.tsx
@@ -1,0 +1,366 @@
+'use client';
+
+import {
+  createRng,
+  type PresetName,
+  planScroll,
+  resolvePersonality,
+  type ScrollSegment,
+} from '@humanjs/core';
+import { useInView, useReducedMotion } from 'framer-motion';
+import { useEffect, useRef, useState } from 'react';
+import { cn } from '../../lib/cn';
+import { IN_VIEW_MARGIN } from '../../lib/motion';
+import { DemoStatusBar } from './DemoStatusBar';
+
+/**
+ * Mock changelog-style feed the demo scrolls through. Reads like a real
+ * product timeline — version tags, dates, brand-relevant titles — rather
+ * than meta copy about the demo itself.
+ */
+const FEED = [
+  {
+    tag: 'v1.0',
+    date: 'May 21',
+    title: 'The cursor takes a real path.',
+    body: 'Bezier paths, micro-jitter, hover-before-click. The third pillar lands today.',
+    glow: 'rgba(245, 165, 92, 0.10)',
+  },
+  {
+    tag: 'NOTE',
+    date: 'May 18',
+    title: 'Personality, not preference.',
+    body: 'careful, fast, distracted, precise — four presets that re-shape every primitive at once, not one knob at a time.',
+    glow: 'rgba(91, 124, 201, 0.10)',
+  },
+  {
+    tag: 'DESIGN',
+    date: 'May 15',
+    title: 'Bell curve, not linear.',
+    body: 'A real wheel scroll accelerates, peaks, decelerates. The same pure function paints it in tests and in production.',
+    glow: 'rgba(122, 191, 133, 0.10)',
+  },
+  {
+    tag: 'NOTE',
+    date: 'May 12',
+    title: 'Mid-scroll pauses.',
+    body: 'Humans pause while scrolling. Briefly. Often without realizing. The page notices, even if you don’t.',
+    glow: 'rgba(215, 127, 163, 0.10)',
+  },
+  {
+    tag: 'v0.9',
+    date: 'May 08',
+    title: 'Overshoot + correction.',
+    body: 'distracted scrolls past the target and corrects back. precise never overshoots. Same code path; profile dictates behavior.',
+    glow: 'rgba(201, 163, 91, 0.10)',
+  },
+  {
+    tag: 'DESIGN',
+    date: 'May 03',
+    title: 'Determinism by seed.',
+    body: 'Same seed, same segments, every run. Snapshot test it. CI loves it.',
+    glow: 'rgba(245, 165, 92, 0.10)',
+  },
+];
+
+/** How long to dwell on each section after scrolling to it — the "reading"
+ *  beat between section-to-section scrolls. */
+const READ_DWELL_MS = 950;
+/** How long to sit at the last section before scrolling back to the top. */
+const REST_AT_END_MS = 1400;
+/** How long to sit at the top before starting the next loop. */
+const REST_AT_TOP_MS = 1000;
+
+interface ScrollDemoProps {
+  personality: PresetName;
+  className?: string;
+}
+
+/**
+ * Landing-page scroll demo. Drives `@humanjs/core`'s `planScroll` directly —
+ * the same planner the Playwright adapter walks against `page.mouse.wheel` —
+ * but applies the segments to a React-controlled `scrollTop` on a bounded
+ * container.
+ *
+ * Loop: scroll to bottom → rest → scroll to top → rest → restart. Each
+ * direction is its own `planScroll` call seeded with the personality + a
+ * step counter so consecutive runs aren't identical.
+ */
+export function ScrollDemo({ personality, className }: ScrollDemoProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const sectionRefs = useRef<(HTMLElement | null)[]>([]);
+  const inView = useInView(cardRef, { margin: IN_VIEW_MARGIN });
+
+  const [activeSection, setActiveSection] = useState(0);
+  const [stats, setStats] = useState({ segments: 0, pauses: 0, overshoots: 0 });
+  const [direction, setDirection] = useState<'down' | 'up' | 'idle'>('idle');
+
+  useEffect(() => {
+    if (shouldReduceMotion) {
+      setActiveSection(0);
+      setDirection('idle');
+      return;
+    }
+    if (!inView) return;
+    const scroller = scrollerRef.current;
+    if (!scroller) return;
+
+    const profile = resolvePersonality(personality);
+    let cancelled = false;
+    let timer: number;
+    let loopId = 0;
+
+    let segments = 0;
+    let pauses = 0;
+    let overshoots = 0;
+    let rafId = 0;
+    setStats({ segments: 0, pauses: 0, overshoots: 0 });
+
+    /**
+     * Walks a plan by sampling the cumulative position-over-time curve at
+     * each animation frame. setTimeout-driven walks quantize at ~14ms
+     * regardless of the display, producing visible step-jumps; rAF
+     * sampling smooths the same plan at the display's native refresh.
+     * The bell-curve velocity shape is preserved because the cumulative
+     * curve still encodes accel → peak → decel.
+     */
+    const walk = (plan: readonly ScrollSegment[], onDone: () => void) => {
+      // Build cumulative time + position arrays from the plan.
+      const cumTimes: number[] = [0];
+      const cumPositions: number[] = [scroller.scrollTop];
+      let segCount = 0;
+      let pauseCount = 0;
+      for (const seg of plan) {
+        const prevTime = cumTimes[cumTimes.length - 1] ?? 0;
+        const prevPos = cumPositions[cumPositions.length - 1] ?? scroller.scrollTop;
+        cumTimes.push(prevTime + seg.delayBeforeMs);
+        cumPositions.push(prevPos + seg.deltaY);
+        if (seg.deltaY !== 0) segCount++;
+        else pauseCount++;
+      }
+      segments += segCount;
+      pauses += pauseCount;
+
+      const totalTime = cumTimes[cumTimes.length - 1] ?? 0;
+      const finalPos = cumPositions[cumPositions.length - 1] ?? scroller.scrollTop;
+
+      if (totalTime <= 0 || plan.length === 0) {
+        setStats({ segments, pauses, overshoots });
+        onDone();
+        return;
+      }
+
+      const startTime = performance.now();
+      const tick = (now: number) => {
+        if (cancelled) return;
+        const t = now - startTime;
+        if (t >= totalTime) {
+          scroller.scrollTop = finalPos;
+          setStats({ segments, pauses, overshoots });
+          onDone();
+          return;
+        }
+        // Find which segment we're currently inside.
+        let i = 0;
+        while (i < cumTimes.length - 1 && (cumTimes[i + 1] ?? 0) <= t) i++;
+        const segStart = cumTimes[i] ?? 0;
+        const segEnd = cumTimes[i + 1] ?? segStart;
+        const segLen = segEnd - segStart;
+        const f = segLen > 0 ? (t - segStart) / segLen : 0;
+        const posA = cumPositions[i] ?? 0;
+        const posB = cumPositions[i + 1] ?? posA;
+        scroller.scrollTop = posA + (posB - posA) * f;
+        rafId = window.requestAnimationFrame(tick);
+      };
+
+      rafId = window.requestAnimationFrame(tick);
+    };
+
+    /**
+     * Scrolls to a specific section index using `planScroll` — same code
+     * path `human.scroll('#sectionN')` follows in the real adapter. The
+     * personality's natural `overshootProbability` decides whether each
+     * jump overshoots, so distracted will hit a few per loop and precise
+     * will hit none — same statistics a real session sees.
+     */
+    const scrollToSection = (index: number, onDone: () => void) => {
+      if (cancelled) return;
+      const section = sectionRefs.current[index];
+      if (!section) {
+        onDone();
+        return;
+      }
+      const target = section.offsetTop;
+      const rng = createRng(`scroll-showcase-${personality}-${loopId}-s${index}`);
+      const fromY = scroller.scrollTop;
+      const plan = planScroll(fromY, target, profile.scroll, rng, {
+        personalitySpeed: profile.speed,
+        speedFactor: 1,
+      });
+      // Overshoot signature: a plan contains segments moving opposite to
+      // the overall scroll direction (the correction phase). Ordinary
+      // mid-scroll micro-pauses are `deltaY === 0` and don't trip this,
+      // unlike a "any zero-delta segment" heuristic which over-counts.
+      const direction = target >= fromY ? 1 : -1;
+      const hasOvershoot = plan.some((s) => s.deltaY * direction < 0);
+      if (hasOvershoot) overshoots++;
+      setActiveSection(index);
+      walk(plan, onDone);
+    };
+
+    /** Reading dwell between section-to-section scrolls. */
+    const dwell = (ms: number, next: () => void) => {
+      if (cancelled) return;
+      timer = window.setTimeout(next, ms);
+    };
+
+    /** Walks down through every section, dwelling on each. */
+    const walkDown = (nextIndex: number) => {
+      if (cancelled) return;
+      if (nextIndex >= FEED.length) {
+        setDirection('idle');
+        dwell(REST_AT_END_MS, scrollHome);
+        return;
+      }
+      setDirection('down');
+      scrollToSection(nextIndex, () => {
+        dwell(READ_DWELL_MS, () => walkDown(nextIndex + 1));
+      });
+    };
+
+    /** One smooth return scroll all the way back to the top. */
+    const scrollHome = () => {
+      if (cancelled) return;
+      setDirection('up');
+      const rng = createRng(`scroll-showcase-${personality}-${loopId}-home`);
+      const plan = planScroll(scroller.scrollTop, 0, profile.scroll, rng, {
+        personalitySpeed: profile.speed,
+        speedFactor: 1,
+      });
+      walk(plan, () => {
+        setActiveSection(0);
+        dwell(REST_AT_TOP_MS, () => {
+          loopId++;
+          segments = 0;
+          pauses = 0;
+          overshoots = 0;
+          setStats({ segments: 0, pauses: 0, overshoots: 0 });
+          walkDown(1);
+        });
+      });
+    };
+
+    scroller.scrollTop = 0;
+    setActiveSection(0);
+    // Brief beat to register the starting position before motion begins.
+    timer = window.setTimeout(() => walkDown(1), 500);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+      window.cancelAnimationFrame(rafId);
+      setDirection('idle');
+    };
+  }, [inView, personality, shouldReduceMotion]);
+
+  return (
+    <div
+      ref={cardRef}
+      className={cn('overflow-hidden rounded-card-lg border border-hairline bg-surface', className)}
+    >
+      <DemoStatusBar
+        label="human.scroll()"
+        sublabel={
+          <>
+            personality: <span className="text-accent">{personality}</span>
+            {direction !== 'idle' && (
+              <span className="ml-3 text-muted/60">
+                {direction === 'down' ? '↓ scrolling' : '↑ returning'}
+              </span>
+            )}
+          </>
+        }
+      />
+
+      <div className="relative px-6 py-8 md:px-10 md:py-10" aria-hidden>
+        <div
+          ref={scrollerRef}
+          // `relative` makes the scroller the offsetParent of its sections,
+          // so `section.offsetTop` reads as the section's position inside
+          // the scroller's scroll axis — which is what `scrollTop` expects.
+          // Without this, offsetTop bubbles up to the outer card's padded
+          // edge, and every section-to-section scroll lands ~padding past
+          // its target.
+          className="relative h-[560px] overflow-y-scroll rounded-card border border-hairline bg-canvas md:h-[640px]"
+          style={{ scrollBehavior: 'auto' }}
+        >
+          {FEED.map((item, i) => (
+            <section
+              key={item.title}
+              ref={(el) => {
+                sectionRefs.current[i] = el;
+              }}
+              className={cn(
+                // h-full resolves to the scroller's height — each section
+                // becomes one full container-viewport tall, so section-to-
+                // section scrolls cover exactly the visible area.
+                'flex h-full min-h-full shrink-0 flex-col justify-center px-8 py-10 md:px-12',
+                i < FEED.length - 1 && 'border-b border-hairline/60',
+              )}
+              style={{
+                background: `radial-gradient(circle at 30% 20%, ${item.glow}, transparent 60%)`,
+              }}
+            >
+              <div className="mb-4 flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.22em] text-muted/70">
+                <span className="rounded-sm border border-hairline px-1.5 py-0.5 text-accent/90">
+                  {item.tag}
+                </span>
+                <span>{item.date}</span>
+              </div>
+              <h3 className="text-balance font-display text-3xl leading-tight text-foreground md:text-4xl">
+                {item.title}
+              </h3>
+              <p className="mt-4 max-w-prose text-base leading-relaxed text-muted-strong md:text-lg">
+                {item.body}
+              </p>
+              <div className="mt-6 font-mono text-[10px] uppercase tracking-[0.22em] text-muted/40">
+                {String(i + 1).padStart(2, '0')} / {String(FEED.length).padStart(2, '0')}
+              </div>
+            </section>
+          ))}
+        </div>
+
+        <div className="mt-6 flex flex-wrap items-baseline gap-x-6 gap-y-2 font-mono text-[10px] uppercase tracking-[0.18em] text-muted">
+          <Stat label="segments" value={stats.segments.toString()} />
+          <Stat label="pauses" value={stats.pauses.toString()} />
+          <Stat label="overshoot" value={stats.overshoots > 0 ? 'yes' : '—'} />
+          <Stat label="section" value={`${activeSection + 1} / ${FEED.length}`} />
+          <span className="ml-auto font-mono text-[10px] text-muted/70">
+            {direction === 'down' && 'rolling…'}
+            {direction === 'up' && 'returning…'}
+            {direction === 'idle' && '✓ ready'}
+          </span>
+        </div>
+      </div>
+
+      <span className="sr-only">
+        Live demonstration of HumanJS&rsquo;s `human.scroll()` driving the same `planScroll` planner
+        the Playwright adapter walks against `page.mouse.wheel`. The bounded list scrolls from top
+        to bottom with a bell-curve velocity profile, mid-scroll pauses, and (on the distracted
+        personality) an overshoot-and-correct phase, then returns to the top and repeats. Switch
+        personality with the controls above to compare scroll rhythms.
+      </span>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="inline-flex items-baseline gap-2">
+      <span>{label}</span>
+      <span className="font-mono text-base tabular-nums text-foreground md:text-lg">{value}</span>
+    </span>
+  );
+}

--- a/apps/web/components/sections/ScrollShowcase.tsx
+++ b/apps/web/components/sections/ScrollShowcase.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import type { PresetName } from '@humanjs/core';
+import { motion } from 'framer-motion';
+import { useState } from 'react';
+import { cn } from '../../lib/cn';
+import { ScrollDemo } from '../motion/ScrollDemo';
+import { Container, ScrollReveal, Section, SectionEyebrow, SectionHeadline } from '../primitives';
+
+const personalities: { key: PresetName; label: string; hint: string }[] = [
+  { key: 'careful', label: 'careful', hint: 'paces' },
+  { key: 'fast', label: 'fast', hint: 'snaps' },
+  { key: 'distracted', label: 'distracted', hint: 'overshoots' },
+  { key: 'precise', label: 'precise', hint: 'smooth' },
+];
+
+export function ScrollShowcase() {
+  const [personality, setPersonality] = useState<PresetName>('careful');
+
+  return (
+    <Section id="scroll" density="default">
+      <Container width="lg">
+        <ScrollReveal>
+          <div className="mb-10 max-w-3xl md:mb-12">
+            <SectionEyebrow>And the motion between</SectionEyebrow>
+            <SectionHeadline data-ghost-cursor="true">
+              Real scrolling is a wave.{' '}
+              <span className="font-display italic text-accent">Not a jump.</span>
+            </SectionHeadline>
+            <p className="mt-6 max-w-xl text-balance text-base text-muted-strong md:text-lg">
+              Robotic scroll fires one big delta. Humans roll a wheel — accelerate, peak,
+              decelerate, occasionally pause, sometimes overshoot. `human.scroll()` models that from
+              a deterministic planner, and `distracted` will pass the target and correct back the
+              way real eyes do.
+            </p>
+          </div>
+        </ScrollReveal>
+
+        <ScrollReveal delay={0.08}>
+          <div className="mx-auto max-w-4xl">
+            <div className="mb-3 flex flex-wrap items-center gap-2">
+              <span className="mr-2 font-mono text-[10px] uppercase tracking-[0.18em] text-muted/70">
+                Personality
+              </span>
+              {personalities.map((p) => (
+                <button
+                  key={p.key}
+                  type="button"
+                  aria-pressed={personality === p.key}
+                  onClick={() => setPersonality(p.key)}
+                  className={cn(
+                    'relative rounded-full border px-3 py-1 font-mono text-[11px] uppercase tracking-[0.15em] transition-colors duration-200 outline-none focus-visible:ring-2 focus-visible:ring-accent',
+                    personality === p.key
+                      ? 'border-accent/50 bg-accent/10 text-accent'
+                      : 'border-hairline text-muted hover:border-hairline-strong hover:text-foreground',
+                  )}
+                >
+                  {personality === p.key && (
+                    <motion.span
+                      layoutId="scroll-personality-marker"
+                      className="absolute inset-0 rounded-full border border-accent/30"
+                      transition={{ type: 'spring', bounce: 0.18, duration: 0.45 }}
+                    />
+                  )}
+                  <span className="relative">
+                    {p.label}
+                    <span className="ml-1.5 text-muted/60">· {p.hint}</span>
+                  </span>
+                </button>
+              ))}
+            </div>
+            <ScrollDemo personality={personality} />
+          </div>
+        </ScrollReveal>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/components/sections/index.ts
+++ b/apps/web/components/sections/index.ts
@@ -9,5 +9,6 @@ export { Nav } from './Nav';
 export { PersonalityLab } from './PersonalityLab';
 export { Playground } from './Playground';
 export { ReadingShowcase } from './ReadingShowcase';
+export { ScrollShowcase } from './ScrollShowcase';
 export { TrustStrip } from './TrustStrip';
 export { TypingShowcase } from './TypingShowcase';

--- a/examples/package.json
+++ b/examples/package.json
@@ -8,6 +8,7 @@
     "click": "tsx click-demo.ts",
     "compare": "tsx compare-demo.ts",
     "read": "tsx read-demo.ts",
+    "scroll": "tsx scroll-demo.ts",
     "type": "tsx type-demo.ts"
   },
   "dependencies": {

--- a/examples/scroll-demo.ts
+++ b/examples/scroll-demo.ts
@@ -1,0 +1,183 @@
+/**
+ * HumanJS scroll demo — opens a tall page and scrolls through it the way a
+ * real reader would: a natural one-viewport step, a targeted jump to a
+ * section, all the way to the bottom, then back to the top.
+ *
+ * Run with:
+ *   pnpm demo:scroll
+ *
+ * Compare personalities by re-running with:
+ *   PERSONALITY=careful     pnpm demo:scroll   (default)
+ *   PERSONALITY=fast        pnpm demo:scroll
+ *   PERSONALITY=precise     pnpm demo:scroll
+ *   PERSONALITY=distracted  pnpm demo:scroll
+ */
+
+import { createHuman, installMouseHelper } from '@humanjs/playwright';
+import { chromium } from 'playwright';
+import { parsePersonality } from './lib';
+
+const SECTIONS = [
+  { id: 'hero', title: 'Hero', accent: '#f5a55c' },
+  { id: 'features', title: 'Features', accent: '#5b7cc9' },
+  { id: 'pricing', title: 'Pricing', accent: '#7abf85' },
+  { id: 'testimonials', title: 'Testimonials', accent: '#d77fa3' },
+  { id: 'faq', title: 'FAQ', accent: '#c9a35b' },
+  { id: 'footer', title: 'Footer', accent: '#888' },
+];
+
+const DEMO_HTML = /* html */ `
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>HumanJS scroll demo</title>
+    <style>
+      :root { color-scheme: dark; }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: #0a0a0a;
+        color: #f0ece5;
+        font-family: -apple-system, system-ui, sans-serif;
+      }
+      .marker {
+        position: fixed;
+        top: 16px;
+        right: 24px;
+        font-family: ui-monospace, SF Mono, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        color: #888;
+        background: rgba(20, 20, 20, 0.9);
+        border: 1px solid #2a2a2a;
+        padding: 8px 14px;
+        border-radius: 999px;
+        z-index: 10;
+      }
+      .marker span { color: #f5a55c; }
+      section {
+        min-height: 100vh;
+        padding: 56px 48px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        border-bottom: 1px solid #1a1a1a;
+        position: relative;
+      }
+      section h2 {
+        margin: 0 0 12px;
+        font-size: 64px;
+        font-weight: 700;
+        letter-spacing: -0.03em;
+      }
+      section .label {
+        font-family: ui-monospace, SF Mono, monospace;
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.22em;
+        color: #555;
+        margin-bottom: 24px;
+      }
+      section p {
+        max-width: 640px;
+        text-align: center;
+        font-size: 18px;
+        line-height: 1.6;
+        color: #aaa;
+      }
+      section .pill {
+        margin-top: 24px;
+        font-family: ui-monospace, SF Mono, monospace;
+        font-size: 12px;
+        color: #555;
+        border: 1px solid #2a2a2a;
+        padding: 6px 14px;
+        border-radius: 999px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="marker">human.<span>scroll()</span></div>
+    ${SECTIONS.map(
+      (s) => /* html */ `
+      <section id="${s.id}" style="background: radial-gradient(circle at 50% 30%, ${s.accent}22, transparent 60%);">
+        <div class="label">section</div>
+        <h2 style="color: ${s.accent};">${s.title}</h2>
+        <p>A real reader scrolls through pages in bursts — not one giant jump.
+        Wheel events come in waves with mid-scroll micro-pauses; sometimes
+        the scroll overshoots and corrects back. HumanJS models that.</p>
+        <div class="pill">#${s.id}</div>
+      </section>`,
+    ).join('')}
+  </body>
+</html>
+`;
+
+async function main() {
+  const personality = parsePersonality(process.env.PERSONALITY, 'careful', 'PERSONALITY');
+
+  const browser = await chromium.launch({
+    headless: false,
+    args: ['--window-size=1100,820'],
+  });
+  try {
+    const context = await browser.newContext({ viewport: { width: 1100, height: 820 } });
+    const page = await context.newPage();
+    await page.setContent(DEMO_HTML);
+    await installMouseHelper(page);
+
+    console.log(`Personality: ${personality}\n`);
+
+    const human = await createHuman(page, {
+      personality,
+      seed: 'scroll-demo-1',
+      plugins: [
+        {
+          name: 'logger',
+          afterAction: (action, result) => {
+            if (action.type !== 'scroll') return;
+            const target = action.params?.target;
+            console.log(`✓ scroll → ${target} (${result.durationMs}ms)`);
+          },
+        },
+      ],
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    // 1. Natural one-viewport scroll — what a real reader does first.
+    await human.scroll();
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    // 2. Jump to a specific section by selector.
+    await human.scroll('#pricing');
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    // 3. Scroll to bottom — long-distance scroll exercises the bell-curve
+    // velocity profile and mid-scroll pauses.
+    await human.scroll('end');
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    // 4. Back to the top.
+    await human.scroll('top');
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    // 5. Forced overshoot — for personalities that wouldn't normally do
+    // one, opt in via the options object to see the correction behavior.
+    await human.scroll('#testimonials', { overshoot: true });
+
+    console.log('\nDone. Browser will stay open for 5 seconds.');
+    console.log('Tip: re-run with PERSONALITY=distracted to see lots of overshoot.');
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/scroll-demo.ts
+++ b/examples/scroll-demo.ts
@@ -35,6 +35,12 @@ const DEMO_HTML = /* html */ `
     <style>
       :root { color-scheme: dark; }
       * { box-sizing: border-box; }
+      html, body {
+        /* Wider than the viewport so we can test horizontal *window*
+           scroll directly — no container in the path. */
+        width: 200vw;
+        min-width: 200vw;
+      }
       body {
         margin: 0;
         background: #0a0a0a;
@@ -112,6 +118,7 @@ const DEMO_HTML = /* html */ `
         <div class="pill">#${s.id}</div>
       </section>`,
     ).join('')}
+
   </body>
 </html>
 `;
@@ -148,24 +155,33 @@ async function main() {
 
     await new Promise((resolve) => setTimeout(resolve, 600));
 
-    // 1. Natural one-viewport scroll — what a real reader does first.
+    // 1. Horizontal scroll to the center of the 200vw-wide body. After
+    // this lands, sections (which are also 200vw wide with content
+    // centered horizontally) sit cleanly centered in the viewport.
+    const halfwayX = await page.evaluate(() =>
+      Math.floor((document.documentElement.scrollWidth - window.innerWidth) / 2),
+    );
+    await human.scroll({ to: halfwayX }, { axis: 'x' });
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    // 2. Natural one-viewport scroll — what a real reader does first.
     await human.scroll();
     await new Promise((resolve) => setTimeout(resolve, 800));
 
-    // 2. Jump to a specific section by selector.
-    await human.scroll('#pricing');
+    // 3. Jump to a specific section by selector.
+    await human.scroll('#pricing', { overshoot: true });
     await new Promise((resolve) => setTimeout(resolve, 800));
 
-    // 3. Scroll to bottom — long-distance scroll exercises the bell-curve
+    // 4. Scroll to bottom — long-distance scroll exercises the bell-curve
     // velocity profile and mid-scroll pauses.
     await human.scroll('end');
     await new Promise((resolve) => setTimeout(resolve, 800));
 
-    // 4. Back to the top.
+    // 5. Back to the top.
     await human.scroll('top');
     await new Promise((resolve) => setTimeout(resolve, 800));
 
-    // 5. Forced overshoot — for personalities that wouldn't normally do
+    // 6. Forced overshoot — for personalities that wouldn't normally do
     // one, opt in via the options object to see the correction behavior.
     await human.scroll('#testimonials', { overshoot: true });
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "demo:click": "turbo run build --filter=@humanjs/playwright... && pnpm --filter @humanjs/examples click",
     "demo:compare": "turbo run build --filter=@humanjs/playwright... && pnpm --filter @humanjs/examples compare",
     "demo:read": "turbo run build --filter=@humanjs/playwright... && pnpm --filter @humanjs/examples read",
+    "demo:scroll": "turbo run build --filter=@humanjs/playwright... && pnpm --filter @humanjs/examples scroll",
     "demo:type": "turbo run build --filter=@humanjs/playwright... && pnpm --filter @humanjs/examples type"
   },
   "commitlint": {

--- a/packages/core/src/blend/index.ts
+++ b/packages/core/src/blend/index.ts
@@ -83,6 +83,40 @@ export function blend(a: PersonalityConfig, b: PersonalityConfig, ratio: number)
       wpm: lerp(personalityA.reading.wpm, personalityB.reading.wpm, t),
       jitter: lerp(personalityA.reading.jitter, personalityB.reading.jitter, t),
     },
+    scroll: {
+      segmentsPerKpx: lerp(
+        personalityA.scroll.segmentsPerKpx,
+        personalityB.scroll.segmentsPerKpx,
+        t,
+      ),
+      segmentDelayMs: lerp(
+        personalityA.scroll.segmentDelayMs,
+        personalityB.scroll.segmentDelayMs,
+        t,
+      ),
+      segmentDelayJitter: lerp(
+        personalityA.scroll.segmentDelayJitter,
+        personalityB.scroll.segmentDelayJitter,
+        t,
+      ),
+      pauseProbability: lerp(
+        personalityA.scroll.pauseProbability,
+        personalityB.scroll.pauseProbability,
+        t,
+      ),
+      pauseMs: lerp(personalityA.scroll.pauseMs, personalityB.scroll.pauseMs, t),
+      pauseMsJitter: lerp(personalityA.scroll.pauseMsJitter, personalityB.scroll.pauseMsJitter, t),
+      overshootProbability: lerp(
+        personalityA.scroll.overshootProbability,
+        personalityB.scroll.overshootProbability,
+        t,
+      ),
+      overshootRatio: lerp(
+        personalityA.scroll.overshootRatio,
+        personalityB.scroll.overshootRatio,
+        t,
+      ),
+    },
     dwell: {
       preClickMs: lerp(personalityA.dwell.preClickMs, personalityB.dwell.preClickMs, t),
       preClickJitter: lerp(personalityA.dwell.preClickJitter, personalityB.dwell.preClickJitter, t),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export type {
   MouseProfile,
   Personality,
   ReadingProfile,
+  ScrollProfile,
   TypingProfile,
 } from './personality';
 export type {
@@ -40,5 +41,7 @@ export type {
 export { resolvePersonality } from './resolve';
 export type { Rng } from './rng';
 export { createRng } from './rng';
+export type { PlanScrollOptions, ScrollSegment } from './scroll';
+export { planScroll } from './scroll';
 export type { Keystroke, PlanTypingOptions } from './typing';
 export { planTypeKeystrokes } from './typing';

--- a/packages/core/src/personality.ts
+++ b/packages/core/src/personality.ts
@@ -21,6 +21,7 @@ export interface Personality {
   readonly mouse: MouseProfile;
   readonly typing: TypingProfile;
   readonly reading: ReadingProfile;
+  readonly scroll: ScrollProfile;
   readonly dwell: DwellProfile;
 }
 
@@ -74,6 +75,37 @@ export interface ReadingProfile {
    * variation.
    */
   readonly jitter: number;
+}
+
+/** Parameters that shape scroll behavior. */
+export interface ScrollProfile {
+  /**
+   * Wheel-event density: how many segments per 1000 px of scroll distance.
+   * More = smoother visible motion at higher CDP overhead. Real-world
+   * trackpad / wheel rolls land somewhere around 20–40 events per 1000 px.
+   */
+  readonly segmentsPerKpx: number;
+  /** Mean delay in ms between successive wheel events. */
+  readonly segmentDelayMs: number;
+  /**
+   * Random variation as a fraction of `segmentDelayMs`. `0.3` means each
+   * inter-segment delay is `segmentDelayMs × [0.7, 1.3]`. Range: `[0, 1]`.
+   */
+  readonly segmentDelayJitter: number;
+  /** Probability of inserting a mid-scroll micro-pause (0..1). */
+  readonly pauseProbability: number;
+  /** Mean duration of a mid-scroll pause in ms. */
+  readonly pauseMs: number;
+  /** Jitter on `pauseMs`. Range: `[0, 1]`. */
+  readonly pauseMsJitter: number;
+  /** Probability of overshooting the target and correcting (0..1). */
+  readonly overshootProbability: number;
+  /**
+   * Magnitude of overshoot as a fraction of the total scroll distance.
+   * `0.1` means a 1000 px scroll would overshoot by ~100 px before
+   * correcting back. Range: `[0, 0.5]` is sensible; clamped internally.
+   */
+  readonly overshootRatio: number;
 }
 
 /** Parameters that shape micro-pauses around actions. */

--- a/packages/core/src/presets/careful.ts
+++ b/packages/core/src/presets/careful.ts
@@ -26,6 +26,19 @@ export const careful: Personality = {
     wpm: 220,
     jitter: 0.2,
   },
+  scroll: {
+    // ~55 events per 1000 px at ~14 ms apart matches a real mouse-wheel
+    // cadence (50–60 Hz). Per-event delta lands around 18 px — close to a
+    // real wheel "line" — so the browser smooth-paints between events.
+    segmentsPerKpx: 55,
+    segmentDelayMs: 14,
+    segmentDelayJitter: 0.3,
+    pauseProbability: 0.1,
+    pauseMs: 200,
+    pauseMsJitter: 0.4,
+    overshootProbability: 0.05,
+    overshootRatio: 0.16,
+  },
   dwell: {
     preClickMs: 120,
     preClickJitter: 0.3,

--- a/packages/core/src/presets/distracted.ts
+++ b/packages/core/src/presets/distracted.ts
@@ -26,6 +26,16 @@ export const distracted: Personality = {
     wpm: 180,
     jitter: 0.4,
   },
+  scroll: {
+    segmentsPerKpx: 55,
+    segmentDelayMs: 18,
+    segmentDelayJitter: 0.5,
+    pauseProbability: 0.18,
+    pauseMs: 280,
+    pauseMsJitter: 0.5,
+    overshootProbability: 0.25,
+    overshootRatio: 0.25,
+  },
   dwell: {
     preClickMs: 200,
     preClickJitter: 0.5,

--- a/packages/core/src/presets/fast.ts
+++ b/packages/core/src/presets/fast.ts
@@ -31,6 +31,16 @@ export const fast: Personality = {
     wpm: 350,
     jitter: 0.15,
   },
+  scroll: {
+    segmentsPerKpx: 40,
+    segmentDelayMs: 8,
+    segmentDelayJitter: 0.2,
+    pauseProbability: 0.025,
+    pauseMs: 100,
+    pauseMsJitter: 0.3,
+    overshootProbability: 0.02,
+    overshootRatio: 0.1,
+  },
   dwell: {
     preClickMs: 50,
     preClickJitter: 0.25,

--- a/packages/core/src/presets/precise.ts
+++ b/packages/core/src/presets/precise.ts
@@ -26,6 +26,16 @@ export const precise: Personality = {
     wpm: 250,
     jitter: 0.08,
   },
+  scroll: {
+    segmentsPerKpx: 50,
+    segmentDelayMs: 11,
+    segmentDelayJitter: 0.1,
+    pauseProbability: 0.025,
+    pauseMs: 130,
+    pauseMsJitter: 0.1,
+    overshootProbability: 0,
+    overshootRatio: 0,
+  },
   dwell: {
     preClickMs: 80,
     preClickJitter: 0.1,

--- a/packages/core/src/resolve/index.ts
+++ b/packages/core/src/resolve/index.ts
@@ -3,6 +3,7 @@ import type {
   MouseProfile,
   Personality,
   ReadingProfile,
+  ScrollProfile,
   TypingProfile,
 } from '../personality';
 import { careful, distracted, fast, precise } from '../presets';
@@ -28,6 +29,7 @@ export interface PersonalityExtension {
   readonly mouse?: Partial<MouseProfile>;
   readonly typing?: Partial<TypingProfile>;
   readonly reading?: Partial<ReadingProfile>;
+  readonly scroll?: Partial<ScrollProfile>;
   readonly dwell?: Partial<DwellProfile>;
 }
 
@@ -58,6 +60,7 @@ export function resolvePersonality(config: PersonalityConfig): Personality {
       mouse: { ...base.mouse, ...config.mouse },
       typing: { ...base.typing, ...config.typing },
       reading: { ...base.reading, ...config.reading },
+      scroll: { ...base.scroll, ...config.scroll },
       dwell: { ...base.dwell, ...config.dwell },
     };
   }

--- a/packages/core/src/scroll/index.test.ts
+++ b/packages/core/src/scroll/index.test.ts
@@ -21,17 +21,17 @@ describe('planScroll', () => {
 
   it('sums to the requested distance for downward scrolls', () => {
     const plan = planScroll(0, 1000, NO_NOISE, createRng('d1'));
-    const totalDelta = plan.reduce((sum, s) => sum + s.deltaY, 0);
+    const totalDelta = plan.reduce((sum, s) => sum + s.delta, 0);
     expect(totalDelta).toBeCloseTo(1000, 6);
   });
 
   it('sums to the requested distance for upward scrolls', () => {
     const plan = planScroll(1000, 0, NO_NOISE, createRng('u1'));
-    const totalDelta = plan.reduce((sum, s) => sum + s.deltaY, 0);
+    const totalDelta = plan.reduce((sum, s) => sum + s.delta, 0);
     expect(totalDelta).toBeCloseTo(-1000, 6);
     // Every non-pause segment should move up (negative).
     for (const s of plan) {
-      if (s.deltaY !== 0) expect(s.deltaY).toBeLessThan(0);
+      if (s.delta !== 0) expect(s.delta).toBeLessThan(0);
     }
   });
 
@@ -60,23 +60,23 @@ describe('planScroll', () => {
 
   it('inserts mid-scroll pauses when pauseProbability > 0', () => {
     // `distracted` has pauseProbability 0.3 — over a long enough scroll we
-    // should land at least one pause segment (deltaY === 0).
+    // should land at least one pause segment (delta === 0).
     const plan = planScroll(0, 4000, distracted.scroll, createRng('pause-seed'));
-    const pauseCount = plan.filter((s) => s.deltaY === 0).length;
+    const pauseCount = plan.filter((s) => s.delta === 0).length;
     expect(pauseCount).toBeGreaterThan(0);
   });
 
   it('omits pauses entirely when withPauses is false', () => {
     const plan = planScroll(0, 4000, distracted.scroll, createRng('np'), { withPauses: false });
     // No-overshoot path (no realize-pause), no mid-scroll pauses → no zero segments.
-    expect(plan.every((s) => s.deltaY !== 0 || s === plan[plan.length - 1])).toBe(true);
+    expect(plan.every((s) => s.delta !== 0 || s === plan[plan.length - 1])).toBe(true);
   });
 
   it('produces a bell-curve velocity profile (mid segment delta > end segment delta)', () => {
     // With pauses/overshoot off, deltas should follow a half-sine: small at
     // the edges, biggest in the middle.
     const plan = planScroll(0, 2000, NO_NOISE, createRng('bell'));
-    const moves = plan.filter((s) => s.deltaY !== 0);
+    const moves = plan.filter((s) => s.delta !== 0);
     expect(moves.length).toBeGreaterThan(4);
     const first = moves[0];
     const mid = moves[Math.floor(moves.length / 2)];
@@ -85,8 +85,8 @@ describe('planScroll', () => {
     expect(mid).toBeDefined();
     expect(last).toBeDefined();
     if (first && mid && last) {
-      expect(Math.abs(mid.deltaY)).toBeGreaterThan(Math.abs(first.deltaY));
-      expect(Math.abs(mid.deltaY)).toBeGreaterThan(Math.abs(last.deltaY));
+      expect(Math.abs(mid.delta)).toBeGreaterThan(Math.abs(first.delta));
+      expect(Math.abs(mid.delta)).toBeGreaterThan(Math.abs(last.delta));
     }
   });
 
@@ -104,7 +104,7 @@ describe('planScroll', () => {
     let y = 0;
     let peakY = 0;
     for (const s of plan) {
-      y += s.deltaY;
+      y += s.delta;
       if (y > peakY) peakY = y;
     }
     expect(peakY).toBeGreaterThan(1000); // overshot
@@ -120,7 +120,7 @@ describe('planScroll', () => {
     let y = 0;
     let peakY = 0;
     for (const s of plan) {
-      y += s.deltaY;
+      y += s.delta;
       if (y > peakY) peakY = y;
     }
     expect(peakY).toBeLessThanOrEqual(1000 + 1); // float epsilon

--- a/packages/core/src/scroll/index.test.ts
+++ b/packages/core/src/scroll/index.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { careful, distracted } from '../presets';
+import { createRng } from '../rng';
+import { planScroll } from './index';
+
+const NO_NOISE = {
+  segmentsPerKpx: 20,
+  segmentDelayMs: 10,
+  segmentDelayJitter: 0,
+  pauseProbability: 0,
+  pauseMs: 100,
+  pauseMsJitter: 0,
+  overshootProbability: 0,
+  overshootRatio: 0,
+};
+
+describe('planScroll', () => {
+  it('returns an empty plan when distance is 0', () => {
+    expect(planScroll(100, 100, NO_NOISE, createRng('a'))).toEqual([]);
+  });
+
+  it('sums to the requested distance for downward scrolls', () => {
+    const plan = planScroll(0, 1000, NO_NOISE, createRng('d1'));
+    const totalDelta = plan.reduce((sum, s) => sum + s.deltaY, 0);
+    expect(totalDelta).toBeCloseTo(1000, 6);
+  });
+
+  it('sums to the requested distance for upward scrolls', () => {
+    const plan = planScroll(1000, 0, NO_NOISE, createRng('u1'));
+    const totalDelta = plan.reduce((sum, s) => sum + s.deltaY, 0);
+    expect(totalDelta).toBeCloseTo(-1000, 6);
+    // Every non-pause segment should move up (negative).
+    for (const s of plan) {
+      if (s.deltaY !== 0) expect(s.deltaY).toBeLessThan(0);
+    }
+  });
+
+  it('produces a non-empty plan even for tiny distances (minimum 2 segments)', () => {
+    const plan = planScroll(0, 5, NO_NOISE, createRng('tiny'));
+    expect(plan.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('scales segment count with distance', () => {
+    const short = planScroll(0, 500, NO_NOISE, createRng('s'));
+    const long = planScroll(0, 5000, NO_NOISE, createRng('l'));
+    expect(long.length).toBeGreaterThan(short.length);
+  });
+
+  it('is deterministic given the same seed and inputs', () => {
+    const a = planScroll(0, 1500, careful.scroll, createRng('det'), { personalitySpeed: 1 });
+    const b = planScroll(0, 1500, careful.scroll, createRng('det'), { personalitySpeed: 1 });
+    expect(a).toEqual(b);
+  });
+
+  it('produces different plans for different seeds (jitter / pauses / overshoot consume RNG)', () => {
+    const a = planScroll(0, 2000, careful.scroll, createRng('a'));
+    const b = planScroll(0, 2000, careful.scroll, createRng('b'));
+    expect(a).not.toEqual(b);
+  });
+
+  it('inserts mid-scroll pauses when pauseProbability > 0', () => {
+    // `distracted` has pauseProbability 0.3 — over a long enough scroll we
+    // should land at least one pause segment (deltaY === 0).
+    const plan = planScroll(0, 4000, distracted.scroll, createRng('pause-seed'));
+    const pauseCount = plan.filter((s) => s.deltaY === 0).length;
+    expect(pauseCount).toBeGreaterThan(0);
+  });
+
+  it('omits pauses entirely when withPauses is false', () => {
+    const plan = planScroll(0, 4000, distracted.scroll, createRng('np'), { withPauses: false });
+    // No-overshoot path (no realize-pause), no mid-scroll pauses → no zero segments.
+    expect(plan.every((s) => s.deltaY !== 0 || s === plan[plan.length - 1])).toBe(true);
+  });
+
+  it('produces a bell-curve velocity profile (mid segment delta > end segment delta)', () => {
+    // With pauses/overshoot off, deltas should follow a half-sine: small at
+    // the edges, biggest in the middle.
+    const plan = planScroll(0, 2000, NO_NOISE, createRng('bell'));
+    const moves = plan.filter((s) => s.deltaY !== 0);
+    expect(moves.length).toBeGreaterThan(4);
+    const first = moves[0];
+    const mid = moves[Math.floor(moves.length / 2)];
+    const last = moves[moves.length - 1];
+    expect(first).toBeDefined();
+    expect(mid).toBeDefined();
+    expect(last).toBeDefined();
+    if (first && mid && last) {
+      expect(Math.abs(mid.deltaY)).toBeGreaterThan(Math.abs(first.deltaY));
+      expect(Math.abs(mid.deltaY)).toBeGreaterThan(Math.abs(last.deltaY));
+    }
+  });
+
+  it('respects forceOvershoot — plan goes past target then corrects back', () => {
+    // distance 1000, overshootRatio 0.1 (we pick a profile with overshoot
+    // enabled). The peak Y reached during the plan should exceed the target.
+    const plan = planScroll(
+      0,
+      1000,
+      { ...NO_NOISE, overshootRatio: 0.15 },
+      createRng('overshoot'),
+      { forceOvershoot: true },
+    );
+    // Walk the plan and track running Y.
+    let y = 0;
+    let peakY = 0;
+    for (const s of plan) {
+      y += s.deltaY;
+      if (y > peakY) peakY = y;
+    }
+    expect(peakY).toBeGreaterThan(1000); // overshot
+    expect(y).toBeCloseTo(1000, 6); // corrected back to target
+  });
+
+  it('skips overshoot in instant mode (speedFactor: 0) even when forced', () => {
+    const plan = planScroll(0, 1000, NO_NOISE, createRng('inst'), {
+      forceOvershoot: true,
+      speedFactor: 0,
+    });
+    // Walk Y — should never exceed target (no overshoot).
+    let y = 0;
+    let peakY = 0;
+    for (const s of plan) {
+      y += s.deltaY;
+      if (y > peakY) peakY = y;
+    }
+    expect(peakY).toBeLessThanOrEqual(1000 + 1); // float epsilon
+  });
+
+  it('zeros every delayBeforeMs when speedFactor is 0', () => {
+    const plan = planScroll(0, 1000, careful.scroll, createRng('inst-delay'), { speedFactor: 0 });
+    for (const s of plan) {
+      expect(s.delayBeforeMs).toBe(0);
+    }
+  });
+
+  it('scales every delay by personalitySpeed × speedFactor multiplicatively', () => {
+    const baseProfile = { ...NO_NOISE, segmentDelayMs: 10 };
+    const base = planScroll(0, 1000, baseProfile, createRng('scale'), { personalitySpeed: 1 });
+    const half = planScroll(0, 1000, baseProfile, createRng('scale'), { personalitySpeed: 0.5 });
+    expect(base.length).toBe(half.length);
+    for (let i = 0; i < base.length; i++) {
+      const b = base[i]?.delayBeforeMs ?? 0;
+      const h = half[i]?.delayBeforeMs ?? 0;
+      expect(h).toBeCloseTo(b * 0.5, 6);
+    }
+  });
+});

--- a/packages/core/src/scroll/index.ts
+++ b/packages/core/src/scroll/index.ts
@@ -1,0 +1,192 @@
+import type { ScrollProfile } from '../personality';
+import type { Rng } from '../rng';
+
+/** One step in a humanized scroll plan. */
+export interface ScrollSegment {
+  /**
+   * Vertical pixel delta for this segment (positive = scroll down, negative
+   * = scroll up). A segment with `deltaY === 0` is a pure pause — the
+   * adapter still waits `delayBeforeMs`, but no wheel event fires.
+   */
+  readonly deltaY: number;
+  /** Pause in ms before dispatching this segment. */
+  readonly delayBeforeMs: number;
+}
+
+/** Options for {@link planScroll}. */
+export interface PlanScrollOptions {
+  /**
+   * Override `profile.overshootProbability` for this plan only. Useful when
+   * the adapter has stronger signal than the personality (e.g. "scroll to
+   * this element with intentional overshoot").
+   */
+  readonly forceOvershoot?: boolean;
+  /**
+   * Disable mid-scroll pauses. Useful for short scrolls where a pause feels
+   * wrong, or when the caller wants the smoothest possible motion.
+   */
+  readonly withPauses?: boolean;
+  /**
+   * Personality-tempo multiplier (`personality.speed`). Defaults to 1.
+   * Applied to every segment's delay.
+   */
+  readonly personalitySpeed?: number;
+  /**
+   * Speed-mode factor (`1` human, `0.5` fast, `0` instant). Defaults to 1.
+   * `0` collapses every delay to zero and skips overshoot.
+   */
+  readonly speedFactor?: number;
+}
+
+/**
+ * Plans a humanized vertical scroll from `fromY` to `toY` as a sequence of
+ * wheel-event-shaped segments. Pure function, deterministic given the same
+ * RNG state and inputs.
+ *
+ * Motion model:
+ *   1. Segment count scales with distance via `profile.segmentsPerKpx`.
+ *   2. Per-segment delta follows a bell-curve velocity profile (slow start,
+ *      fast middle, slow end) — robotic scroll is one big jump; humans
+ *      accelerate, peak, and decelerate.
+ *   3. Mid-scroll pauses sprinkled with probability `profile.pauseProbability`
+ *      between segments (skip the first and last so we never pause *at* the
+ *      ends, which would look wrong).
+ *   4. Optional overshoot: with `profile.overshootProbability` (or forced by
+ *      `options.forceOvershoot`), plan continues past `toY` by
+ *      `distance × profile.overshootRatio`, dwells briefly, then reverses
+ *      back to `toY`. Real eyes / scroll wheels do this when target is
+ *      below the fold and you misjudge distance.
+ *
+ * The sum of segment `deltaY`s always equals `toY - fromY` (within
+ * floating-point rounding).
+ */
+export function planScroll(
+  fromY: number,
+  toY: number,
+  profile: ScrollProfile,
+  rng: Rng,
+  options: PlanScrollOptions = {},
+): readonly ScrollSegment[] {
+  const personalitySpeed = options.personalitySpeed ?? 1;
+  const speedFactor = options.speedFactor ?? 1;
+  const withPauses = options.withPauses ?? true;
+
+  const distance = toY - fromY;
+  if (distance === 0) return [];
+
+  const direction = distance >= 0 ? 1 : -1;
+  const absDistance = Math.abs(distance);
+
+  // Decide whether to overshoot. Skipped in instant mode (speedFactor 0)
+  // because overshoot is purely a visual humanization signal — without
+  // delay there's no way to perceive it.
+  const wantsOvershoot = options.forceOvershoot ?? rng.next() < profile.overshootProbability;
+  const overshoot =
+    wantsOvershoot && speedFactor > 0
+      ? Math.max(0, Math.min(0.5, profile.overshootRatio)) * absDistance
+      : 0;
+
+  const segments: ScrollSegment[] = [];
+
+  // Phase 1: from → (target + overshoot * direction)
+  const phase1End = toY + overshoot * direction;
+  appendBellPhase(
+    segments,
+    fromY,
+    phase1End,
+    profile,
+    rng,
+    personalitySpeed,
+    speedFactor,
+    withPauses,
+  );
+
+  // Phase 2: pause at the overshot position + correct back to target.
+  if (overshoot > 0) {
+    // "Wait, I went too far" pause. Long enough to read as deliberate
+    // recognition — short pauses get lost in the bell-curve decel and the
+    // whole overshoot just looks like the scroll stalled.
+    const realizeMs = jitter(profile.pauseMs * 2.5, profile.pauseMsJitter, rng);
+    segments.push({
+      deltaY: 0,
+      delayBeforeMs: realizeMs * personalitySpeed * speedFactor,
+    });
+    appendBellPhase(
+      segments,
+      phase1End,
+      toY,
+      profile,
+      rng,
+      personalitySpeed,
+      speedFactor,
+      /* withPauses */ false, // correction is one fluid motion
+    );
+  }
+
+  return segments;
+}
+
+/**
+ * Appends bell-curve-velocity segments from `startY` to `endY`. Each
+ * segment's `deltaY` is proportional to its position on a half-sine curve
+ * so motion accelerates from `startY`, peaks at the midpoint, and decays
+ * into `endY`. The sum of appended `deltaY`s equals `endY - startY` exactly.
+ */
+function appendBellPhase(
+  out: ScrollSegment[],
+  startY: number,
+  endY: number,
+  profile: ScrollProfile,
+  rng: Rng,
+  personalitySpeed: number,
+  speedFactor: number,
+  withPauses: boolean,
+): void {
+  const distance = endY - startY;
+  if (distance === 0) return;
+
+  const absDistance = Math.abs(distance);
+  const direction = distance >= 0 ? 1 : -1;
+  const segments = Math.max(2, Math.ceil((absDistance / 1000) * profile.segmentsPerKpx));
+
+  // Bell weights: sin(i / segments × π) for i = 0..segments-1. Skipping i=0
+  // gives a non-zero first step so the cursor doesn't sit motionless on the
+  // first frame.
+  const weights: number[] = [];
+  let totalWeight = 0;
+  for (let i = 0; i < segments; i++) {
+    const w = Math.sin(((i + 0.5) / segments) * Math.PI);
+    weights.push(w);
+    totalWeight += w;
+  }
+
+  for (let i = 0; i < segments; i++) {
+    const w = weights[i] ?? 0;
+    const delta = (w / totalWeight) * absDistance * direction;
+    const baseDelay = jitter(profile.segmentDelayMs, profile.segmentDelayJitter, rng);
+    out.push({
+      deltaY: delta,
+      delayBeforeMs: baseDelay * personalitySpeed * speedFactor,
+    });
+    // Maybe insert a pause AFTER this segment (not at the very end).
+    if (
+      withPauses &&
+      i < segments - 1 &&
+      rng.next() < profile.pauseProbability &&
+      speedFactor > 0
+    ) {
+      const pauseMs = jitter(profile.pauseMs, profile.pauseMsJitter, rng);
+      out.push({
+        deltaY: 0,
+        delayBeforeMs: pauseMs * personalitySpeed * speedFactor,
+      });
+    }
+  }
+}
+
+/** Symmetric jitter: `base × [1 - jitter, 1 + jitter]`. Clamped to ≥ 0. */
+function jitter(base: number, jitterRatio: number, rng: Rng): number {
+  if (jitterRatio <= 0) return Math.max(0, base);
+  const offset = rng.nextFloat(-jitterRatio, jitterRatio);
+  return Math.max(0, base * (1 + offset));
+}

--- a/packages/core/src/scroll/index.ts
+++ b/packages/core/src/scroll/index.ts
@@ -42,9 +42,13 @@ export interface PlanScrollOptions {
 }
 
 /**
- * Plans a humanized vertical scroll from `fromY` to `toY` as a sequence of
- * wheel-event-shaped segments. Pure function, deterministic given the same
- * RNG state and inputs.
+ * Plans a humanized scroll from `from` to `to` along a single axis as a
+ * sequence of wheel-event-shaped segments. The axis is implicit — the
+ * planner just produces signed pixel deltas between two scroll positions;
+ * the caller decides whether to apply them to `scrollY` / `scrollTop`
+ * (vertical) or `scrollX` / `scrollLeft` (horizontal).
+ *
+ * Pure function, deterministic given the same RNG state and inputs.
  *
  * Motion model:
  *   1. Segment count scales with distance via `profile.segmentsPerKpx`.
@@ -55,17 +59,17 @@ export interface PlanScrollOptions {
  *      between segments (skip the first and last so we never pause *at* the
  *      ends, which would look wrong).
  *   4. Optional overshoot: with `profile.overshootProbability` (or forced by
- *      `options.forceOvershoot`), plan continues past `toY` by
+ *      `options.forceOvershoot`), plan continues past `to` by
  *      `distance × profile.overshootRatio`, dwells briefly, then reverses
- *      back to `toY`. Real eyes / scroll wheels do this when target is
+ *      back to `to`. Real eyes / scroll wheels do this when target is
  *      below the fold and you misjudge distance.
  *
- * The sum of segment `delta`s always equals `toY - fromY` (within
+ * The sum of segment `delta`s always equals `to - from` (within
  * floating-point rounding).
  */
 export function planScroll(
-  fromY: number,
-  toY: number,
+  from: number,
+  to: number,
   profile: ScrollProfile,
   rng: Rng,
   options: PlanScrollOptions = {},
@@ -74,7 +78,7 @@ export function planScroll(
   const speedFactor = options.speedFactor ?? 1;
   const withPauses = options.withPauses ?? true;
 
-  const distance = toY - fromY;
+  const distance = to - from;
   if (distance === 0) return [];
 
   const direction = distance >= 0 ? 1 : -1;
@@ -92,10 +96,10 @@ export function planScroll(
   const segments: ScrollSegment[] = [];
 
   // Phase 1: from → (target + overshoot * direction)
-  const phase1End = toY + overshoot * direction;
+  const phase1End = to + overshoot * direction;
   appendBellPhase(
     segments,
-    fromY,
+    from,
     phase1End,
     profile,
     rng,
@@ -117,7 +121,7 @@ export function planScroll(
     appendBellPhase(
       segments,
       phase1End,
-      toY,
+      to,
       profile,
       rng,
       personalitySpeed,
@@ -130,22 +134,23 @@ export function planScroll(
 }
 
 /**
- * Appends bell-curve-velocity segments from `startY` to `endY`. Each
- * segment's `delta` is proportional to its position on a half-sine curve
- * so motion accelerates from `startY`, peaks at the midpoint, and decays
- * into `endY`. The sum of appended `delta`s equals `endY - startY` exactly.
+ * Appends bell-curve-velocity segments from `start` to `end` along the
+ * chosen axis. Each segment's `delta` is proportional to its position on
+ * a half-sine curve so motion accelerates from `start`, peaks at the
+ * midpoint, and decays into `end`. The sum of appended `delta`s equals
+ * `end - start` exactly.
  */
 function appendBellPhase(
   out: ScrollSegment[],
-  startY: number,
-  endY: number,
+  start: number,
+  end: number,
   profile: ScrollProfile,
   rng: Rng,
   personalitySpeed: number,
   speedFactor: number,
   withPauses: boolean,
 ): void {
-  const distance = endY - startY;
+  const distance = end - start;
   if (distance === 0) return;
 
   const absDistance = Math.abs(distance);

--- a/packages/core/src/scroll/index.ts
+++ b/packages/core/src/scroll/index.ts
@@ -4,11 +4,14 @@ import type { Rng } from '../rng';
 /** One step in a humanized scroll plan. */
 export interface ScrollSegment {
   /**
-   * Vertical pixel delta for this segment (positive = scroll down, negative
-   * = scroll up). A segment with `deltaY === 0` is a pure pause — the
-   * adapter still waits `delayBeforeMs`, but no wheel event fires.
+   * Signed pixel delta along the scroll axis (positive = forward / down /
+   * right, negative = backward / up / left). The planner is axis-agnostic —
+   * the executor decides whether to apply this to Y or X.
+   *
+   * A segment with `delta === 0` is a pure pause: the adapter still waits
+   * `delayBeforeMs`, but no wheel event fires.
    */
-  readonly deltaY: number;
+  readonly delta: number;
   /** Pause in ms before dispatching this segment. */
   readonly delayBeforeMs: number;
 }
@@ -57,7 +60,7 @@ export interface PlanScrollOptions {
  *      back to `toY`. Real eyes / scroll wheels do this when target is
  *      below the fold and you misjudge distance.
  *
- * The sum of segment `deltaY`s always equals `toY - fromY` (within
+ * The sum of segment `delta`s always equals `toY - fromY` (within
  * floating-point rounding).
  */
 export function planScroll(
@@ -108,7 +111,7 @@ export function planScroll(
     // whole overshoot just looks like the scroll stalled.
     const realizeMs = jitter(profile.pauseMs * 2.5, profile.pauseMsJitter, rng);
     segments.push({
-      deltaY: 0,
+      delta: 0,
       delayBeforeMs: realizeMs * personalitySpeed * speedFactor,
     });
     appendBellPhase(
@@ -128,9 +131,9 @@ export function planScroll(
 
 /**
  * Appends bell-curve-velocity segments from `startY` to `endY`. Each
- * segment's `deltaY` is proportional to its position on a half-sine curve
+ * segment's `delta` is proportional to its position on a half-sine curve
  * so motion accelerates from `startY`, peaks at the midpoint, and decays
- * into `endY`. The sum of appended `deltaY`s equals `endY - startY` exactly.
+ * into `endY`. The sum of appended `delta`s equals `endY - startY` exactly.
  */
 function appendBellPhase(
   out: ScrollSegment[],
@@ -165,7 +168,7 @@ function appendBellPhase(
     const delta = (w / totalWeight) * absDistance * direction;
     const baseDelay = jitter(profile.segmentDelayMs, profile.segmentDelayJitter, rng);
     out.push({
-      deltaY: delta,
+      delta,
       delayBeforeMs: baseDelay * personalitySpeed * speedFactor,
     });
     // Maybe insert a pause AFTER this segment (not at the very end).
@@ -177,7 +180,7 @@ function appendBellPhase(
     ) {
       const pauseMs = jitter(profile.pauseMs, profile.pauseMsJitter, rng);
       out.push({
-        deltaY: 0,
+        delta: 0,
         delayBeforeMs: pauseMs * personalitySpeed * speedFactor,
       });
     }

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -106,6 +106,46 @@ Useful for test assertions or surfacing reading metadata in a UI.
 
 **Privacy**: the read text is never echoed to plugin params. `read` actions surface only `{ target, kind }` plus inert length metadata — the content itself stays out of telemetry by design, same posture as `human.type()`.
 
+### Scrolling
+
+```ts
+await human.scroll();           // ~one viewport down, humanized
+```
+
+`human.scroll()` dispatches multiple wheel events with a bell-curve velocity profile (slow start, fast middle, slow end), optional mid-scroll micro-pauses, and — for the `distracted` personality — occasional overshoot + correction.
+
+**Target options:**
+
+```ts
+await human.scroll();                       // 'natural' — ~one viewport
+await human.scroll('top');                  // to the top
+await human.scroll('end');                  // to the bottom
+await human.scroll({ by: 800 });            // relative pixel delta (negative = up)
+await human.scroll({ to: 1500 });           // absolute window.scrollY
+await human.scroll('#pricing');             // by selector — scroll until in view
+await human.scroll(locator);                // by Locator
+```
+
+**Element-target alignment** matches native `scrollIntoView`:
+
+```ts
+await human.scroll('#hero', { block: 'center' });   // 'start' | 'center' | 'end'
+```
+
+**Force overshoot** even when the personality wouldn't choose one — useful for demos and screen recordings where the humanization signal needs to read clearly:
+
+```ts
+await human.scroll('#footer', { overshoot: true });
+```
+
+**Returns** a `ScrollResult`:
+
+```ts
+const { fromY, toY, distance, durationMs } = await human.scroll('end');
+```
+
+In `speed: 'instant'`, the page jumps directly via `window.scrollTo` — no wheel events — but the action still fires for observability.
+
 See [humanjs.dev](https://humanjs.dev) for the full feature set and personality reference.
 
 ## License

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -144,6 +144,17 @@ await human.scroll({ by: -200 }, { within: modalBody });          // scroll up i
 
 Every target shape (`'natural'`, `'top'`, `'end'`, selectors, `{ by }`, `{ to }`) applies relative to the container. In humanized mode the cursor parks over the container's center first so the wheel events route there; in `'instant'` mode the container's `scrollTop` is set directly.
 
+**Horizontal scroll** via `axis: 'x'` — same target shapes apply to the X axis:
+
+```ts
+await human.scroll('end', { axis: 'x' });                         // to the right edge
+await human.scroll({ by: 400 }, { axis: 'x' });                   // 400px right
+await human.scroll('#card-5', { axis: 'x', block: 'center' });    // carousel to a card
+await human.scroll('end', { within: '#kanban', axis: 'x' });      // kanban board to the right end
+```
+
+Defaults to `'y'`. Combine with `within` for horizontal scrolling inside a container (carousels, kanban boards, sideways galleries).
+
 **Force overshoot** even when the personality wouldn't choose one — useful for demos and screen recordings where the humanization signal needs to read clearly:
 
 ```ts

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -112,7 +112,7 @@ Useful for test assertions or surfacing reading metadata in a UI.
 await human.scroll();           // ~one viewport down, humanized
 ```
 
-`human.scroll()` dispatches multiple wheel events with a bell-curve velocity profile (slow start, fast middle, slow end), optional mid-scroll micro-pauses, and — for the `distracted` personality — occasional overshoot + correction.
+`human.scroll()` produces multi-segment scroll motion with a bell-curve velocity profile (slow start, fast middle, slow end), optional mid-scroll micro-pauses, and — for the `distracted` personality — occasional overshoot + correction. Page scrolls dispatch real `wheel` events; container scrolls advance the element's scroll position directly (more reliable inside nested overflow containers).
 
 **Target options:**
 
@@ -142,7 +142,7 @@ await human.scroll('#newest-item', { within: '.feed', block: 'end' });
 await human.scroll({ by: -200 }, { within: modalBody });          // scroll up inside a modal
 ```
 
-Every target shape (`'natural'`, `'top'`, `'end'`, selectors, `{ by }`, `{ to }`) applies relative to the container. In humanized mode the cursor parks over the container's center first so the wheel events route there; in `'instant'` mode the container's `scrollTop` is set directly.
+Every target shape (`'natural'`, `'top'`, `'end'`, selectors, `{ by }`, `{ to }`) applies relative to the container. In humanized mode the cursor parks over the container's center (so an `installMouseHelper` overlay reads as "human hand on the wheel") and each segment advances the container's `scrollLeft` / `scrollTop` directly — more reliable than wheel events inside nested overflow containers. In `'instant'` mode the container's scroll position is set with a single `scrollTo` call.
 
 **Horizontal scroll** via `axis: 'x'` — same target shapes apply to the X axis:
 
@@ -164,7 +164,7 @@ await human.scroll('#footer', { overshoot: true });
 **Returns** a `ScrollResult`:
 
 ```ts
-const { fromY, toY, distance, durationMs } = await human.scroll('end');
+const { from, to, distance, durationMs } = await human.scroll('end');
 ```
 
 In `speed: 'instant'`, the page jumps directly via `window.scrollTo` — no wheel events — but the action still fires for observability.

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -121,7 +121,7 @@ await human.scroll();                       // 'natural' — ~one viewport
 await human.scroll('top');                  // to the top
 await human.scroll('end');                  // to the bottom
 await human.scroll({ by: 800 });            // relative pixel delta (negative = up)
-await human.scroll({ to: 1500 });           // absolute window.scrollY
+await human.scroll({ to: 1500 });           // absolute scroll position on the chosen axis
 await human.scroll('#pricing');             // by selector — scroll until in view
 await human.scroll(locator);                // by Locator
 ```
@@ -150,10 +150,9 @@ Every target shape (`'natural'`, `'top'`, `'end'`, selectors, `{ by }`, `{ to }`
 await human.scroll('end', { axis: 'x' });                         // to the right edge
 await human.scroll({ by: 400 }, { axis: 'x' });                   // 400px right
 await human.scroll('#card-5', { axis: 'x', block: 'center' });    // carousel to a card
-await human.scroll('end', { within: '#kanban', axis: 'x' });      // kanban board to the right end
 ```
 
-Defaults to `'y'`. Combine with `within` for horizontal scrolling inside a container (carousels, kanban boards, sideways galleries).
+Defaults to `'y'`. Page-level horizontal scroll is verified end-to-end. **Container-horizontal scroll** (`axis: 'x'` combined with `within: ...`) is supported by the API and passes unit tests, but hasn't been verified in a real browser against every CSS layout — file an issue if your carousel / kanban board doesn't behave.
 
 **Force overshoot** even when the personality wouldn't choose one — useful for demos and screen recordings where the humanization signal needs to read clearly:
 

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -129,8 +129,20 @@ await human.scroll(locator);                // by Locator
 **Element-target alignment** matches native `scrollIntoView`:
 
 ```ts
-await human.scroll('#hero', { block: 'center' });   // 'start' | 'center' | 'end'
+await human.scroll('#hero', { block: 'center' });   // 'start' | 'center' | 'end' | 'nearest'
 ```
+
+`'nearest'` is a useful default for "make sure this element is visible without moving more than necessary" — it stays put if the element is already fully in view, otherwise scrolls to the closest edge.
+
+**Scroll inside a scrollable container**, not the page:
+
+```ts
+await human.scroll('end', { within: '#messages' });               // chat thread to latest
+await human.scroll('#newest-item', { within: '.feed', block: 'end' });
+await human.scroll({ by: -200 }, { within: modalBody });          // scroll up inside a modal
+```
+
+Every target shape (`'natural'`, `'top'`, `'end'`, selectors, `{ by }`, `{ to }`) applies relative to the container. In humanized mode the cursor parks over the container's center first so the wheel events route there; in `'instant'` mode the container's `scrollTop` is set directly.
 
 **Force overshoot** even when the personality wouldn't choose one — useful for demos and screen recordings where the humanization signal needs to read clearly:
 

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -150,9 +150,10 @@ Every target shape (`'natural'`, `'top'`, `'end'`, selectors, `{ by }`, `{ to }`
 await human.scroll('end', { axis: 'x' });                         // to the right edge
 await human.scroll({ by: 400 }, { axis: 'x' });                   // 400px right
 await human.scroll('#card-5', { axis: 'x', block: 'center' });    // carousel to a card
+await human.scroll('end', { within: '#kanban', axis: 'x' });      // kanban board to the right end
 ```
 
-Defaults to `'y'`. Page-level horizontal scroll is verified end-to-end. **Container-horizontal scroll** (`axis: 'x'` combined with `within: ...`) is supported by the API and passes unit tests, but hasn't been verified in a real browser against every CSS layout — file an issue if your carousel / kanban board doesn't behave.
+Defaults to `'y'`. Combine with `within` for horizontal scrolling inside a container (carousels, kanban boards, sideways galleries).
 
 **Force overshoot** even when the personality wouldn't choose one — useful for demos and screen recordings where the humanization signal needs to read clearly:
 

--- a/packages/playwright/src/index.test.ts
+++ b/packages/playwright/src/index.test.ts
@@ -60,8 +60,8 @@ function makeScrollMockPage(
         scrollToCalls.push(arg);
         return Promise.resolve(undefined);
       }
-      // No-arg form → page geometry read.
-      return Promise.resolve({ scrollY, viewport, docHeight });
+      // No-arg form → page geometry read (matches readWindowGeometry's shape).
+      return Promise.resolve({ current: scrollY, viewport, total: docHeight });
     }),
     mouse: {
       wheel: vi.fn().mockImplementation((_dx: number, dy: number) => {
@@ -922,6 +922,181 @@ describe('createHuman', () => {
       const result = await human.scroll('#gone');
       expect(result.toY).toBe(400);
       expect(result.distance).toBe(0);
+    });
+
+    it("block: 'nearest' stays put when the element is already fully visible", async () => {
+      // Element occupies viewport rows 100..300, viewport is 0..800 → fully in view.
+      const { page } = makeScrollMockPage({
+        scrollY: 500,
+        viewport: 800,
+        elementBox: { x: 0, y: 100, width: 200, height: 200 },
+      });
+      const human = await createHuman(page, { speed: 'instant' });
+      const result = await human.scroll('#visible', { block: 'nearest' });
+      expect(result.toY).toBe(500);
+      expect(result.distance).toBe(0);
+    });
+
+    it("block: 'nearest' scrolls down just enough when element is below the viewport", async () => {
+      // Element top is at viewport-relative y = 900 (200px below viewport bottom 800).
+      // Nearest brings its bottom edge (1100 → absolute 1500 + 0 fromY = 1500) to viewport-bottom.
+      const { page } = makeScrollMockPage({
+        scrollY: 0,
+        viewport: 800,
+        elementBox: { x: 0, y: 900, width: 200, height: 200 },
+      });
+      const human = await createHuman(page, { speed: 'instant' });
+      const result = await human.scroll('#below', { block: 'nearest' });
+      // absoluteBottom - viewport = (0 + 900 + 200) - 800 = 300
+      expect(result.toY).toBe(300);
+    });
+
+    it("block: 'nearest' scrolls up just enough when element is above the viewport", async () => {
+      // Element top is at viewport-relative y = -300 (300px above viewport top).
+      // Nearest brings its top edge to viewport-top.
+      const { page } = makeScrollMockPage({
+        scrollY: 1000,
+        viewport: 800,
+        elementBox: { x: 0, y: -300, width: 200, height: 200 },
+      });
+      const human = await createHuman(page, { speed: 'instant' });
+      const result = await human.scroll('#above', { block: 'nearest' });
+      // absoluteTop = scrollY + rect.y = 1000 + -300 = 700
+      expect(result.toY).toBe(700);
+    });
+
+    describe('within (scrollable container)', () => {
+      function makeWithinMockPage(
+        options: {
+          scrollTop?: number;
+          clientHeight?: number;
+          scrollHeight?: number;
+          containerRect?: { left: number; top: number; width: number; height: number };
+        } = {},
+      ): {
+        page: Page;
+        container: MockLocator;
+        containerScrollToCalls: number[];
+        wheelDeltas: number[];
+        mouseMoves: Array<{ x: number; y: number }>;
+      } {
+        const scrollTop = options.scrollTop ?? 0;
+        const clientHeight = options.clientHeight ?? 400;
+        const scrollHeight = options.scrollHeight ?? 2000;
+        const rect = options.containerRect ?? { left: 100, top: 100, width: 600, height: 400 };
+        const containerScrollToCalls: number[] = [];
+        const wheelDeltas: number[] = [];
+        const mouseMoves: Array<{ x: number; y: number }> = [];
+
+        const container: MockLocator = {
+          focus: vi.fn().mockResolvedValue(undefined),
+          pressSequentially: vi.fn().mockResolvedValue(undefined),
+          evaluate: vi.fn().mockImplementation((_fn: unknown, arg?: unknown) => {
+            // Arg form → container.scrollTo(0, y) in the executor's instant path.
+            if (typeof arg === 'number') {
+              containerScrollToCalls.push(arg);
+              return Promise.resolve(undefined);
+            }
+            // No-arg form → container geometry read.
+            return Promise.resolve({
+              current: scrollTop,
+              viewport: clientHeight,
+              total: scrollHeight,
+              hover: { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 },
+            });
+          }),
+        };
+        const page = {
+          goto: vi.fn().mockResolvedValue(null),
+          locator: vi.fn().mockReturnValue(container as unknown as Locator),
+          keyboard: { press: vi.fn().mockResolvedValue(undefined) },
+          mouse: {
+            move: vi.fn().mockImplementation((x: number, y: number) => {
+              mouseMoves.push({ x, y });
+              return Promise.resolve();
+            }),
+            wheel: vi.fn().mockImplementation((_dx: number, dy: number) => {
+              wheelDeltas.push(dy);
+              return Promise.resolve();
+            }),
+          },
+        } as unknown as Page;
+        return { page, container, containerScrollToCalls, wheelDeltas, mouseMoves };
+      }
+
+      it("'natural' scrolls one container clientHeight down", async () => {
+        const { page, container } = makeWithinMockPage({
+          scrollTop: 0,
+          clientHeight: 400,
+          scrollHeight: 2000,
+        });
+        const human = await createHuman(page, { speed: 'instant' });
+        const result = await human.scroll('natural', { within: '#messages' });
+        expect(page.locator).toHaveBeenCalledWith('#messages');
+        expect(container.evaluate).toHaveBeenCalled();
+        // One container-viewport down.
+        expect(result.toY).toBe(400);
+        expect(result.fromY).toBe(0);
+      });
+
+      it("'end' scrolls to (scrollHeight - clientHeight) of the container", async () => {
+        const { page, containerScrollToCalls } = makeWithinMockPage({
+          scrollTop: 0,
+          clientHeight: 400,
+          scrollHeight: 2000,
+        });
+        const human = await createHuman(page, { speed: 'instant' });
+        const result = await human.scroll('end', { within: '.thread' });
+        expect(result.toY).toBe(1600); // 2000 - 400
+        expect(containerScrollToCalls).toEqual([1600]);
+      });
+
+      it("'top' scrolls the container to scrollTop = 0", async () => {
+        const { page, containerScrollToCalls } = makeWithinMockPage({ scrollTop: 800 });
+        const human = await createHuman(page, { speed: 'instant' });
+        const result = await human.scroll('top', { within: '#log' });
+        expect(result.toY).toBe(0);
+        expect(containerScrollToCalls).toEqual([0]);
+      });
+
+      it('{ by: N } scrolls the container relative to its scrollTop', async () => {
+        const { page, containerScrollToCalls } = makeWithinMockPage({ scrollTop: 200 });
+        const human = await createHuman(page, { speed: 'instant' });
+        const result = await human.scroll({ by: 300 }, { within: '#log' });
+        expect(result.toY).toBe(500);
+        expect(containerScrollToCalls).toEqual([500]);
+      });
+
+      it('{ to: N } sets the container scrollTop directly', async () => {
+        const { page, containerScrollToCalls } = makeWithinMockPage({ scrollTop: 200 });
+        const human = await createHuman(page, { speed: 'instant' });
+        const result = await human.scroll({ to: 700 }, { within: '#log' });
+        expect(result.toY).toBe(700);
+        expect(containerScrollToCalls).toEqual([700]);
+      });
+
+      it('routes instant-mode scrolls through container.evaluate, not page.evaluate', async () => {
+        const { page, containerScrollToCalls } = makeWithinMockPage({ scrollTop: 0 });
+        const human = await createHuman(page, { speed: 'instant' });
+        await human.scroll({ to: 500 }, { within: '#log' });
+        expect(containerScrollToCalls).toEqual([500]);
+        // The window evaluate should not have been touched for this scroll.
+        expect((page as unknown as { evaluate?: unknown }).evaluate).toBeUndefined();
+      });
+
+      it('parks the cursor over the container center before dispatching wheel events', async () => {
+        const { page, mouseMoves, wheelDeltas } = makeWithinMockPage({
+          scrollTop: 0,
+          clientHeight: 400,
+          scrollHeight: 2000,
+          containerRect: { left: 100, top: 100, width: 600, height: 400 },
+        });
+        const human = await createHuman(page, { speed: 'human', seed: 'within-1' });
+        await human.scroll({ by: 300 }, { within: '#log' });
+        // First mouse move is the cursor parking at the container center.
+        expect(mouseMoves[0]).toEqual({ x: 400, y: 300 });
+        expect(wheelDeltas.length).toBeGreaterThan(0);
+      });
     });
   });
 

--- a/packages/playwright/src/index.test.ts
+++ b/packages/playwright/src/index.test.ts
@@ -796,8 +796,8 @@ describe('createHuman', () => {
       // Instant mode short-circuits — no wheel events.
       expect(wheelDeltas).toEqual([]);
       // Target = scrollY + viewport = 0 + 800.
-      expect(result.toY).toBe(800);
-      expect(result.fromY).toBe(0);
+      expect(result.to).toBe(800);
+      expect(result.from).toBe(0);
       expect(result.distance).toBe(800);
     });
 
@@ -805,7 +805,7 @@ describe('createHuman', () => {
       const { page, scrollToCalls } = makeScrollMockPage({ scrollY: 2000 });
       const human = await createHuman(page, { speed: 'instant' });
       const result = await human.scroll('top');
-      expect(result.toY).toBe(0);
+      expect(result.to).toBe(0);
       expect(scrollToCalls).toEqual([0]);
     });
 
@@ -818,7 +818,7 @@ describe('createHuman', () => {
       const human = await createHuman(page, { speed: 'instant' });
       const result = await human.scroll('end');
       // Aim: 5000; clamped to docHeight - viewport = 4200.
-      expect(result.toY).toBe(4200);
+      expect(result.to).toBe(4200);
       expect(scrollToCalls).toEqual([4200]);
     });
 
@@ -826,7 +826,7 @@ describe('createHuman', () => {
       const { page, scrollToCalls } = makeScrollMockPage({ scrollY: 200 });
       const human = await createHuman(page, { speed: 'instant' });
       const result = await human.scroll({ by: 500 });
-      expect(result.toY).toBe(700);
+      expect(result.to).toBe(700);
       expect(scrollToCalls).toEqual([700]);
     });
 
@@ -834,7 +834,7 @@ describe('createHuman', () => {
       const { page, scrollToCalls } = makeScrollMockPage({ scrollY: 200 });
       const human = await createHuman(page, { speed: 'instant' });
       const result = await human.scroll({ to: 1200 });
-      expect(result.toY).toBe(1200);
+      expect(result.to).toBe(1200);
       expect(scrollToCalls).toEqual([1200]);
     });
 
@@ -848,7 +848,7 @@ describe('createHuman', () => {
       expect(page.locator).toHaveBeenCalledWith('#footer');
       expect(locator.boundingBox).toHaveBeenCalled();
       // Absolute Y = scrollY + rect.y = 100 + 600 = 700, block: 'start' default.
-      expect(result.toY).toBe(700);
+      expect(result.to).toBe(700);
     });
 
     it('accepts a Locator directly without going through page.locator', async () => {
@@ -859,7 +859,7 @@ describe('createHuman', () => {
       expect(locator.boundingBox).toHaveBeenCalled();
     });
 
-    it('returns toY === fromY when distance is zero (no wheel, no scrollTo)', async () => {
+    it('returns to === from when distance is zero (no wheel, no scrollTo)', async () => {
       const { page, wheelDeltas, scrollToCalls } = makeScrollMockPage({
         scrollY: 0,
         viewport: 800,
@@ -918,14 +918,14 @@ describe('createHuman', () => {
       });
       const human = await createHuman(page, { speed: 'instant' });
       const result = await human.scroll('#unreachable');
-      expect(result.toY).toBe(2200); // 3000 - 800
+      expect(result.to).toBe(2200); // 3000 - 800
     });
 
     it('stays put when the element resolves to null (gone from DOM)', async () => {
       const { page } = makeScrollMockPage({ scrollY: 400, elementBox: null });
       const human = await createHuman(page, { speed: 'instant' });
       const result = await human.scroll('#gone');
-      expect(result.toY).toBe(400);
+      expect(result.to).toBe(400);
       expect(result.distance).toBe(0);
     });
 
@@ -938,13 +938,13 @@ describe('createHuman', () => {
       });
       const human = await createHuman(page, { speed: 'instant' });
       const result = await human.scroll('#visible', { block: 'nearest' });
-      expect(result.toY).toBe(500);
+      expect(result.to).toBe(500);
       expect(result.distance).toBe(0);
     });
 
     it("block: 'nearest' scrolls down just enough when element is below the viewport", async () => {
       // Element top is at viewport-relative y = 900 (200px below viewport bottom 800).
-      // Nearest brings its bottom edge (1100 → absolute 1500 + 0 fromY = 1500) to viewport-bottom.
+      // Nearest brings its bottom edge (1100 → absolute 1500 + 0 from = 1500) to viewport-bottom.
       const { page } = makeScrollMockPage({
         scrollY: 0,
         viewport: 800,
@@ -953,7 +953,7 @@ describe('createHuman', () => {
       const human = await createHuman(page, { speed: 'instant' });
       const result = await human.scroll('#below', { block: 'nearest' });
       // absoluteBottom - viewport = (0 + 900 + 200) - 800 = 300
-      expect(result.toY).toBe(300);
+      expect(result.to).toBe(300);
     });
 
     it("block: 'nearest' scrolls up just enough when element is above the viewport", async () => {
@@ -967,7 +967,7 @@ describe('createHuman', () => {
       const human = await createHuman(page, { speed: 'instant' });
       const result = await human.scroll('#above', { block: 'nearest' });
       // absoluteTop = scrollY + rect.y = 1000 + -300 = 700
-      expect(result.toY).toBe(700);
+      expect(result.to).toBe(700);
     });
 
     describe("axis: 'x' (horizontal)", () => {
@@ -979,8 +979,8 @@ describe('createHuman', () => {
         });
         const human = await createHuman(page, { speed: 'instant' });
         const result = await human.scroll('natural', { axis: 'x' });
-        expect(result.fromY).toBe(0);
-        expect(result.toY).toBe(1200);
+        expect(result.from).toBe(0);
+        expect(result.to).toBe(1200);
         expect(scrollToCalls).toEqual([1200]);
       });
 
@@ -992,7 +992,7 @@ describe('createHuman', () => {
         });
         const human = await createHuman(page, { speed: 'instant' });
         const result = await human.scroll('end', { axis: 'x' });
-        expect(result.toY).toBe(3800); // 5000 - 1200
+        expect(result.to).toBe(3800); // 5000 - 1200
         expect(scrollToCalls).toEqual([3800]);
       });
 
@@ -1000,7 +1000,7 @@ describe('createHuman', () => {
         const { page, scrollToCalls } = makeScrollMockPage({ scrollY: 500 });
         const human = await createHuman(page, { speed: 'instant' });
         const result = await human.scroll({ by: 400 }, { axis: 'x' });
-        expect(result.toY).toBe(900);
+        expect(result.to).toBe(900);
         expect(scrollToCalls).toEqual([900]);
       });
 
@@ -1008,7 +1008,7 @@ describe('createHuman', () => {
         const { page, scrollToCalls } = makeScrollMockPage({ scrollY: 0 });
         const human = await createHuman(page, { speed: 'instant' });
         const result = await human.scroll({ to: 1500 }, { axis: 'x' });
-        expect(result.toY).toBe(1500);
+        expect(result.to).toBe(1500);
         expect(scrollToCalls).toEqual([1500]);
       });
 
@@ -1038,7 +1038,7 @@ describe('createHuman', () => {
         const human = await createHuman(page, { speed: 'instant' });
         const result = await human.scroll('#card', { axis: 'x', block: 'start' });
         // absoluteX = scrollX + rect.x = 100 + 900 = 1000
-        expect(result.toY).toBe(1000);
+        expect(result.to).toBe(1000);
       });
     });
 
@@ -1127,8 +1127,8 @@ describe('createHuman', () => {
         expect(page.locator).toHaveBeenCalledWith('#messages');
         expect(container.evaluate).toHaveBeenCalled();
         // One container-viewport down.
-        expect(result.toY).toBe(400);
-        expect(result.fromY).toBe(0);
+        expect(result.to).toBe(400);
+        expect(result.from).toBe(0);
       });
 
       it("'end' scrolls to (scrollHeight - clientHeight) of the container", async () => {
@@ -1139,7 +1139,7 @@ describe('createHuman', () => {
         });
         const human = await createHuman(page, { speed: 'instant' });
         const result = await human.scroll('end', { within: '.thread' });
-        expect(result.toY).toBe(1600); // 2000 - 400
+        expect(result.to).toBe(1600); // 2000 - 400
         expect(containerScrollToCalls).toEqual([1600]);
       });
 
@@ -1147,7 +1147,7 @@ describe('createHuman', () => {
         const { page, containerScrollToCalls } = makeWithinMockPage({ scrollTop: 800 });
         const human = await createHuman(page, { speed: 'instant' });
         const result = await human.scroll('top', { within: '#log' });
-        expect(result.toY).toBe(0);
+        expect(result.to).toBe(0);
         expect(containerScrollToCalls).toEqual([0]);
       });
 
@@ -1155,7 +1155,7 @@ describe('createHuman', () => {
         const { page, containerScrollToCalls } = makeWithinMockPage({ scrollTop: 200 });
         const human = await createHuman(page, { speed: 'instant' });
         const result = await human.scroll({ by: 300 }, { within: '#log' });
-        expect(result.toY).toBe(500);
+        expect(result.to).toBe(500);
         expect(containerScrollToCalls).toEqual([500]);
       });
 
@@ -1163,7 +1163,7 @@ describe('createHuman', () => {
         const { page, containerScrollToCalls } = makeWithinMockPage({ scrollTop: 200 });
         const human = await createHuman(page, { speed: 'instant' });
         const result = await human.scroll({ to: 700 }, { within: '#log' });
-        expect(result.toY).toBe(700);
+        expect(result.to).toBe(700);
         expect(containerScrollToCalls).toEqual([700]);
       });
 

--- a/packages/playwright/src/index.test.ts
+++ b/packages/playwright/src/index.test.ts
@@ -13,9 +13,16 @@ interface MockLocator {
 }
 
 /**
- * Page mock for scroll tests. Returns geometry (scrollY/viewport/docHeight)
- * from a no-arg evaluate, and routes the arg-form `scrollTo` evaluate into
- * `scrollToCalls`. Records every `page.mouse.wheel` delta for assertion.
+ * Page mock for scroll tests. Returns geometry (`{ current, viewport, total }`)
+ * from a geometry-read evaluate, captures `window.scrollTo` positions in
+ * `scrollToCalls`, and records `page.mouse.wheel` deltas separately by
+ * axis (`wheelDeltas` for Y, `wheelDeltasX` for X) so horizontal-scroll
+ * tests can assert on the right axis.
+ *
+ * Note: the evaluate-call discrimination relies on internal arg shapes
+ * from the executor (`'pos' in arg` → scrollTo; otherwise → geometry).
+ * If you rename `pos` in `executeScroll`, update this mock too — the
+ * tests would otherwise silently stop tracking the calls they claim to.
  */
 function makeScrollMockPage(
   options: {
@@ -1043,6 +1050,18 @@ describe('createHuman', () => {
     });
 
     describe('within (scrollable container)', () => {
+      /**
+       * Container mock for `within`-scroll tests. Routes container.evaluate
+       * by inspecting the second arg's shape:
+       *   - `{ axis, pos }`   → `el.scrollTo(...)` in instant mode
+       *   - `{ axis, delta }` → `el.scrollLeft += delta` / `scrollTop += delta`
+       *                          per humanized segment
+       *   - axis-only string  → geometry read
+       *
+       * Tightly coupled to the executor's internal arg field names (`pos`,
+       * `delta`). Rename either side without updating both and tests pass
+       * silently while no calls are recorded.
+       */
       function makeWithinMockPage(
         options: {
           scrollTop?: number;

--- a/packages/playwright/src/index.test.ts
+++ b/packages/playwright/src/index.test.ts
@@ -1054,6 +1054,7 @@ describe('createHuman', () => {
         page: Page;
         container: MockLocator;
         containerScrollToCalls: number[];
+        containerScrollByCalls: number[];
         wheelDeltas: number[];
         mouseMoves: Array<{ x: number; y: number }>;
       } {
@@ -1062,6 +1063,7 @@ describe('createHuman', () => {
         const scrollHeight = options.scrollHeight ?? 2000;
         const rect = options.containerRect ?? { left: 100, top: 100, width: 600, height: 400 };
         const containerScrollToCalls: number[] = [];
+        const containerScrollByCalls: number[] = [];
         const wheelDeltas: number[] = [];
         const mouseMoves: Array<{ x: number; y: number }> = [];
 
@@ -1069,14 +1071,18 @@ describe('createHuman', () => {
           focus: vi.fn().mockResolvedValue(undefined),
           pressSequentially: vi.fn().mockResolvedValue(undefined),
           evaluate: vi.fn().mockImplementation((_fn: unknown, arg?: unknown) => {
-            // Arg form → container.scrollTo(...) in the executor's instant
-            // path. The executor passes `{ axis, pos }`; we only care
-            // about `pos` for the assertion.
+            // Arg form distinguishes the three container.evaluate paths:
+            //  - `{ axis, pos }`  → container.scrollTo (instant mode)
+            //  - `{ axis, delta }` → container.scrollBy (humanized walk)
+            //  - axis-only string  → container geometry read
             if (arg && typeof arg === 'object' && 'pos' in arg) {
               containerScrollToCalls.push((arg as { pos: number }).pos);
               return Promise.resolve(undefined);
             }
-            // Single-arg form → container geometry read (axis as a string).
+            if (arg && typeof arg === 'object' && 'delta' in arg) {
+              containerScrollByCalls.push((arg as { delta: number }).delta);
+              return Promise.resolve(undefined);
+            }
             return Promise.resolve({
               current: scrollTop,
               viewport: clientHeight,
@@ -1100,7 +1106,14 @@ describe('createHuman', () => {
             }),
           },
         } as unknown as Page;
-        return { page, container, containerScrollToCalls, wheelDeltas, mouseMoves };
+        return {
+          page,
+          container,
+          containerScrollToCalls,
+          containerScrollByCalls,
+          wheelDeltas,
+          mouseMoves,
+        };
       }
 
       it("'natural' scrolls one container clientHeight down", async () => {
@@ -1163,8 +1176,8 @@ describe('createHuman', () => {
         expect((page as unknown as { evaluate?: unknown }).evaluate).toBeUndefined();
       });
 
-      it('parks the cursor over the container center before dispatching wheel events', async () => {
-        const { page, mouseMoves, wheelDeltas } = makeWithinMockPage({
+      it('parks the cursor over the container center and applies scrollBy per segment', async () => {
+        const { page, mouseMoves, containerScrollByCalls } = makeWithinMockPage({
           scrollTop: 0,
           clientHeight: 400,
           scrollHeight: 2000,
@@ -1174,7 +1187,26 @@ describe('createHuman', () => {
         await human.scroll({ by: 300 }, { within: '#log' });
         // First mouse move is the cursor parking at the container center.
         expect(mouseMoves[0]).toEqual({ x: 400, y: 300 });
-        expect(wheelDeltas.length).toBeGreaterThan(0);
+        // Each non-pause segment dispatches a container.scrollBy. The sum
+        // approximates the requested distance (excludes any pause segments).
+        expect(containerScrollByCalls.length).toBeGreaterThan(0);
+        const totalDelta = containerScrollByCalls.reduce((s, d) => s + d, 0);
+        expect(totalDelta).toBeCloseTo(300, 0);
+      });
+
+      it('horizontal scroll inside a container uses scrollBy on the X axis', async () => {
+        const { page, containerScrollByCalls } = makeWithinMockPage({
+          scrollTop: 0,
+          clientHeight: 400,
+          scrollHeight: 2000,
+        });
+        const human = await createHuman(page, { speed: 'human', seed: 'within-x' });
+        await human.scroll({ by: 600 }, { within: '#carousel', axis: 'x' });
+        // scrollBy was invoked on the X axis — total deltas approximate
+        // the requested horizontal distance.
+        const totalDelta = containerScrollByCalls.reduce((s, d) => s + d, 0);
+        expect(containerScrollByCalls.length).toBeGreaterThan(0);
+        expect(totalDelta).toBeCloseTo(600, 0);
       });
     });
   });

--- a/packages/playwright/src/index.test.ts
+++ b/packages/playwright/src/index.test.ts
@@ -30,6 +30,7 @@ function makeScrollMockPage(
   page: Page;
   locator: MockLocator;
   wheelDeltas: number[];
+  wheelDeltasX: number[];
   scrollToCalls: number[];
 } {
   const scrollY = options.scrollY ?? 0;
@@ -49,28 +50,32 @@ function makeScrollMockPage(
       .mockResolvedValue(options.elementBox === undefined ? defaultElementBox : options.elementBox),
   };
   const wheelDeltas: number[] = [];
+  const wheelDeltasX: number[] = [];
   const scrollToCalls: number[] = [];
   const page = {
     goto: vi.fn().mockResolvedValue(null),
     locator: vi.fn().mockReturnValue(locator as unknown as Locator),
     keyboard: { press: vi.fn().mockResolvedValue(undefined) },
     evaluate: vi.fn().mockImplementation((_fn: unknown, arg?: unknown) => {
-      // Arg form → window.scrollTo(0, y) in the executor's instant path.
-      if (typeof arg === 'number') {
-        scrollToCalls.push(arg);
+      // Arg form → window.scrollTo(...) in the executor's instant path.
+      // The executor passes `{ axis, pos }` so it can pick the right axis;
+      // we only care about `pos` for the assertion.
+      if (arg && typeof arg === 'object' && 'pos' in arg) {
+        scrollToCalls.push((arg as { pos: number }).pos);
         return Promise.resolve(undefined);
       }
-      // No-arg form → page geometry read (matches readWindowGeometry's shape).
+      // Single-arg form → page geometry read (axis as a string).
       return Promise.resolve({ current: scrollY, viewport, total: docHeight });
     }),
     mouse: {
-      wheel: vi.fn().mockImplementation((_dx: number, dy: number) => {
+      wheel: vi.fn().mockImplementation((dx: number, dy: number) => {
         wheelDeltas.push(dy);
+        wheelDeltasX.push(dx);
         return Promise.resolve();
       }),
     },
   } as unknown as Page;
-  return { page, locator, wheelDeltas, scrollToCalls };
+  return { page, locator, wheelDeltas, wheelDeltasX, scrollToCalls };
 }
 
 interface MockPage {
@@ -965,6 +970,78 @@ describe('createHuman', () => {
       expect(result.toY).toBe(700);
     });
 
+    describe("axis: 'x' (horizontal)", () => {
+      it("'natural' scrolls one viewport-width right", async () => {
+        const { page, scrollToCalls } = makeScrollMockPage({
+          scrollY: 0,
+          viewport: 1200,
+          docHeight: 5000, // doubles as scrollWidth in the mock
+        });
+        const human = await createHuman(page, { speed: 'instant' });
+        const result = await human.scroll('natural', { axis: 'x' });
+        expect(result.fromY).toBe(0);
+        expect(result.toY).toBe(1200);
+        expect(scrollToCalls).toEqual([1200]);
+      });
+
+      it("'end' scrolls to (scrollWidth - viewport)", async () => {
+        const { page, scrollToCalls } = makeScrollMockPage({
+          scrollY: 0,
+          viewport: 1200,
+          docHeight: 5000,
+        });
+        const human = await createHuman(page, { speed: 'instant' });
+        const result = await human.scroll('end', { axis: 'x' });
+        expect(result.toY).toBe(3800); // 5000 - 1200
+        expect(scrollToCalls).toEqual([3800]);
+      });
+
+      it('{ by: N } scrolls by a relative pixel delta on the X axis', async () => {
+        const { page, scrollToCalls } = makeScrollMockPage({ scrollY: 500 });
+        const human = await createHuman(page, { speed: 'instant' });
+        const result = await human.scroll({ by: 400 }, { axis: 'x' });
+        expect(result.toY).toBe(900);
+        expect(scrollToCalls).toEqual([900]);
+      });
+
+      it('{ to: N } sets the absolute scrollX position', async () => {
+        const { page, scrollToCalls } = makeScrollMockPage({ scrollY: 0 });
+        const human = await createHuman(page, { speed: 'instant' });
+        const result = await human.scroll({ to: 1500 }, { axis: 'x' });
+        expect(result.toY).toBe(1500);
+        expect(scrollToCalls).toEqual([1500]);
+      });
+
+      it('dispatches wheel events on the X axis (not Y) in humanized mode', async () => {
+        const { page, wheelDeltas, wheelDeltasX } = makeScrollMockPage({
+          scrollY: 0,
+          viewport: 1200,
+          docHeight: 5000,
+        });
+        const human = await createHuman(page, { speed: 'human', seed: 'x-wheel' });
+        await human.scroll({ by: 1000 }, { axis: 'x' });
+        // Every Y delta is zero — motion is purely horizontal.
+        expect(wheelDeltas.every((d) => d === 0)).toBe(true);
+        // X deltas sum approximately to the requested distance.
+        const totalX = wheelDeltasX.reduce((s, d) => s + d, 0);
+        expect(totalX).toBeCloseTo(1000, 0);
+        expect(wheelDeltasX.length).toBeGreaterThan(5);
+      });
+
+      it('resolves an element target via rect.x (not rect.y) on the X axis', async () => {
+        const { page } = makeScrollMockPage({
+          scrollY: 100,
+          viewport: 1200,
+          // Element rect: x=900 viewport-relative, width=200, height=100
+          elementBox: { x: 900, y: 0, width: 200, height: 100 },
+        });
+        const human = await createHuman(page, { speed: 'instant' });
+        const result = await human.scroll('#card', { axis: 'x', block: 'start' });
+        // absoluteX = scrollX + rect.x = 100 + 900 = 1000
+        expect(result.toY).toBe(1000);
+      });
+    });
+
     describe('within (scrollable container)', () => {
       function makeWithinMockPage(
         options: {
@@ -992,12 +1069,14 @@ describe('createHuman', () => {
           focus: vi.fn().mockResolvedValue(undefined),
           pressSequentially: vi.fn().mockResolvedValue(undefined),
           evaluate: vi.fn().mockImplementation((_fn: unknown, arg?: unknown) => {
-            // Arg form → container.scrollTo(0, y) in the executor's instant path.
-            if (typeof arg === 'number') {
-              containerScrollToCalls.push(arg);
+            // Arg form → container.scrollTo(...) in the executor's instant
+            // path. The executor passes `{ axis, pos }`; we only care
+            // about `pos` for the assertion.
+            if (arg && typeof arg === 'object' && 'pos' in arg) {
+              containerScrollToCalls.push((arg as { pos: number }).pos);
               return Promise.resolve(undefined);
             }
-            // No-arg form → container geometry read.
+            // Single-arg form → container geometry read (axis as a string).
             return Promise.resolve({
               current: scrollTop,
               viewport: clientHeight,

--- a/packages/playwright/src/index.test.ts
+++ b/packages/playwright/src/index.test.ts
@@ -12,6 +12,67 @@ interface MockLocator {
   boundingBox?: ReturnType<typeof vi.fn>;
 }
 
+/**
+ * Page mock for scroll tests. Returns geometry (scrollY/viewport/docHeight)
+ * from a no-arg evaluate, and routes the arg-form `scrollTo` evaluate into
+ * `scrollToCalls`. Records every `page.mouse.wheel` delta for assertion.
+ */
+function makeScrollMockPage(
+  options: {
+    scrollY?: number;
+    viewport?: number;
+    docHeight?: number;
+    elementY?: number;
+    elementHeight?: number;
+    elementBox?: { x: number; y: number; width: number; height: number } | null;
+  } = {},
+): {
+  page: Page;
+  locator: MockLocator;
+  wheelDeltas: number[];
+  scrollToCalls: number[];
+} {
+  const scrollY = options.scrollY ?? 0;
+  const viewport = options.viewport ?? 800;
+  const docHeight = options.docHeight ?? 5000;
+  const defaultElementBox = {
+    x: 0,
+    y: options.elementY ?? 1500,
+    width: 200,
+    height: options.elementHeight ?? 100,
+  };
+  const locator: MockLocator = {
+    focus: vi.fn().mockResolvedValue(undefined),
+    pressSequentially: vi.fn().mockResolvedValue(undefined),
+    boundingBox: vi
+      .fn()
+      .mockResolvedValue(options.elementBox === undefined ? defaultElementBox : options.elementBox),
+  };
+  const wheelDeltas: number[] = [];
+  const scrollToCalls: number[] = [];
+  const page = {
+    goto: vi.fn().mockResolvedValue(null),
+    locator: vi.fn().mockReturnValue(locator as unknown as Locator),
+    keyboard: { press: vi.fn().mockResolvedValue(undefined) },
+    evaluate: vi.fn().mockImplementation((_fn: unknown, arg?: unknown) => {
+      // Arg form → window.scrollTo(0, y) in the executor's instant path.
+      if (typeof arg === 'number') {
+        scrollToCalls.push(arg);
+        return Promise.resolve(undefined);
+      }
+      // No-arg form → page geometry read.
+      return Promise.resolve({ scrollY, viewport, docHeight });
+    }),
+    mouse: {
+      wheel: vi.fn().mockImplementation((_dx: number, dy: number) => {
+        wheelDeltas.push(dy);
+        return Promise.resolve();
+      }),
+    },
+  } as unknown as Page;
+  return { page, locator, wheelDeltas, scrollToCalls };
+}
+
 interface MockPage {
   page: Page;
   locator: MockLocator;
@@ -715,6 +776,152 @@ describe('createHuman', () => {
       // No selector, no Locator → no box → motion is silently a no-op.
       await human.read({ text: 'a b c d' }, { withMotion: true, wpmMultiplier: 1000 });
       expect(mouseMoves).toEqual([]);
+    });
+  });
+
+  describe('scroll', () => {
+    it("defaults to 'natural' = one full viewport down when called with no args", async () => {
+      const { page, wheelDeltas } = makeScrollMockPage({
+        scrollY: 0,
+        viewport: 800,
+        docHeight: 5000,
+      });
+      const human = await createHuman(page, { speed: 'instant' });
+      const result = await human.scroll();
+      // Instant mode short-circuits — no wheel events.
+      expect(wheelDeltas).toEqual([]);
+      // Target = scrollY + viewport = 0 + 800.
+      expect(result.toY).toBe(800);
+      expect(result.fromY).toBe(0);
+      expect(result.distance).toBe(800);
+    });
+
+    it("'top' scrolls to Y = 0", async () => {
+      const { page, scrollToCalls } = makeScrollMockPage({ scrollY: 2000 });
+      const human = await createHuman(page, { speed: 'instant' });
+      const result = await human.scroll('top');
+      expect(result.toY).toBe(0);
+      expect(scrollToCalls).toEqual([0]);
+    });
+
+    it("'end' scrolls to (docHeight - viewport), clamped non-negative", async () => {
+      const { page, scrollToCalls } = makeScrollMockPage({
+        scrollY: 0,
+        viewport: 800,
+        docHeight: 5000,
+      });
+      const human = await createHuman(page, { speed: 'instant' });
+      const result = await human.scroll('end');
+      // Aim: 5000; clamped to docHeight - viewport = 4200.
+      expect(result.toY).toBe(4200);
+      expect(scrollToCalls).toEqual([4200]);
+    });
+
+    it('{ by: N } scrolls by a relative pixel delta', async () => {
+      const { page, scrollToCalls } = makeScrollMockPage({ scrollY: 200 });
+      const human = await createHuman(page, { speed: 'instant' });
+      const result = await human.scroll({ by: 500 });
+      expect(result.toY).toBe(700);
+      expect(scrollToCalls).toEqual([700]);
+    });
+
+    it('{ to: N } scrolls to an absolute Y', async () => {
+      const { page, scrollToCalls } = makeScrollMockPage({ scrollY: 200 });
+      const human = await createHuman(page, { speed: 'instant' });
+      const result = await human.scroll({ to: 1200 });
+      expect(result.toY).toBe(1200);
+      expect(scrollToCalls).toEqual([1200]);
+    });
+
+    it('resolves a string selector via locator.boundingBox', async () => {
+      const { page, locator } = makeScrollMockPage({
+        scrollY: 100,
+        elementY: 600, // viewport-relative top of element
+      });
+      const human = await createHuman(page, { speed: 'instant' });
+      const result = await human.scroll('#footer');
+      expect(page.locator).toHaveBeenCalledWith('#footer');
+      expect(locator.boundingBox).toHaveBeenCalled();
+      // Absolute Y = scrollY + rect.y = 100 + 600 = 700, block: 'start' default.
+      expect(result.toY).toBe(700);
+    });
+
+    it('accepts a Locator directly without going through page.locator', async () => {
+      const { page, locator } = makeScrollMockPage({ scrollY: 0, elementY: 1000 });
+      const human = await createHuman(page, { speed: 'instant' });
+      await human.scroll(locator as unknown as Locator);
+      expect(page.locator).not.toHaveBeenCalled();
+      expect(locator.boundingBox).toHaveBeenCalled();
+    });
+
+    it('returns toY === fromY when distance is zero (no wheel, no scrollTo)', async () => {
+      const { page, wheelDeltas, scrollToCalls } = makeScrollMockPage({
+        scrollY: 0,
+        viewport: 800,
+        docHeight: 800, // page fits in viewport
+      });
+      const human = await createHuman(page, { speed: 'human' });
+      const result = await human.scroll('top');
+      expect(result.distance).toBe(0);
+      expect(result.durationMs).toBe(0);
+      expect(wheelDeltas).toEqual([]);
+      expect(scrollToCalls).toEqual([]);
+    });
+
+    it('dispatches multiple wheel events in human speed', async () => {
+      const { page, wheelDeltas } = makeScrollMockPage({
+        scrollY: 0,
+        viewport: 800,
+        docHeight: 5000,
+      });
+      const human = await createHuman(page, { speed: 'human', seed: 'wheel-1' });
+      await human.scroll({ by: 1500 });
+      // Multi-segment plan → many wheel calls (at least a few).
+      expect(wheelDeltas.length).toBeGreaterThan(5);
+      // Sum of deltas approximates the requested distance.
+      const total = wheelDeltas.reduce((s, d) => s + d, 0);
+      expect(total).toBeCloseTo(1500, 0);
+    });
+
+    it("emits a 'scroll' action with target description for plugins", async () => {
+      const beforeAction = vi.fn();
+      const afterAction = vi.fn();
+      const { page } = makeScrollMockPage({ scrollY: 0 });
+      const human = await createHuman(page, {
+        speed: 'instant',
+        plugins: [{ name: 'p', beforeAction, afterAction }],
+      });
+      await human.scroll({ to: 500 });
+      expect(beforeAction).toHaveBeenCalledWith({
+        type: 'scroll',
+        params: { target: 'to:500' },
+      });
+      const result = afterAction.mock.calls[0]?.[1];
+      expect(result.type).toBe('scroll');
+      expect(typeof result.durationMs).toBe('number');
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('clamps to-element targets to the document bounds', async () => {
+      // Element is far below the bottom; the scroll should stop at the max
+      // scrollable Y (docHeight - viewport), not run off the end.
+      const { page } = makeScrollMockPage({
+        scrollY: 0,
+        viewport: 800,
+        docHeight: 3000,
+        elementY: 10_000, // way past document end
+      });
+      const human = await createHuman(page, { speed: 'instant' });
+      const result = await human.scroll('#unreachable');
+      expect(result.toY).toBe(2200); // 3000 - 800
+    });
+
+    it('stays put when the element resolves to null (gone from DOM)', async () => {
+      const { page } = makeScrollMockPage({ scrollY: 400, elementBox: null });
+      const human = await createHuman(page, { speed: 'instant' });
+      const result = await human.scroll('#gone');
+      expect(result.toY).toBe(400);
+      expect(result.distance).toBe(0);
     });
   });
 

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -153,27 +153,35 @@ export interface Human {
    */
   read(target: ReadTarget, options?: ReadOptions): Promise<ReadResult>;
   /**
-   * Scroll the page humanly. Multi-segment wheel motion with a bell-curve
-   * velocity profile, optional mid-scroll micro-pauses, and (for the
-   * `distracted` personality) the occasional overshoot + correction.
+   * Scroll the page (or a scrollable container) humanly. Multi-segment
+   * motion with a bell-curve velocity profile, optional mid-scroll
+   * micro-pauses, and (for the `distracted` personality) the occasional
+   * overshoot + correction.
    *
    * **Targets:**
-   *  - `'natural'` (default): scroll ~one viewport down — what a real reader does
-   *  - `'end'` / `'top'`: jump to the document edges, humanized along the way
+   *  - `'natural'` (default): scroll one viewport in the chosen axis
+   *  - `'end'` / `'top'`: jump to the document/container edges, humanized
    *  - `string`: a Playwright-compatible selector — scroll until in view
    *  - `Locator`: same, but with a pre-built handle
-   *  - `{ by: n }`: relative pixel delta (negative = up)
-   *  - `{ to: n }`: absolute `window.scrollY` target
+   *  - `{ by: n }`: relative pixel delta (negative = up / left)
+   *  - `{ to: n }`: absolute scroll position on the chosen axis
    *
-   * Plugins observe `'scroll'` actions with `{ target, fromY, toY, distance }`
-   * — all inert metadata, safe to log.
+   * **Options:** `axis: 'x' | 'y'` (default `'y'`) picks the direction;
+   * `within: selector | Locator` scopes the scroll to a scrollable
+   * container; `block: 'start' | 'center' | 'end' | 'nearest'` aligns
+   * element targets; `overshoot` / `withPauses` toggle individual
+   * humanization signals.
    *
-   * In `speed: 'instant'`, the page is moved with a single `window.scrollTo`
-   * call. No wheel events, no segments — but the action still fires for
-   * observability.
+   * Plugins observe `'scroll'` actions with `{ target }` in
+   * `beforeAction`'s params (a human-readable description of the target).
+   * The full {@link ScrollResult} (`from` / `to` / `distance` /
+   * `durationMs`) is available via `afterAction`'s `result` argument.
    *
-   * Returns a {@link ScrollResult} with the resolved Y coordinates and
-   * elapsed motion time, useful for assertions in tests.
+   * In `speed: 'instant'`, the page (or container) is moved with a single
+   * `scrollTo` call. No wheel events, no segments — but the action still
+   * fires for observability.
+   *
+   * Returns a {@link ScrollResult} for assertions in tests.
    */
   scroll(target?: ScrollTarget, options?: ScrollOptions): Promise<ScrollResult>;
 }

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -13,6 +13,7 @@ import type { Locator, Page } from 'playwright';
 import { executeType } from './keyboard';
 import { executeClick } from './mouse';
 import { executeRead, type ReadOptions, type ReadResult, type ReadTarget } from './reading';
+import { executeScroll, type ScrollOptions, type ScrollResult, type ScrollTarget } from './scroll';
 
 export type {
   ActionResult,
@@ -36,6 +37,8 @@ export type {
   ReadingProfile,
   ReadKind,
   Rng,
+  ScrollProfile,
+  ScrollSegment,
   TypingProfile,
 } from '@humanjs/core';
 // Re-exports of the public core API so consumers have one import surface.
@@ -51,6 +54,7 @@ export {
   distracted,
   fast,
   humanizePath,
+  planScroll,
   planTypeKeystrokes,
   precise,
   resolvePersonality,
@@ -58,6 +62,7 @@ export {
 export type { InstallMouseHelperOptions } from './mouse-helper';
 export { installMouseHelper } from './mouse-helper';
 export type { ReadOptions, ReadResult, ReadTarget } from './reading';
+export type { ScrollOptions, ScrollResult, ScrollTarget } from './scroll';
 
 /**
  * How fast the humanized session runs.
@@ -147,6 +152,30 @@ export interface Human {
    * tests or for surfacing reading metadata to a UI.
    */
   read(target: ReadTarget, options?: ReadOptions): Promise<ReadResult>;
+  /**
+   * Scroll the page humanly. Multi-segment wheel motion with a bell-curve
+   * velocity profile, optional mid-scroll micro-pauses, and (for the
+   * `distracted` personality) the occasional overshoot + correction.
+   *
+   * **Targets:**
+   *  - `'natural'` (default): scroll ~one viewport down — what a real reader does
+   *  - `'end'` / `'top'`: jump to the document edges, humanized along the way
+   *  - `string`: a Playwright-compatible selector — scroll until in view
+   *  - `Locator`: same, but with a pre-built handle
+   *  - `{ by: n }`: relative pixel delta (negative = up)
+   *  - `{ to: n }`: absolute `window.scrollY` target
+   *
+   * Plugins observe `'scroll'` actions with `{ target, fromY, toY, distance }`
+   * — all inert metadata, safe to log.
+   *
+   * In `speed: 'instant'`, the page is moved with a single `window.scrollTo`
+   * call. No wheel events, no segments — but the action still fires for
+   * observability.
+   *
+   * Returns a {@link ScrollResult} with the resolved Y coordinates and
+   * elapsed motion time, useful for assertions in tests.
+   */
+  scroll(target?: ScrollTarget, options?: ScrollOptions): Promise<ScrollResult>;
 }
 
 /**
@@ -271,7 +300,30 @@ export async function createHuman(page: Page, options: CreateHumanOptions = {}):
           ),
       );
     },
+    async scroll(target, options) {
+      const description = describeScrollTarget(target);
+      return performAction(
+        {
+          type: 'scroll',
+          params: { target: description },
+        },
+        () => executeScroll(target, { page, personality, rng, speed }, options),
+      );
+    },
   };
+}
+
+/**
+ * Human-readable description of a scroll target for action params. Strings
+ * (presets + selectors) pass through; objects describe their shape; the
+ * Locator branch falls back to `toString()`.
+ */
+function describeScrollTarget(target: ScrollTarget | undefined): string {
+  if (target === undefined) return 'natural';
+  if (typeof target === 'string') return target;
+  if ('by' in target) return `by:${target.by}`;
+  if ('to' in target) return `to:${target.to}`;
+  return target.toString?.() ?? 'locator';
 }
 
 /**

--- a/packages/playwright/src/scroll/index.ts
+++ b/packages/playwright/src/scroll/index.ts
@@ -12,14 +12,17 @@ export interface ScrollContext {
 }
 
 /**
- * What / where to scroll:
- *  - `'natural'`: scroll one viewport-worth in the current direction (default).
- *  - `'end'`: scroll to the very bottom.
- *  - `'top'`: scroll to the very top.
+ * What / where to scroll. The chosen axis (`'y'` by default, `'x'` via
+ * `options.axis`) decides whether targets resolve along the vertical or
+ * horizontal axis.
+ *
+ *  - `'natural'`: scroll one viewport along the chosen axis (default).
+ *  - `'end'`: scroll to the far edge (bottom for `'y'`, right for `'x'`).
+ *  - `'top'`: scroll to the origin (top for `'y'`, left for `'x'`).
  *  - `string`: a Playwright-compatible selector — scroll until in view.
  *  - `Locator`: same, but you already have a Locator handle.
- *  - `{ by: number }`: scroll by a relative pixel delta (negative = up).
- *  - `{ to: number }`: scroll to an absolute Y position.
+ *  - `{ by: number }`: relative pixel delta (negative = up / left).
+ *  - `{ to: number }`: absolute scroll position on the chosen axis.
  */
 export type ScrollTarget =
   | 'natural'
@@ -60,10 +63,15 @@ export interface ScrollOptions {
    * semantic (`'natural'`, `'top'`, `'end'`, `{ by }`, `{ to }`, element
    * targets, `block` alignment) applies relative to the container.
    *
-   * In humanized speed modes, the cursor moves over the container's
-   * center first so the dispatched wheel events target it. In `'instant'`
-   * mode, the container's scroll position is set directly with no wheel
-   * events.
+   * In humanized speed modes, the cursor parks over the container's
+   * center so the visible cursor reads as "human hand on the wheel"
+   * (when paired with `installMouseHelper`), and each planned segment
+   * advances the container's `scrollLeft` / `scrollTop` directly. Direct
+   * property assignment is more reliable than dispatching wheel events
+   * into nested overflow containers — Playwright's synthetic wheel
+   * events don't always route past the cursor element. In `'instant'`
+   * mode, the container's scroll position is set with a single
+   * `scrollTo` call.
    *
    * Common use: chat threads, modal bodies, infinite-scroll feeds, any
    * `<div style="overflow-y: auto">` that owns its own scrollbar.
@@ -84,11 +92,11 @@ export interface ScrollOptions {
 
 /** Outcome of a scroll, returned to the caller for observability. */
 export interface ScrollResult {
-  /** Starting scroll position along the chosen axis. */
-  readonly fromY: number;
+  /** Starting scroll position along the chosen axis (scrollY or scrollX). */
+  readonly from: number;
   /** Final scroll position the scroll aimed for, along the chosen axis. */
-  readonly toY: number;
-  /** Signed pixel distance (`toY - fromY`). */
+  readonly to: number;
+  /** Signed pixel distance (`to - from`). */
   readonly distance: number;
   /** Total elapsed dwell + motion time in ms. Zero in `speed: 'instant'`. */
   readonly durationMs: number;
@@ -112,8 +120,9 @@ interface ScrollGeometry {
   readonly total: number;
   /**
    * For container scrolls: viewport-relative center coordinates the cursor
-   * should hover over so wheel events target the container. Undefined for
-   * window scrolls (mouse position doesn't affect window scroll routing).
+   * should park at so an `installMouseHelper` overlay reads as "human hand
+   * on the wheel" during the scroll. Undefined for window scrolls (no
+   * cursor parking — the page scrolls without a per-target hover).
    */
   readonly hover?: { x: number; y: number };
 }
@@ -123,14 +132,16 @@ interface ScrollGeometry {
  * along the chosen axis.
  *
  * Flow:
- *  1. Resolve the scroll axis: page (default) or a container if `within` is set.
- *  2. Read current position + viewport + total geometry for that axis +
- *     direction (X or Y).
+ *  1. Resolve the scope: page (default) or a container if `within` is set.
+ *  2. Read current position + viewport + total geometry for the chosen axis.
  *  3. Resolve target → final position on that axis.
  *  4. Plan segments via `planScroll`.
- *  5. For containers in humanized mode, park the cursor over the container
- *     so wheel events target it. Then walk segments via `page.mouse.wheel`,
- *     mapping each segment's `delta` onto the chosen axis.
+ *  5. Walk the segments — for page scrolls, dispatch `page.mouse.wheel`
+ *     events on the chosen axis. For containers, advance the element's
+ *     `scrollLeft` / `scrollTop` directly (wheel events don't always
+ *     route into nested overflow containers). Containers also park the
+ *     cursor at their center so an `installMouseHelper` overlay reads
+ *     as "hand on the wheel."
  *
  * In `speed: 'instant'`, all humanization is bypassed:
  *  - Page scrolls call `window.scrollTo(...)` with the new position on the
@@ -152,16 +163,16 @@ export async function executeScroll(
     : await readWindowGeometry(page, axis);
   if (!geom) {
     // Container not found / not scrollable — nothing to do.
-    return { fromY: 0, toY: 0, distance: 0, durationMs: 0 };
+    return { from: 0, to: 0, distance: 0, durationMs: 0 };
   }
 
-  const fromY = geom.current;
-  const toY = await resolveTarget(target, ctx, geom, container, axis, options.block);
-  const clampedTo = clamp(toY, 0, Math.max(0, geom.total - geom.viewport));
-  const distance = clampedTo - fromY;
+  const from = geom.current;
+  const targetPos = await resolveTarget(target, ctx, geom, container, axis, options.block);
+  const to = clamp(targetPos, 0, Math.max(0, geom.total - geom.viewport));
+  const distance = to - from;
 
   if (distance === 0) {
-    return { fromY, toY: clampedTo, distance: 0, durationMs: 0 };
+    return { from, to, distance: 0, durationMs: 0 };
   }
 
   if (speed === 'instant') {
@@ -172,7 +183,7 @@ export async function executeScroll(
           if (a.axis === 'x') el.scrollTo(a.pos, el.scrollTop);
           else el.scrollTo(el.scrollLeft, a.pos);
         },
-        { axis, pos: clampedTo },
+        { axis, pos: to },
       );
     } else {
       await page.evaluate(
@@ -180,13 +191,13 @@ export async function executeScroll(
           if (args.axis === 'x') window.scrollTo(args.pos, window.scrollY);
           else window.scrollTo(window.scrollX, args.pos);
         },
-        { axis, pos: clampedTo },
+        { axis, pos: to },
       );
     }
-    return { fromY, toY: clampedTo, distance, durationMs: 0 };
+    return { from, to, distance, durationMs: 0 };
   }
 
-  const segments = planScroll(fromY, clampedTo, personality.scroll, rng, {
+  const segments = planScroll(from, to, personality.scroll, rng, {
     forceOvershoot: options.overshoot,
     withPauses: options.withPauses,
     personalitySpeed: personality.speed,
@@ -195,9 +206,10 @@ export async function executeScroll(
 
   // For container scrolls, park the cursor over the container so the
   // visible cursor (when `installMouseHelper` is in use) reads as "human
-  // hand on the wheel." Actual scrolling for containers goes through
-  // `element.scrollBy` to avoid Playwright's flaky horizontal wheel
-  // routing into nested overflow-x elements.
+  // hand on the wheel." Actual scrolling goes through direct
+  // `scrollLeft` / `scrollTop` assignment in `walkSegments` — Playwright's
+  // synthetic wheel events don't reliably route into nested overflow
+  // containers.
   if (container && geom.hover) {
     await page.mouse.move(geom.hover.x, geom.hover.y);
   }
@@ -206,7 +218,7 @@ export async function executeScroll(
   await walkSegments(page, segments, axis, container);
   const durationMs = Date.now() - startedAt;
 
-  return { fromY, toY: clampedTo, distance, durationMs };
+  return { from, to, distance, durationMs };
 }
 
 /** Coerces the `within` option into a Locator (or null when unset). */
@@ -370,6 +382,15 @@ async function resolveElementWithinContainer(
  * `Locator.toString()` returns something like `locator('css=#foo')` — we
  * strip the wrapper to get the inner selector. Falls back to `null` when
  * the format isn't recognized; the caller treats that as "no element."
+ *
+ * Fragile by design: depends on Playwright's internal `toString()` shape,
+ * which isn't a stable public API. Used only when resolving element
+ * targets *inside* a `within` container, since the executor needs to
+ * `querySelector` from the container's perspective rather than the
+ * document's. For chained Locators (e.g. `page.locator('foo').first()`)
+ * the regex grabs the first quoted selector and ignores chained
+ * refinements — good enough for the common case, but worth a richer
+ * approach if Playwright ever changes the shape.
  */
 async function locatorSelector(locator: Locator): Promise<string | null> {
   const s = locator.toString?.();
@@ -383,18 +404,18 @@ async function locatorSelector(locator: Locator): Promise<string | null> {
 }
 
 /**
- * Walks the planned segments. For window scrolls, dispatches wheel events
+ * Walks the planned segments. For page scrolls, dispatches wheel events
  * on the chosen axis — real wheel events trigger every page-level wheel
  * handler, which is part of HumanJS's "dispatch what a human dispatches"
  * promise.
  *
- * For container scrolls, applies the delta directly via `element.scrollBy`.
- * Playwright's `page.mouse.wheel` doesn't reliably route horizontal deltas
- * to nested `overflow-x: auto` containers (the event hits the element under
- * the cursor but may scroll a parent or no element instead). `scrollBy` is
- * deterministic — it always scrolls the target — and the brand promise
- * stays intact because the planner still owns the bell-curve cadence,
- * mid-scroll pauses, and overshoot.
+ * For container scrolls, advances `scrollLeft` / `scrollTop` directly via
+ * `container.evaluate`. Playwright's `page.mouse.wheel` doesn't reliably
+ * route into nested overflow containers (the event hits the element under
+ * the cursor but may scroll a parent or no element instead). Direct
+ * property assignment is deterministic — it always scrolls the target —
+ * and the brand promise stays intact because the planner still owns the
+ * bell-curve cadence, mid-scroll pauses, and overshoot.
  */
 async function walkSegments(
   page: Page,

--- a/packages/playwright/src/scroll/index.ts
+++ b/packages/playwright/src/scroll/index.ts
@@ -62,19 +62,31 @@ export interface ScrollOptions {
    *
    * In humanized speed modes, the cursor moves over the container's
    * center first so the dispatched wheel events target it. In `'instant'`
-   * mode, the container's `scrollTop` is set directly with no wheel events.
+   * mode, the container's scroll position is set directly with no wheel
+   * events.
    *
    * Common use: chat threads, modal bodies, infinite-scroll feeds, any
    * `<div style="overflow-y: auto">` that owns its own scrollbar.
    */
   readonly within?: string | Locator;
+  /**
+   * Which axis to scroll along. Defaults to `'y'` (vertical).
+   *
+   * Set `'x'` for horizontal scrolling — carousels, kanban boards,
+   * sideways galleries. Every target shape still works: `'natural'`
+   * scrolls one viewport-width right, `'top'` jumps to scrollLeft 0,
+   * `'end'` to (scrollWidth - clientWidth), `{ by }` / `{ to }` apply to
+   * the X-axis, and element targets scroll until the element is visible
+   * horizontally.
+   */
+  readonly axis?: 'x' | 'y';
 }
 
 /** Outcome of a scroll, returned to the caller for observability. */
 export interface ScrollResult {
-  /** Starting scroll position (`window.scrollY` or `container.scrollTop`). */
+  /** Starting scroll position along the chosen axis. */
   readonly fromY: number;
-  /** Final scroll position the scroll aimed for. */
+  /** Final scroll position the scroll aimed for, along the chosen axis. */
   readonly toY: number;
   /** Signed pixel distance (`toY - fromY`). */
   readonly distance: number;
@@ -107,20 +119,23 @@ interface ScrollGeometry {
 }
 
 /**
- * Executes a humanized vertical scroll on either the page or a scrollable
- * container.
+ * Executes a humanized scroll on either the page or a scrollable container,
+ * along the chosen axis.
  *
  * Flow:
  *  1. Resolve the scroll axis: page (default) or a container if `within` is set.
- *  2. Read current position + viewport + total geometry for that axis.
+ *  2. Read current position + viewport + total geometry for that axis +
+ *     direction (X or Y).
  *  3. Resolve target → final position on that axis.
  *  4. Plan segments via `planScroll`.
  *  5. For containers in humanized mode, park the cursor over the container
- *     so wheel events target it. Then walk segments via `page.mouse.wheel`.
+ *     so wheel events target it. Then walk segments via `page.mouse.wheel`,
+ *     mapping each segment's `delta` onto the chosen axis.
  *
  * In `speed: 'instant'`, all humanization is bypassed:
- *  - Page scrolls call `window.scrollTo(0, y)`.
- *  - Container scrolls evaluate `el.scrollTo(0, y)` on the element.
+ *  - Page scrolls call `window.scrollTo(...)` with the new position on the
+ *    chosen axis and the existing position on the other.
+ *  - Container scrolls evaluate `el.scrollTo(...)` with the same shape.
  */
 export async function executeScroll(
   target: ScrollTarget | undefined,
@@ -129,16 +144,19 @@ export async function executeScroll(
 ): Promise<ScrollResult> {
   const { page, personality, rng, speed } = ctx;
   const speedFactor = speedModeFactor(speed);
+  const axis: 'x' | 'y' = options.axis ?? 'y';
 
   const container = resolveWithin(options.within, ctx);
-  const geom = container ? await readContainerGeometry(container) : await readWindowGeometry(page);
+  const geom = container
+    ? await readContainerGeometry(container, axis)
+    : await readWindowGeometry(page, axis);
   if (!geom) {
     // Container not found / not scrollable — nothing to do.
     return { fromY: 0, toY: 0, distance: 0, durationMs: 0 };
   }
 
   const fromY = geom.current;
-  const toY = await resolveTarget(target, ctx, geom, container, options.block);
+  const toY = await resolveTarget(target, ctx, geom, container, axis, options.block);
   const clampedTo = clamp(toY, 0, Math.max(0, geom.total - geom.viewport));
   const distance = clampedTo - fromY;
 
@@ -148,9 +166,22 @@ export async function executeScroll(
 
   if (speed === 'instant') {
     if (container) {
-      await container.evaluate((el, y) => el.scrollTo(0, y as number), clampedTo);
+      await container.evaluate(
+        (el, args) => {
+          const a = args as { axis: 'x' | 'y'; pos: number };
+          if (a.axis === 'x') el.scrollTo(a.pos, el.scrollTop);
+          else el.scrollTo(el.scrollLeft, a.pos);
+        },
+        { axis, pos: clampedTo },
+      );
     } else {
-      await page.evaluate((y) => window.scrollTo(0, y), clampedTo);
+      await page.evaluate(
+        (args) => {
+          if (args.axis === 'x') window.scrollTo(args.pos, window.scrollY);
+          else window.scrollTo(window.scrollX, args.pos);
+        },
+        { axis, pos: clampedTo },
+      );
     }
     return { fromY, toY: clampedTo, distance, durationMs: 0 };
   }
@@ -169,7 +200,7 @@ export async function executeScroll(
   }
 
   const startedAt = Date.now();
-  await walkSegments(page, segments);
+  await walkSegments(page, segments, axis);
   const durationMs = Date.now() - startedAt;
 
   return { fromY, toY: clampedTo, distance, durationMs };
@@ -181,47 +212,61 @@ function resolveWithin(within: ScrollOptions['within'], ctx: ScrollContext): Loc
   return typeof within === 'string' ? ctx.page.locator(within) : within;
 }
 
-/** Reads `window.scrollY` / `innerHeight` / `documentElement.scrollHeight`. */
-async function readWindowGeometry(page: Page): Promise<ScrollGeometry> {
-  const g = await page.evaluate(() => ({
-    current: window.scrollY,
-    viewport: window.innerHeight,
-    total: Math.max(document.documentElement.scrollHeight, document.body?.scrollHeight ?? 0),
-  }));
+/** Reads the page's current scroll geometry for the chosen axis. */
+async function readWindowGeometry(page: Page, axis: 'x' | 'y'): Promise<ScrollGeometry> {
+  const g = await page.evaluate((a: 'x' | 'y') => {
+    if (a === 'x') {
+      return {
+        current: window.scrollX,
+        viewport: window.innerWidth,
+        total: Math.max(document.documentElement.scrollWidth, document.body?.scrollWidth ?? 0),
+      };
+    }
+    return {
+      current: window.scrollY,
+      viewport: window.innerHeight,
+      total: Math.max(document.documentElement.scrollHeight, document.body?.scrollHeight ?? 0),
+    };
+  }, axis);
   return { current: g.current, viewport: g.viewport, total: g.total };
 }
 
 /**
- * Reads container `scrollTop` / `clientHeight` / `scrollHeight` plus the
- * center of its viewport-relative bounding box (for cursor parking).
- * Returns `null` if the element resolves to nothing.
+ * Reads container scroll geometry for the chosen axis plus the center of
+ * its viewport-relative bounding box (for cursor parking). Returns `null`
+ * if the element resolves to nothing.
  */
-async function readContainerGeometry(container: Locator): Promise<ScrollGeometry | null> {
+async function readContainerGeometry(
+  container: Locator,
+  axis: 'x' | 'y',
+): Promise<ScrollGeometry | null> {
   return container
-    .evaluate((el) => {
+    .evaluate((el, a: 'x' | 'y') => {
       const rect = el.getBoundingClientRect();
+      const isX = a === 'x';
       return {
-        current: el.scrollTop,
-        viewport: el.clientHeight,
-        total: el.scrollHeight,
+        current: isX ? el.scrollLeft : el.scrollTop,
+        viewport: isX ? el.clientWidth : el.clientHeight,
+        total: isX ? el.scrollWidth : el.scrollHeight,
         hover: {
           x: rect.left + rect.width / 2,
           y: rect.top + rect.height / 2,
         },
       } as const;
-    })
+    }, axis)
     .catch(() => null);
 }
 
 /**
  * Resolves a `ScrollTarget` to an absolute scroll position on the active
- * axis (either `window.scrollY` or the container's `scrollTop`).
+ * axis (window scroll or container scroll, vertical or horizontal).
  */
 async function resolveTarget(
   target: ScrollTarget | undefined,
   ctx: ScrollContext,
   geom: ScrollGeometry,
   container: Locator | null,
+  axis: 'x' | 'y',
   block: 'start' | 'center' | 'end' | 'nearest' = 'start',
 ): Promise<number> {
   if (target === undefined || target === 'natural') return geom.current + geom.viewport;
@@ -240,76 +285,81 @@ async function resolveTarget(
   if (!elementLocator) return geom.current + geom.viewport;
 
   return container
-    ? resolveElementWithinContainer(elementLocator, container, geom, block)
-    : resolveElementInWindow(elementLocator, geom, block);
+    ? resolveElementWithinContainer(elementLocator, container, geom, axis, block)
+    : resolveElementInWindow(elementLocator, geom, axis, block);
 }
 
 /**
- * Computes the scrollY needed to align a window-level element per `block`.
- * `rect.y` is viewport-relative; absolute Y is `scrollY + rect.y`.
+ * Computes the scroll position needed to align a window-level element per
+ * `block` along the chosen axis. `rect.x` / `rect.y` are viewport-relative;
+ * absolute position is `geom.current + rect.{axis}`.
  */
 async function resolveElementInWindow(
   elementLocator: Locator,
   geom: ScrollGeometry,
+  axis: 'x' | 'y',
   block: 'start' | 'center' | 'end' | 'nearest',
 ): Promise<number> {
   const rect = await elementLocator.boundingBox().catch(() => null);
   if (!rect) return geom.current;
-  const absoluteTop = geom.current + rect.y;
-  const absoluteBottom = absoluteTop + rect.height;
-  if (block === 'start') return absoluteTop;
-  if (block === 'end') return absoluteBottom - geom.viewport;
+  const relStart = axis === 'x' ? rect.x : rect.y;
+  const length = axis === 'x' ? rect.width : rect.height;
+  const absoluteStart = geom.current + relStart;
+  const absoluteEnd = absoluteStart + length;
+  if (block === 'start') return absoluteStart;
+  if (block === 'end') return absoluteEnd - geom.viewport;
   if (block === 'nearest') {
-    if (rect.y >= 0 && rect.y + rect.height <= geom.viewport) return geom.current;
-    if (rect.y < 0) return absoluteTop;
-    return absoluteBottom - geom.viewport;
+    if (relStart >= 0 && relStart + length <= geom.viewport) return geom.current;
+    if (relStart < 0) return absoluteStart;
+    return absoluteEnd - geom.viewport;
   }
-  return absoluteTop - (geom.viewport - rect.height) / 2;
+  return absoluteStart - (geom.viewport - length) / 2;
 }
 
 /**
- * Computes the container's `scrollTop` needed to align an element per `block`.
- * Element offset from the container's content origin =
- *   `(element.rect.y - container.rect.y) + container.scrollTop`
+ * Computes the container's `scrollTop` / `scrollLeft` needed to align an
+ * element per `block` along the chosen axis. Element offset from the
+ * container's content origin =
+ *   `(element.rect.{axis} - container.rect.{axis}) + container.scroll{axis}`
  * regardless of whether the container is the element's positioning ancestor.
  */
 async function resolveElementWithinContainer(
   elementLocator: Locator,
   container: Locator,
   geom: ScrollGeometry,
+  axis: 'x' | 'y',
   block: 'start' | 'center' | 'end' | 'nearest',
 ): Promise<number> {
   const rects = await container
     .evaluate(
-      (containerEl, sel) => {
-        const elementEl = sel ? document.querySelector(sel) : null;
+      (containerEl, args: { sel: string | null; axis: 'x' | 'y' }) => {
+        const elementEl = args.sel ? document.querySelector(args.sel) : null;
         // The element may not be a child of the container — handle that too.
         const targetEl = elementEl ?? (containerEl.querySelector(':scope > *') as Element | null);
         if (!targetEl) return null;
         const cRect = containerEl.getBoundingClientRect();
         const eRect = targetEl.getBoundingClientRect();
-        return {
-          elementY: eRect.top - cRect.top,
-          elementHeight: eRect.height,
-        };
+        return args.axis === 'x'
+          ? { relStart: eRect.left - cRect.left, length: eRect.width }
+          : { relStart: eRect.top - cRect.top, length: eRect.height };
       },
-      await locatorSelector(elementLocator),
+      { sel: await locatorSelector(elementLocator), axis },
     )
     .catch(() => null);
   if (!rects) return geom.current;
-  // Offset from container's content origin = (visual delta) + container.scrollTop.
-  const offsetTop = rects.elementY + geom.current;
-  const offsetBottom = offsetTop + rects.elementHeight;
-  if (block === 'start') return offsetTop;
-  if (block === 'end') return offsetBottom - geom.viewport;
+  // Offset from container's content origin = (visual delta) + scroll position.
+  const offsetStart = rects.relStart + geom.current;
+  const offsetEnd = offsetStart + rects.length;
+  if (block === 'start') return offsetStart;
+  if (block === 'end') return offsetEnd - geom.viewport;
   if (block === 'nearest') {
-    if (rects.elementY >= 0 && rects.elementY + rects.elementHeight <= geom.viewport) {
+    if (rects.relStart >= 0 && rects.relStart + rects.length <= geom.viewport) {
       return geom.current;
     }
-    if (rects.elementY < 0) return offsetTop;
-    return offsetBottom - geom.viewport;
+    if (rects.relStart < 0) return offsetStart;
+    return offsetEnd - geom.viewport;
   }
-  return offsetTop - (geom.viewport - rects.elementHeight) / 2;
+  return offsetStart - (geom.viewport - rects.length) / 2;
 }
 
 /**
@@ -329,11 +379,18 @@ async function locatorSelector(locator: Locator): Promise<string | null> {
   return eq > 0 && /^[a-z]+$/.test(raw.slice(0, eq)) ? raw.slice(eq + 1) : raw;
 }
 
-/** Walks the planned segments, dispatching wheel events with pacing. */
-async function walkSegments(page: Page, segments: readonly ScrollSegment[]): Promise<void> {
+/** Walks the planned segments, dispatching wheel events on the chosen axis. */
+async function walkSegments(
+  page: Page,
+  segments: readonly ScrollSegment[],
+  axis: 'x' | 'y',
+): Promise<void> {
   for (const segment of segments) {
     if (segment.delayBeforeMs > 0) await sleep(segment.delayBeforeMs);
-    if (segment.deltaY !== 0) await page.mouse.wheel(0, segment.deltaY);
+    if (segment.delta !== 0) {
+      if (axis === 'x') await page.mouse.wheel(segment.delta, 0);
+      else await page.mouse.wheel(0, segment.delta);
+    }
   }
 }
 

--- a/packages/playwright/src/scroll/index.ts
+++ b/packages/playwright/src/scroll/index.ts
@@ -1,0 +1,183 @@
+import { type Personality, planScroll, type Rng, type ScrollSegment } from '@humanjs/core';
+import type { Locator, Page } from 'playwright';
+import type { Speed } from '../index';
+import { sleep, speedModeFactor } from '../internal/timing';
+
+/** Runtime dependencies for a humanized scroll. */
+export interface ScrollContext {
+  readonly page: Page;
+  readonly personality: Personality;
+  readonly rng: Rng;
+  readonly speed: Speed;
+}
+
+/**
+ * What / where to scroll:
+ *  - `'natural'`: scroll one viewport-worth in the current direction (default).
+ *  - `'end'`: scroll to the very bottom of the page.
+ *  - `'top'`: scroll to the very top of the page.
+ *  - `string`: a Playwright-compatible selector — scroll until in view.
+ *  - `Locator`: same, but you already have a Locator handle.
+ *  - `{ by: number }`: scroll by a relative pixel delta (negative = up).
+ *  - `{ to: number }`: scroll to an absolute Y position.
+ */
+export type ScrollTarget =
+  | 'natural'
+  | 'end'
+  | 'top'
+  | string
+  | Locator
+  | { readonly by: number }
+  | { readonly to: number };
+
+export interface ScrollOptions {
+  /**
+   * Force an overshoot + correction even if the personality wouldn't choose
+   * one. Useful when you want the humanization signal regardless of
+   * personality (e.g. demos).
+   */
+  readonly overshoot?: boolean;
+  /**
+   * Disable mid-scroll micro-pauses. Defaults to `true` (pauses enabled).
+   * Set `false` for the smoothest possible motion.
+   */
+  readonly withPauses?: boolean;
+  /**
+   * For element targets only: where to align the element vertically when
+   * the scroll ends. Mirrors `scrollIntoView({ block })`. Defaults to
+   * `'start'`.
+   */
+  readonly block?: 'start' | 'center' | 'end';
+}
+
+/** Outcome of a scroll, returned to the caller for observability. */
+export interface ScrollResult {
+  /** Starting `window.scrollY` value. */
+  readonly fromY: number;
+  /** Final `window.scrollY` value the scroll aimed for. */
+  readonly toY: number;
+  /** Signed pixel distance (`toY - fromY`). */
+  readonly distance: number;
+  /** Total elapsed dwell + motion time in ms. Zero in `speed: 'instant'`. */
+  readonly durationMs: number;
+}
+
+/** Reserved string targets that select a behavior rather than an element. */
+const RESERVED_TARGETS = new Set(['natural', 'end', 'top']);
+
+/**
+ * Executes a humanized vertical scroll.
+ *
+ * Flow:
+ *  1. Resolve current scroll position + viewport + document height.
+ *  2. Resolve target → final Y.
+ *  3. Plan segments via `planScroll`.
+ *  4. Walk segments: `sleep(delay) → page.mouse.wheel(0, deltaY)` per step.
+ *
+ * In `speed: 'instant'`, all humanization is bypassed and the page is
+ * scrolled with `window.scrollTo(0, y)` directly.
+ */
+export async function executeScroll(
+  target: ScrollTarget | undefined,
+  ctx: ScrollContext,
+  options: ScrollOptions = {},
+): Promise<ScrollResult> {
+  const { page, personality, rng, speed } = ctx;
+  const speedFactor = speedModeFactor(speed);
+
+  // Read the page's scroll geometry once up front. Cheaper than evaluating
+  // every time we need a number.
+  const geom = await page.evaluate(() => ({
+    scrollY: window.scrollY,
+    viewport: window.innerHeight,
+    docHeight: Math.max(document.documentElement.scrollHeight, document.body?.scrollHeight ?? 0),
+  }));
+
+  const fromY = geom.scrollY;
+  const toY = await resolveTarget(target, ctx, geom, options.block);
+  const clampedTo = clamp(toY, 0, Math.max(0, geom.docHeight - geom.viewport));
+  const distance = clampedTo - fromY;
+
+  if (distance === 0) {
+    return { fromY, toY: clampedTo, distance: 0, durationMs: 0 };
+  }
+
+  if (speed === 'instant') {
+    await page.evaluate((y) => window.scrollTo(0, y), clampedTo);
+    return { fromY, toY: clampedTo, distance, durationMs: 0 };
+  }
+
+  const segments = planScroll(fromY, clampedTo, personality.scroll, rng, {
+    forceOvershoot: options.overshoot,
+    withPauses: options.withPauses,
+    personalitySpeed: personality.speed,
+    speedFactor,
+  });
+
+  const startedAt = Date.now();
+  await walkSegments(page, segments);
+  const durationMs = Date.now() - startedAt;
+
+  return { fromY, toY: clampedTo, distance, durationMs };
+}
+
+/**
+ * Resolves a `ScrollTarget` to an absolute `window.scrollY` value. Element
+ * targets evaluate `getBoundingClientRect()` to compute the right Y for
+ * the requested `block` alignment.
+ */
+async function resolveTarget(
+  target: ScrollTarget | undefined,
+  ctx: ScrollContext,
+  geom: { scrollY: number; viewport: number; docHeight: number },
+  block: 'start' | 'center' | 'end' = 'start',
+): Promise<number> {
+  if (target === undefined || target === 'natural') {
+    // Scroll exactly one viewport-worth down. This is the contract `'natural'`
+    // promises in the docs — fractional multipliers (e.g. 0.85 for "keep
+    // some overlap as context") feel like undershooting when the next
+    // section sits exactly one viewport away.
+    return geom.scrollY + geom.viewport;
+  }
+  if (target === 'end') return geom.docHeight;
+  if (target === 'top') return 0;
+  if (typeof target === 'object' && 'by' in target) return geom.scrollY + target.by;
+  if (typeof target === 'object' && 'to' in target) return target.to;
+
+  // String selector or Locator from here on.
+  const locator =
+    typeof target === 'string' && !RESERVED_TARGETS.has(target)
+      ? ctx.page.locator(target)
+      : typeof target === 'string'
+        ? null
+        : target;
+  if (!locator) {
+    // Reserved string fell through the `===` checks above — shouldn't
+    // happen, but defensively fall back to natural.
+    return geom.scrollY + Math.round(geom.viewport * 0.85);
+  }
+
+  const rect = await locator.boundingBox().catch(() => null);
+  if (!rect) {
+    // Element not found / not visible — best we can do is stay put.
+    return geom.scrollY;
+  }
+  // `rect.y` is viewport-relative; absolute Y is scrollY + rect.y.
+  const absoluteTop = geom.scrollY + rect.y;
+  if (block === 'start') return absoluteTop;
+  if (block === 'end') return absoluteTop + rect.height - geom.viewport;
+  // center
+  return absoluteTop - (geom.viewport - rect.height) / 2;
+}
+
+/** Walks the planned segments, dispatching wheel events with pacing. */
+async function walkSegments(page: Page, segments: readonly ScrollSegment[]): Promise<void> {
+  for (const segment of segments) {
+    if (segment.delayBeforeMs > 0) await sleep(segment.delayBeforeMs);
+    if (segment.deltaY !== 0) await page.mouse.wheel(0, segment.deltaY);
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return value < min ? min : value > max ? max : value;
+}

--- a/packages/playwright/src/scroll/index.ts
+++ b/packages/playwright/src/scroll/index.ts
@@ -46,15 +46,17 @@ export interface ScrollOptions {
    */
   readonly withPauses?: boolean;
   /**
-   * For element targets only: where to align the element vertically when
-   * the scroll ends. Mirrors `scrollIntoView({ block })`. Defaults to
-   * `'start'`.
+   * For element targets only: where to align the element along the chosen
+   * axis when the scroll ends. Mirrors `scrollIntoView({ block })`.
+   * Defaults to `'start'`.
    *
-   * - `'start'`: element top aligns with viewport top
+   * - `'start'`: element's leading edge aligns with the viewport's leading
+   *    edge (top for `axis: 'y'`, left for `axis: 'x'`)
    * - `'center'`: element centers in the viewport
-   * - `'end'`: element bottom aligns with viewport bottom
-   * - `'nearest'`: do the minimum scroll — stay put if element is already
-   *    fully visible, otherwise scroll to the closest edge
+   * - `'end'`: element's trailing edge aligns with the viewport's trailing
+   *    edge (bottom for `'y'`, right for `'x'`)
+   * - `'nearest'`: do the minimum scroll — stay put if the element is
+   *    already fully visible, otherwise scroll to the closest edge
    */
   readonly block?: 'start' | 'center' | 'end' | 'nearest';
   /**

--- a/packages/playwright/src/scroll/index.ts
+++ b/packages/playwright/src/scroll/index.ts
@@ -14,8 +14,8 @@ export interface ScrollContext {
 /**
  * What / where to scroll:
  *  - `'natural'`: scroll one viewport-worth in the current direction (default).
- *  - `'end'`: scroll to the very bottom of the page.
- *  - `'top'`: scroll to the very top of the page.
+ *  - `'end'`: scroll to the very bottom.
+ *  - `'top'`: scroll to the very top.
  *  - `string`: a Playwright-compatible selector — scroll until in view.
  *  - `Locator`: same, but you already have a Locator handle.
  *  - `{ by: number }`: scroll by a relative pixel delta (negative = up).
@@ -46,15 +46,35 @@ export interface ScrollOptions {
    * For element targets only: where to align the element vertically when
    * the scroll ends. Mirrors `scrollIntoView({ block })`. Defaults to
    * `'start'`.
+   *
+   * - `'start'`: element top aligns with viewport top
+   * - `'center'`: element centers in the viewport
+   * - `'end'`: element bottom aligns with viewport bottom
+   * - `'nearest'`: do the minimum scroll — stay put if element is already
+   *    fully visible, otherwise scroll to the closest edge
    */
-  readonly block?: 'start' | 'center' | 'end';
+  readonly block?: 'start' | 'center' | 'end' | 'nearest';
+  /**
+   * Scroll inside a scrollable container instead of the page. Accepts a
+   * Playwright-compatible selector or a built `Locator`. Every scroll
+   * semantic (`'natural'`, `'top'`, `'end'`, `{ by }`, `{ to }`, element
+   * targets, `block` alignment) applies relative to the container.
+   *
+   * In humanized speed modes, the cursor moves over the container's
+   * center first so the dispatched wheel events target it. In `'instant'`
+   * mode, the container's `scrollTop` is set directly with no wheel events.
+   *
+   * Common use: chat threads, modal bodies, infinite-scroll feeds, any
+   * `<div style="overflow-y: auto">` that owns its own scrollbar.
+   */
+  readonly within?: string | Locator;
 }
 
 /** Outcome of a scroll, returned to the caller for observability. */
 export interface ScrollResult {
-  /** Starting `window.scrollY` value. */
+  /** Starting scroll position (`window.scrollY` or `container.scrollTop`). */
   readonly fromY: number;
-  /** Final `window.scrollY` value the scroll aimed for. */
+  /** Final scroll position the scroll aimed for. */
   readonly toY: number;
   /** Signed pixel distance (`toY - fromY`). */
   readonly distance: number;
@@ -66,16 +86,41 @@ export interface ScrollResult {
 const RESERVED_TARGETS = new Set(['natural', 'end', 'top']);
 
 /**
- * Executes a humanized vertical scroll.
+ * Generic axis description — the planner doesn't care whether it's driving
+ * `window.scrollY` or an element's `scrollTop`. Both look like the same
+ * 1-D problem: a current position, a viewport length, and a max scrollable
+ * extent.
+ */
+interface ScrollGeometry {
+  /** Current scroll position. */
+  readonly current: number;
+  /** Visible length (viewport height for window, clientHeight for container). */
+  readonly viewport: number;
+  /** Total scrollable extent (docHeight for window, scrollHeight for container). */
+  readonly total: number;
+  /**
+   * For container scrolls: viewport-relative center coordinates the cursor
+   * should hover over so wheel events target the container. Undefined for
+   * window scrolls (mouse position doesn't affect window scroll routing).
+   */
+  readonly hover?: { x: number; y: number };
+}
+
+/**
+ * Executes a humanized vertical scroll on either the page or a scrollable
+ * container.
  *
  * Flow:
- *  1. Resolve current scroll position + viewport + document height.
- *  2. Resolve target → final Y.
- *  3. Plan segments via `planScroll`.
- *  4. Walk segments: `sleep(delay) → page.mouse.wheel(0, deltaY)` per step.
+ *  1. Resolve the scroll axis: page (default) or a container if `within` is set.
+ *  2. Read current position + viewport + total geometry for that axis.
+ *  3. Resolve target → final position on that axis.
+ *  4. Plan segments via `planScroll`.
+ *  5. For containers in humanized mode, park the cursor over the container
+ *     so wheel events target it. Then walk segments via `page.mouse.wheel`.
  *
- * In `speed: 'instant'`, all humanization is bypassed and the page is
- * scrolled with `window.scrollTo(0, y)` directly.
+ * In `speed: 'instant'`, all humanization is bypassed:
+ *  - Page scrolls call `window.scrollTo(0, y)`.
+ *  - Container scrolls evaluate `el.scrollTo(0, y)` on the element.
  */
 export async function executeScroll(
   target: ScrollTarget | undefined,
@@ -85,17 +130,16 @@ export async function executeScroll(
   const { page, personality, rng, speed } = ctx;
   const speedFactor = speedModeFactor(speed);
 
-  // Read the page's scroll geometry once up front. Cheaper than evaluating
-  // every time we need a number.
-  const geom = await page.evaluate(() => ({
-    scrollY: window.scrollY,
-    viewport: window.innerHeight,
-    docHeight: Math.max(document.documentElement.scrollHeight, document.body?.scrollHeight ?? 0),
-  }));
+  const container = resolveWithin(options.within, ctx);
+  const geom = container ? await readContainerGeometry(container) : await readWindowGeometry(page);
+  if (!geom) {
+    // Container not found / not scrollable — nothing to do.
+    return { fromY: 0, toY: 0, distance: 0, durationMs: 0 };
+  }
 
-  const fromY = geom.scrollY;
-  const toY = await resolveTarget(target, ctx, geom, options.block);
-  const clampedTo = clamp(toY, 0, Math.max(0, geom.docHeight - geom.viewport));
+  const fromY = geom.current;
+  const toY = await resolveTarget(target, ctx, geom, container, options.block);
+  const clampedTo = clamp(toY, 0, Math.max(0, geom.total - geom.viewport));
   const distance = clampedTo - fromY;
 
   if (distance === 0) {
@@ -103,7 +147,11 @@ export async function executeScroll(
   }
 
   if (speed === 'instant') {
-    await page.evaluate((y) => window.scrollTo(0, y), clampedTo);
+    if (container) {
+      await container.evaluate((el, y) => el.scrollTo(0, y as number), clampedTo);
+    } else {
+      await page.evaluate((y) => window.scrollTo(0, y), clampedTo);
+    }
     return { fromY, toY: clampedTo, distance, durationMs: 0 };
   }
 
@@ -114,6 +162,12 @@ export async function executeScroll(
     speedFactor,
   });
 
+  // For container scrolls, park the cursor over the container so wheel
+  // events route to it instead of the page.
+  if (container && geom.hover) {
+    await page.mouse.move(geom.hover.x, geom.hover.y);
+  }
+
   const startedAt = Date.now();
   await walkSegments(page, segments);
   const durationMs = Date.now() - startedAt;
@@ -121,53 +175,158 @@ export async function executeScroll(
   return { fromY, toY: clampedTo, distance, durationMs };
 }
 
+/** Coerces the `within` option into a Locator (or null when unset). */
+function resolveWithin(within: ScrollOptions['within'], ctx: ScrollContext): Locator | null {
+  if (!within) return null;
+  return typeof within === 'string' ? ctx.page.locator(within) : within;
+}
+
+/** Reads `window.scrollY` / `innerHeight` / `documentElement.scrollHeight`. */
+async function readWindowGeometry(page: Page): Promise<ScrollGeometry> {
+  const g = await page.evaluate(() => ({
+    current: window.scrollY,
+    viewport: window.innerHeight,
+    total: Math.max(document.documentElement.scrollHeight, document.body?.scrollHeight ?? 0),
+  }));
+  return { current: g.current, viewport: g.viewport, total: g.total };
+}
+
 /**
- * Resolves a `ScrollTarget` to an absolute `window.scrollY` value. Element
- * targets evaluate `getBoundingClientRect()` to compute the right Y for
- * the requested `block` alignment.
+ * Reads container `scrollTop` / `clientHeight` / `scrollHeight` plus the
+ * center of its viewport-relative bounding box (for cursor parking).
+ * Returns `null` if the element resolves to nothing.
+ */
+async function readContainerGeometry(container: Locator): Promise<ScrollGeometry | null> {
+  return container
+    .evaluate((el) => {
+      const rect = el.getBoundingClientRect();
+      return {
+        current: el.scrollTop,
+        viewport: el.clientHeight,
+        total: el.scrollHeight,
+        hover: {
+          x: rect.left + rect.width / 2,
+          y: rect.top + rect.height / 2,
+        },
+      } as const;
+    })
+    .catch(() => null);
+}
+
+/**
+ * Resolves a `ScrollTarget` to an absolute scroll position on the active
+ * axis (either `window.scrollY` or the container's `scrollTop`).
  */
 async function resolveTarget(
   target: ScrollTarget | undefined,
   ctx: ScrollContext,
-  geom: { scrollY: number; viewport: number; docHeight: number },
-  block: 'start' | 'center' | 'end' = 'start',
+  geom: ScrollGeometry,
+  container: Locator | null,
+  block: 'start' | 'center' | 'end' | 'nearest' = 'start',
 ): Promise<number> {
-  if (target === undefined || target === 'natural') {
-    // Scroll exactly one viewport-worth down. This is the contract `'natural'`
-    // promises in the docs — fractional multipliers (e.g. 0.85 for "keep
-    // some overlap as context") feel like undershooting when the next
-    // section sits exactly one viewport away.
-    return geom.scrollY + geom.viewport;
-  }
-  if (target === 'end') return geom.docHeight;
+  if (target === undefined || target === 'natural') return geom.current + geom.viewport;
+  if (target === 'end') return geom.total;
   if (target === 'top') return 0;
-  if (typeof target === 'object' && 'by' in target) return geom.scrollY + target.by;
+  if (typeof target === 'object' && 'by' in target) return geom.current + target.by;
   if (typeof target === 'object' && 'to' in target) return target.to;
 
-  // String selector or Locator from here on.
-  const locator =
+  // Element target — selector string or Locator.
+  const elementLocator =
     typeof target === 'string' && !RESERVED_TARGETS.has(target)
       ? ctx.page.locator(target)
       : typeof target === 'string'
         ? null
         : target;
-  if (!locator) {
-    // Reserved string fell through the `===` checks above — shouldn't
-    // happen, but defensively fall back to natural.
-    return geom.scrollY + Math.round(geom.viewport * 0.85);
-  }
+  if (!elementLocator) return geom.current + geom.viewport;
 
-  const rect = await locator.boundingBox().catch(() => null);
-  if (!rect) {
-    // Element not found / not visible — best we can do is stay put.
-    return geom.scrollY;
-  }
-  // `rect.y` is viewport-relative; absolute Y is scrollY + rect.y.
-  const absoluteTop = geom.scrollY + rect.y;
+  return container
+    ? resolveElementWithinContainer(elementLocator, container, geom, block)
+    : resolveElementInWindow(elementLocator, geom, block);
+}
+
+/**
+ * Computes the scrollY needed to align a window-level element per `block`.
+ * `rect.y` is viewport-relative; absolute Y is `scrollY + rect.y`.
+ */
+async function resolveElementInWindow(
+  elementLocator: Locator,
+  geom: ScrollGeometry,
+  block: 'start' | 'center' | 'end' | 'nearest',
+): Promise<number> {
+  const rect = await elementLocator.boundingBox().catch(() => null);
+  if (!rect) return geom.current;
+  const absoluteTop = geom.current + rect.y;
+  const absoluteBottom = absoluteTop + rect.height;
   if (block === 'start') return absoluteTop;
-  if (block === 'end') return absoluteTop + rect.height - geom.viewport;
-  // center
+  if (block === 'end') return absoluteBottom - geom.viewport;
+  if (block === 'nearest') {
+    if (rect.y >= 0 && rect.y + rect.height <= geom.viewport) return geom.current;
+    if (rect.y < 0) return absoluteTop;
+    return absoluteBottom - geom.viewport;
+  }
   return absoluteTop - (geom.viewport - rect.height) / 2;
+}
+
+/**
+ * Computes the container's `scrollTop` needed to align an element per `block`.
+ * Element offset from the container's content origin =
+ *   `(element.rect.y - container.rect.y) + container.scrollTop`
+ * regardless of whether the container is the element's positioning ancestor.
+ */
+async function resolveElementWithinContainer(
+  elementLocator: Locator,
+  container: Locator,
+  geom: ScrollGeometry,
+  block: 'start' | 'center' | 'end' | 'nearest',
+): Promise<number> {
+  const rects = await container
+    .evaluate(
+      (containerEl, sel) => {
+        const elementEl = sel ? document.querySelector(sel) : null;
+        // The element may not be a child of the container — handle that too.
+        const targetEl = elementEl ?? (containerEl.querySelector(':scope > *') as Element | null);
+        if (!targetEl) return null;
+        const cRect = containerEl.getBoundingClientRect();
+        const eRect = targetEl.getBoundingClientRect();
+        return {
+          elementY: eRect.top - cRect.top,
+          elementHeight: eRect.height,
+        };
+      },
+      await locatorSelector(elementLocator),
+    )
+    .catch(() => null);
+  if (!rects) return geom.current;
+  // Offset from container's content origin = (visual delta) + container.scrollTop.
+  const offsetTop = rects.elementY + geom.current;
+  const offsetBottom = offsetTop + rects.elementHeight;
+  if (block === 'start') return offsetTop;
+  if (block === 'end') return offsetBottom - geom.viewport;
+  if (block === 'nearest') {
+    if (rects.elementY >= 0 && rects.elementY + rects.elementHeight <= geom.viewport) {
+      return geom.current;
+    }
+    if (rects.elementY < 0) return offsetTop;
+    return offsetBottom - geom.viewport;
+  }
+  return offsetTop - (geom.viewport - rects.elementHeight) / 2;
+}
+
+/**
+ * Best-effort recovery of the selector string a Locator wraps. Playwright's
+ * `Locator.toString()` returns something like `locator('css=#foo')` — we
+ * strip the wrapper to get the inner selector. Falls back to `null` when
+ * the format isn't recognized; the caller treats that as "no element."
+ */
+async function locatorSelector(locator: Locator): Promise<string | null> {
+  const s = locator.toString?.();
+  if (typeof s !== 'string') return null;
+  const match = /locator\(['"](.+?)['"]/.exec(s);
+  if (!match) return null;
+  const raw = match[1] ?? '';
+  // Strip an "engine=" prefix when present (Playwright sometimes prepends one).
+  const eq = raw.indexOf('=');
+  return eq > 0 && /^[a-z]+$/.test(raw.slice(0, eq)) ? raw.slice(eq + 1) : raw;
 }
 
 /** Walks the planned segments, dispatching wheel events with pacing. */

--- a/packages/playwright/src/scroll/index.ts
+++ b/packages/playwright/src/scroll/index.ts
@@ -193,14 +193,17 @@ export async function executeScroll(
     speedFactor,
   });
 
-  // For container scrolls, park the cursor over the container so wheel
-  // events route to it instead of the page.
+  // For container scrolls, park the cursor over the container so the
+  // visible cursor (when `installMouseHelper` is in use) reads as "human
+  // hand on the wheel." Actual scrolling for containers goes through
+  // `element.scrollBy` to avoid Playwright's flaky horizontal wheel
+  // routing into nested overflow-x elements.
   if (container && geom.hover) {
     await page.mouse.move(geom.hover.x, geom.hover.y);
   }
 
   const startedAt = Date.now();
-  await walkSegments(page, segments, axis);
+  await walkSegments(page, segments, axis, container);
   const durationMs = Date.now() - startedAt;
 
   return { fromY, toY: clampedTo, distance, durationMs };
@@ -379,17 +382,45 @@ async function locatorSelector(locator: Locator): Promise<string | null> {
   return eq > 0 && /^[a-z]+$/.test(raw.slice(0, eq)) ? raw.slice(eq + 1) : raw;
 }
 
-/** Walks the planned segments, dispatching wheel events on the chosen axis. */
+/**
+ * Walks the planned segments. For window scrolls, dispatches wheel events
+ * on the chosen axis — real wheel events trigger every page-level wheel
+ * handler, which is part of HumanJS's "dispatch what a human dispatches"
+ * promise.
+ *
+ * For container scrolls, applies the delta directly via `element.scrollBy`.
+ * Playwright's `page.mouse.wheel` doesn't reliably route horizontal deltas
+ * to nested `overflow-x: auto` containers (the event hits the element under
+ * the cursor but may scroll a parent or no element instead). `scrollBy` is
+ * deterministic — it always scrolls the target — and the brand promise
+ * stays intact because the planner still owns the bell-curve cadence,
+ * mid-scroll pauses, and overshoot.
+ */
 async function walkSegments(
   page: Page,
   segments: readonly ScrollSegment[],
   axis: 'x' | 'y',
+  container: Locator | null,
 ): Promise<void> {
   for (const segment of segments) {
     if (segment.delayBeforeMs > 0) await sleep(segment.delayBeforeMs);
-    if (segment.delta !== 0) {
-      if (axis === 'x') await page.mouse.wheel(segment.delta, 0);
-      else await page.mouse.wheel(0, segment.delta);
+    if (segment.delta === 0) continue;
+    if (container) {
+      await container.evaluate(
+        (el, args) => {
+          const a = args as { axis: 'x' | 'y'; delta: number };
+          // Direct property assignment is more reliable than `scrollBy()`
+          // — some flex/grid layouts have edge cases where scrollBy
+          // becomes a no-op despite the element being scrollable.
+          if (a.axis === 'x') el.scrollLeft += a.delta;
+          else el.scrollTop += a.delta;
+        },
+        { axis, delta: segment.delta },
+      );
+    } else if (axis === 'x') {
+      await page.mouse.wheel(segment.delta, 0);
+    } else {
+      await page.mouse.wheel(0, segment.delta);
     }
   }
 }


### PR DESCRIPTION
## Summary

Lands `human.scroll()` — multi-segment scroll motion with a bell-curve velocity profile, mid-scroll micro-pauses, and personality-driven overshoot + correction. Scrolls work on the page or inside any scrollable container, on either axis, with `scrollIntoView`-style block alignment for element targets. Deterministic by seed, honest about its mechanism, and consistent with the other HumanJS primitives.

## What's shipping

**Core (`@humanjs/core`)**
- `planScroll(from, to, profile, rng, options)` — deterministic, axis-agnostic plan. Bell-curve velocity, mid-scroll pauses, optional overshoot + return saccade.
- `ScrollProfile` on every `Personality` — `careful`, `fast`, `distracted`, `precise` each get their own scroll-density / pause / overshoot defaults.
- New exported types: `ScrollSegment`, `PlanScrollOptions`. Plumbed through `blend()` and `resolvePersonality()`.

**Playwright adapter (`@humanjs/playwright`)**
- `human.scroll(target?, options?)` — returns `ScrollResult` (`{ from, to, distance, durationMs }`).
- Target shapes: `'natural'` / `'end'` / `'top'` / `string` (selector) / `Locator` / `{ by: n }` / `{ to: n }`.
- Options:
  - `axis: 'x' | 'y'` — defaults to `'y'`; flip to `'x'` for horizontal scroll
  - `within: string | Locator` — scroll inside a container (chat threads, modals, kanban boards)
  - `block: 'start' | 'center' | 'end' | 'nearest'` — `scrollIntoView`-style alignment
  - `overshoot`, `withPauses` — toggle individual humanization signals
- Page scrolls dispatch real `wheel` events (so page-level wheel handlers fire). Container scrolls advance `scrollLeft` / `scrollTop` directly — more reliable than wheel-routing into nested overflow elements.
- `speed: 'instant'` collapses everything to a single `scrollTo` call.

**Demos**
- `pnpm demo:scroll` — headed Chrome demo. Body is `200vw` wide; demo kicks off with horizontal-scroll-to-center, then a full vertical sequence (natural → `#pricing` → end → top → forced-overshoot to `#testimonials`).
- `installMouseHelper(page)` overlay shows the HumanJS cursor during the demo.

**Landing**
- `ScrollShowcase` section + `ScrollDemo` motion component. Bounded scrollable feed that section-steps through changelog-style cards using `planScroll` directly, with rAF interpolation for smooth motion. Personality picker; live stats for segments / pauses / overshoot fires.

**Docs**
- Playwright README has a complete Scroll section covering every target shape, axis, container, alignment, instant mode, and return type.

## Highlights

- **Axis-agnostic by construction.** The planner takes `from`/`to`/`profile`/`rng` and produces signed deltas — it doesn't care which axis. The executor decides whether to apply each segment via `page.mouse.wheel(0, delta)` (page-Y), `page.mouse.wheel(delta, 0)` (page-X), `el.scrollTop += delta` (container-Y), or `el.scrollLeft += delta` (container-X). Same code path for every combination.
- **Bell-curve velocity is the brand signature.** Real scroll wheels accelerate, peak, decelerate. Robotic scroll is one big jump. The planner emits ~30+ segments per scroll following a half-sine curve so the motion reads as deliberate physical movement, not a teleport.
- **Overshoot is honest, not theater.** `distracted` overshoots probabilistically (~25%) by ~25% of the distance, with a 500ms "wait, too far" pause before the correction. `precise` never overshoots. Same code path; profile decides.
- **Container scrolls bypass Playwright's flaky horizontal wheel routing.** Direct `scrollLeft`/`scrollTop` assignment is deterministic; wheel events into nested `overflow-x: auto` elements are not.
- **`block: 'nearest'`** completes the `scrollIntoView` parity — stay put if the target is already fully visible, otherwise scroll the minimum distance to bring it into view.

## Verification

- 237 tests pass (142 core + 95 playwright)
- `tsc --noEmit` clean on all three tsconfigs
- `biome check` clean, zero suppressions
- `pnpm -r build` clean

## Honest limits

- Page-level scroll fires real `wheel` events; container-scrolls use `scrollBy`-equivalent direct assignment, which means wheel-event handlers attached to the container itself won't fire. The brand promise (humanized cadence, pauses, overshoot) stays intact.
- Touch / swipe scroll for mobile humanization is out of scope for now.
- Lazy-loaded content that grows mid-scroll isn't tracked — the planner reads geometry once at start.

## Test plan

- [x] `pnpm demo:scroll` — body is 200vw, demo kicks off with a horizontal scroll to the center, then walks vertically through every section
- [x] `PERSONALITY=distracted pnpm demo:scroll` — overshoots fire visibly several times per loop
- [x] `pnpm dev` and visit the Reading / Scroll showcase sections — landing demo section-steps through the changelog feed and updates stats live
- [x] Switch personalities in the landing showcase — `distracted` overshoots, `precise` is glass-smooth