### PR TITLE
chore: scroll-pillar follow-ups (changesets, tests, examples polish)

### DIFF
--- a/.changeset/scroll-core.md
+++ b/.changeset/scroll-core.md
@@ -1,0 +1,16 @@
+---
+"@humanjs/core": minor
+---
+
+Add `planScroll()` — the deterministic, axis-agnostic scroll planner that turns a (`from`, `to`) request into a sequence of `ScrollSegment`s shaped by a `ScrollProfile` and a seeded `Rng`.
+
+The planner models real wheel motion: bell-curve velocity (sin(i/n × π) weights across segments), opt-in mid-scroll pauses, and an opt-in overshoot-and-correct phase where phase 1 goes past the target, the cursor "realizes" and pauses (~2.5× the configured pause), then phase 2 corrects back. Same seed produces identical segment sequences on every run and every platform — the math is pure, with no DOM and no `y`-axis bias in the names.
+
+`Personality.scroll` is now a stable, publicly-exported shape (`ScrollProfile`) controlling segments-per-Kpx, segment delay + jitter, pause probability + duration, and overshoot probability + ratio. All four built-in presets (`careful`, `fast`, `distracted`, `precise`) ship sensible scroll defaults — `distracted` overshoots aggressively, `precise` never overshoots, `careful` and `fast` sit in between.
+
+New public exports:
+
+- `planScroll(from, to, profile, rng, options?) → readonly ScrollSegment[]`
+- `ScrollProfile`, `ScrollSegment`, `PlanScrollOptions` types
+
+Adapters (`@humanjs/playwright` ships next; future `@humanjs/puppeteer` will follow) build the I/O layer on top of this — the planner itself is reusable across any browser-driver that can deliver wheel events or assign `scrollLeft`/`scrollTop`.

--- a/.changeset/scroll-playwright.md
+++ b/.changeset/scroll-playwright.md
@@ -1,0 +1,29 @@
+---
+"@humanjs/playwright": minor
+---
+
+Add `human.scroll(target?, options?)` — the scroll pillar, built on top of `planScroll` from `@humanjs/core`.
+
+```ts
+await human.scroll();                                     // 'natural': one viewport
+await human.scroll('top');                                // back to the top
+await human.scroll('end');                                // all the way down
+await human.scroll('#pricing');                           // selector
+await human.scroll(locator);                              // Locator
+await human.scroll({ by: 480 });                          // relative offset
+await human.scroll({ to: 1200 });                         // absolute position
+await human.scroll('#card', { axis: 'x' });               // horizontal
+await human.scroll('#row', { within: '.scroller' });      // inside a container
+await human.scroll('#hero', { block: 'nearest' });        // minimum scroll
+await human.scroll('#testimonials', { overshoot: true }); // force overshoot
+```
+
+Routes between window and container, X and Y axis. Window scrolls dispatch real `page.mouse.wheel()` events so page-level wheel listeners fire. Container scrolls assign `scrollLeft` / `scrollTop` directly because Playwright's wheel doesn't reliably route into nested overflow scrollers.
+
+`block` mirrors `Element.scrollIntoView({ block })`: `'start'` (default), `'center'`, `'end'`, and `'nearest'` — `'nearest'` does the minimum scroll, no-opping if the element is already fully visible along the chosen axis.
+
+Returns `ScrollResult` with `{ from, to, distance, durationMs }` so observers know where the scroll landed. Each scroll flows through the plugin pipeline as `{ type: 'scroll', params: { target } }`.
+
+`speed: 'instant'` bypasses the planner and uses Playwright's native scroll. In `human` and `fast` modes, scrolls are deterministic given a session seed.
+
+New public exports: `ScrollTarget`, `ScrollOptions`, `ScrollResult` (plus a re-export of `ScrollProfile` from `@humanjs/core`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,7 @@ Don't ship core packages without these:
 - Imports: use the short form for relative paths — `from './module'`, not `from './module/index.js'` or `from './module.js'`. Our `moduleResolution: "Bundler"` resolves both directory and file forms without explicit extensions, and tsup bundles everything for publishing so the source style doesn't affect output.
 - Conventional commits: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`.
 - One logical change per commit. No squash-bombs.
+- Demos using template-literal embedded HTML/CSS (e.g. `examples/*-demo.ts`) **must not use backticks inside their content**, even in code-reference comments. Backticks close the outer template literal — `esbuild` rejects this at runtime and `biome` lint doesn't catch it.
 
 ## Things to refuse — repeat for emphasis
 

--- a/examples/click-demo.ts
+++ b/examples/click-demo.ts
@@ -14,7 +14,7 @@
 
 import { createHuman, installMouseHelper } from '@humanjs/playwright';
 import { chromium } from 'playwright';
-import { parsePersonality } from './lib';
+import { parsePersonality, sleep } from './lib';
 
 const DEMO_HTML = /* html */ `
 <!doctype html>
@@ -195,7 +195,7 @@ async function main() {
 
     const human = await createHuman(page, {
       personality,
-      seed: 'demo-1',
+      seed: 'click-demo-1',
       initialMousePosition: cursorStart,
       plugins: [
         {
@@ -208,7 +208,7 @@ async function main() {
       ],
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 400));
+    await sleep(400);
 
     console.log(`Personality: ${personality}`);
     console.log(`Clicking ${TARGET_SEQUENCE.length} targets in sequence…\n`);
@@ -218,12 +218,12 @@ async function main() {
       // Cadence floor so the "clicked" visual stays perceptible across all
       // personalities — postActionMs adds on top for the slower ones. Matches
       // the same floor used by compare-demo.ts.
-      await new Promise((resolve) => setTimeout(resolve, 250));
+      await sleep(250);
     }
 
     console.log('\nDone. Browser will stay open for 5 seconds.');
     console.log('Tip: re-run with PERSONALITY=careful (or fast / precise) to compare.');
-    await new Promise((resolve) => setTimeout(resolve, 5000));
+    await sleep(5000);
   } finally {
     await browser.close();
   }

--- a/examples/compare-demo.ts
+++ b/examples/compare-demo.ts
@@ -24,7 +24,7 @@ import {
   resolvePersonality,
 } from '@humanjs/playwright';
 import { chromium } from 'playwright';
-import { parsePersonality } from './lib';
+import { parsePersonality, sleep } from './lib';
 
 const WINDOW_WIDTH = 1100;
 const WINDOW_HEIGHT = 750;
@@ -408,7 +408,7 @@ async function main() {
     // Installed AFTER setContent because setContent replaces the document.
     await installMouseHelper(page);
 
-    await new Promise((resolve) => setTimeout(resolve, 1200));
+    await sleep(1200);
 
     await page.evaluate(
       ({ left, right }) => {
@@ -429,7 +429,7 @@ async function main() {
     const maxDuration = Math.max(totalDurationA, totalDurationB);
     console.log(`Estimated runtime: ${Math.round(maxDuration / 1000)}s\n`);
 
-    await new Promise((resolve) => setTimeout(resolve, maxDuration + 5000));
+    await sleep(maxDuration + 5000);
   } finally {
     await browser.close();
   }

--- a/examples/lib.ts
+++ b/examples/lib.ts
@@ -34,3 +34,12 @@ export function parsePersonality(
   }
   return value as PresetName;
 }
+
+/**
+ * Awaitable sleep — used by every demo to space out actions so the headed
+ * browser has a beat between scripted steps. Kept here rather than inline so
+ * each demo's main flow reads as a sequence of intent, not setTimeout noise.
+ */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/examples/read-demo.ts
+++ b/examples/read-demo.ts
@@ -15,7 +15,7 @@
 
 import { createHuman, installMouseHelper } from '@humanjs/playwright';
 import { chromium } from 'playwright';
-import { parsePersonality } from './lib';
+import { parsePersonality, sleep } from './lib';
 
 const PASSAGE =
   "The cursor doesn't have to lie. It can take a real path, type at a real rhythm, and dwell where a person would dwell. That's the whole library.";
@@ -172,7 +172,7 @@ async function main() {
       ],
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await sleep(500);
 
     // `withMotion: true` walks a humanized cursor scan through each element's
     // bounding box as the dwell elapses — the third pillar (the pace) made
@@ -186,18 +186,18 @@ async function main() {
 
     // 1. Prose — defaults to kind 'prose'
     await human.read('.passage', { withMotion: true });
-    await new Promise((resolve) => setTimeout(resolve, 600));
+    await sleep(600);
 
     // 2. Code — auto-detected from <pre> tag, no explicit kind
     await human.read('.code-snippet', { withMotion: true });
-    await new Promise((resolve) => setTimeout(resolve, 600));
+    await sleep(600);
 
     // 3. Scan — explicit kind to skim a list
     await human.read('.scan-list', { kind: 'scan', withMotion: true });
 
     console.log('\nDone. Browser will stay open for 5 seconds.');
     console.log('Tip: re-run with PERSONALITY=fast (or precise / distracted) to compare.');
-    await new Promise((resolve) => setTimeout(resolve, 5000));
+    await sleep(5000);
   } finally {
     await browser.close();
   }

--- a/examples/scroll-demo.ts
+++ b/examples/scroll-demo.ts
@@ -15,7 +15,7 @@
 
 import { createHuman, installMouseHelper } from '@humanjs/playwright';
 import { chromium } from 'playwright';
-import { parsePersonality } from './lib';
+import { parsePersonality, sleep } from './lib';
 
 const SECTIONS = [
   { id: 'hero', title: 'Hero', accent: '#f5a55c' },
@@ -134,6 +134,9 @@ async function main() {
     const context = await browser.newContext({ viewport: { width: 1100, height: 820 } });
     const page = await context.newPage();
     await page.setContent(DEMO_HTML);
+    // Inject the HumanJS cursor overlay so synthetic mouse motion is visible
+    // in headed Chrome — `page.mouse.move()` doesn't render a system pointer.
+    // Installed AFTER setContent because setContent replaces the document.
     await installMouseHelper(page);
 
     console.log(`Personality: ${personality}\n`);
@@ -153,7 +156,7 @@ async function main() {
       ],
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 600));
+    await sleep(600);
 
     // 1. Horizontal scroll to the center of the 200vw-wide body. After
     // this lands, sections (which are also 200vw wide with content
@@ -162,24 +165,24 @@ async function main() {
       Math.floor((document.documentElement.scrollWidth - window.innerWidth) / 2),
     );
     await human.scroll({ to: halfwayX }, { axis: 'x' });
-    await new Promise((resolve) => setTimeout(resolve, 800));
+    await sleep(800);
 
     // 2. Natural one-viewport scroll — what a real reader does first.
     await human.scroll();
-    await new Promise((resolve) => setTimeout(resolve, 800));
+    await sleep(800);
 
     // 3. Jump to a specific section by selector.
     await human.scroll('#pricing', { overshoot: true });
-    await new Promise((resolve) => setTimeout(resolve, 800));
+    await sleep(800);
 
     // 4. Scroll to bottom — long-distance scroll exercises the bell-curve
     // velocity profile and mid-scroll pauses.
     await human.scroll('end');
-    await new Promise((resolve) => setTimeout(resolve, 800));
+    await sleep(800);
 
     // 5. Back to the top.
     await human.scroll('top');
-    await new Promise((resolve) => setTimeout(resolve, 800));
+    await sleep(800);
 
     // 6. Forced overshoot — for personalities that wouldn't normally do
     // one, opt in via the options object to see the correction behavior.
@@ -187,7 +190,7 @@ async function main() {
 
     console.log('\nDone. Browser will stay open for 5 seconds.');
     console.log('Tip: re-run with PERSONALITY=distracted to see lots of overshoot.');
-    await new Promise((resolve) => setTimeout(resolve, 5000));
+    await sleep(5000);
   } finally {
     await browser.close();
   }

--- a/examples/type-demo.ts
+++ b/examples/type-demo.ts
@@ -15,7 +15,7 @@
 
 import { createHuman, installMouseHelper } from '@humanjs/playwright';
 import { chromium } from 'playwright';
-import { parsePersonality } from './lib';
+import { parsePersonality, sleep } from './lib';
 
 // Brand-direct phrase that matches the rest of the HumanJS surface area:
 // three short sentences that describe what `human.type()` actually does.
@@ -194,7 +194,7 @@ async function main() {
     });
 
     // Give the page a beat to render before we focus + type.
-    await new Promise((resolve) => setTimeout(resolve, 600));
+    await sleep(600);
 
     await human.type('#field', PHRASE);
 
@@ -211,7 +211,7 @@ async function main() {
 
     console.log('\nDone. Browser will stay open for 5 seconds.');
     console.log('Tip: re-run with PERSONALITY=fast (or precise / distracted) to compare.');
-    await new Promise((resolve) => setTimeout(resolve, 5000));
+    await sleep(5000);
   } finally {
     await browser.close();
   }

--- a/packages/core/src/blend/blend.test.ts
+++ b/packages/core/src/blend/blend.test.ts
@@ -10,6 +10,7 @@ describe('blend', () => {
       expect(result.mouse.curvature).toBe(careful.mouse.curvature);
       expect(result.typing.baseDelayMs).toBe(careful.typing.baseDelayMs);
       expect(result.reading.wpm).toBe(careful.reading.wpm);
+      expect(result.scroll.segmentsPerKpx).toBe(careful.scroll.segmentsPerKpx);
       expect(result.dwell.preClickMs).toBe(careful.dwell.preClickMs);
     });
 
@@ -19,6 +20,7 @@ describe('blend', () => {
       expect(result.mouse.curvature).toBe(distracted.mouse.curvature);
       expect(result.typing.baseDelayMs).toBe(distracted.typing.baseDelayMs);
       expect(result.reading.wpm).toBe(distracted.reading.wpm);
+      expect(result.scroll.segmentsPerKpx).toBe(distracted.scroll.segmentsPerKpx);
       expect(result.dwell.preClickMs).toBe(distracted.dwell.preClickMs);
     });
 
@@ -63,6 +65,10 @@ describe('blend', () => {
         expected(careful.typing.thinkPauseMeanMs, distracted.typing.thinkPauseMeanMs),
         10,
       );
+      expect(result.scroll.pauseMs).toBeCloseTo(
+        expected(careful.scroll.pauseMs, distracted.scroll.pauseMs),
+        10,
+      );
     });
 
     it('keeps probabilities in [0, 1] when both inputs are', () => {
@@ -73,6 +79,8 @@ describe('blend', () => {
         result.typing.typoProbability,
         result.typing.typoCorrectionProbability,
         result.typing.thinkPauseProbability,
+        result.scroll.pauseProbability,
+        result.scroll.overshootProbability,
       ];
       for (const p of probabilities) {
         expect(p).toBeGreaterThanOrEqual(0);

--- a/packages/core/src/resolve/resolve.test.ts
+++ b/packages/core/src/resolve/resolve.test.ts
@@ -56,7 +56,18 @@ describe('resolvePersonality', () => {
       });
       expect(result.typing).toEqual(careful.typing);
       expect(result.reading).toEqual(careful.reading);
+      expect(result.scroll).toEqual(careful.scroll);
       expect(result.dwell).toEqual(careful.dwell);
+    });
+
+    it('merges a partial scroll override without losing the rest', () => {
+      const result = resolvePersonality({
+        extends: 'careful',
+        scroll: { overshootProbability: 0.5 },
+      });
+      expect(result.scroll.overshootProbability).toBe(0.5);
+      expect(result.scroll.segmentsPerKpx).toBe(careful.scroll.segmentsPerKpx);
+      expect(result.scroll.pauseMs).toBe(careful.scroll.pauseMs);
     });
 
     it('merges multiple facets simultaneously', () => {
@@ -65,10 +76,12 @@ describe('resolvePersonality', () => {
         mouse: { curvature: 0.9 },
         typing: { typoProbability: 0.5 },
         reading: { wpm: 100 },
+        scroll: { overshootProbability: 0.5 },
       });
       expect(result.mouse.curvature).toBe(0.9);
       expect(result.typing.typoProbability).toBe(0.5);
       expect(result.reading.wpm).toBe(100);
+      expect(result.scroll.overshootProbability).toBe(0.5);
       expect(result.dwell).toEqual(precise.dwell);
     });
 


### PR DESCRIPTION
## Summary

Four follow-ups that close gaps from #10 and tighten the examples directory:

- **Changesets for the scroll pillar** — `@humanjs/core` and `@humanjs/playwright` each get a minor bump so the scroll feature can actually publish. These should have been in #10; adding them as a follow-up so the next `pnpm changeset version` picks them up.
- **Test coverage for the scroll profile in `blend()` and `resolvePersonality()`** — both functions were extended in #10 to merge/interpolate the new `scroll` field, but their test files still only asserted on `mouse`, `typing`, `reading`, and `dwell`. Extends the existing patterns so `scroll` gets parity coverage: ratio-bounds, lerp, probability-bounds, partial-override, multi-facet merge.
- **`sleep(ms)` helper in `examples/lib.ts`** — replaces 17 inline `await new Promise(r => setTimeout(r, X))` repetitions across all five demos. Each demo's `main()` flow now reads as a sequence of intent (`sleep(800); human.scroll(...); sleep(800)`) instead of timer boilerplate. Also brings `click-demo`'s seed naming and `scroll-demo`'s `installMouseHelper` rationale comment into line with the other demos.
- **CLAUDE.md convention: no backticks inside template-literal demo content** — codifies a hygiene rule discovered during the scroll work. Backticks inside embedded HTML/CSS (even in code-reference comments) close the outer template literal; `esbuild` rejects at runtime and `biome` doesn't catch it. No existing demos violate the rule today — this is forward-looking insurance.

## Test plan

- [x] `pnpm -w -r test` — 238/238 pass (143 core + 95 playwright)
- [x] `pnpm -w lint` — biome clean
- [x] `pnpm exec tsc --noEmit` clean in `packages/core`, `packages/playwright`, `apps/web`
- [x] `pnpm exec changeset status` reports `@humanjs/core` minor + `@humanjs/playwright` minor pending
- [x] `pnpm demo:click` / `demo:type` / `demo:read` / `demo:scroll` / `demo:compare` all run end-to-end with the new `sleep()` helper

