### PR TITLE
feat(playwright): human.type clicks the target first

### DIFF
--- a/.changeset/type-clicks-first.md
+++ b/.changeset/type-clicks-first.md
@@ -1,0 +1,23 @@
+---
+"@humanjs/playwright": minor
+---
+
+`human.type()` now clicks the target before typing in humanized speed modes (`'human'` and `'fast'`).
+
+Previously, `human.type(selector, value)` called `locator.focus()` directly — a programmatic focus with no cursor motion. A real user doesn't teleport-focus a field; they move their cursor to it and click. The new behavior moves the cursor along a Bezier path to the input, clicks it (which triggers a real focus event via the click), then types.
+
+```ts
+await human.type('#email', 'demo@humanjs.dev');
+//  → cursor moves to #email
+//  → click event fires (focuses the input naturally)
+//  → typing proceeds with realistic per-key rhythm
+```
+
+The implicit click is a sub-step of the type action — **not** its own timeline event. `human.type()` still emits exactly one `'type'` event, the same way `human.click()` already does an implicit hover-before-click motion without emitting a separate `'hover'` event. This keeps timelines compact and the `toHumanJS()` exporter round-trip clean: `[type]` → `human.type(s, v)` → click+type on replay.
+
+**Skipped when:**
+
+- `speed: 'instant'` — the whole point of instant mode is to bypass humanization for fast CI runs.
+- The value is empty — no typing to set up, no click needed.
+
+**Migration**: code that called `human.type(selector, value)` and depended on the cursor staying put will see the cursor move to the input. To opt out of cursor motion entirely for a typing action, use `speed: 'instant'` (bypasses all humanization) or call `page.locator(selector).fill(value)` directly — `@humanjs/playwright` re-exports the Playwright primitives, so no second import is needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ const human = await createHuman(page, {
 
 await human.goto(url);
 await human.click(selector);              // hover, micro-move, click
-await human.type(selector, value);        // realistic typing rhythm
+await human.type(selector, value);        // click, then realistic typing rhythm
 await human.paste(selector, value);       // Cmd-V style (no per-char timing)
 await human.read(text);                   // dwell based on word count
 await human.scroll('natural');

--- a/packages/playwright/src/index.test.ts
+++ b/packages/playwright/src/index.test.ts
@@ -89,6 +89,7 @@ interface MockPage {
   page: Page;
   locator: MockLocator;
   pressedKeys: string[];
+  mouseClicks: Array<{ x: number; y: number }>;
 }
 
 /**
@@ -119,8 +120,16 @@ function makeKeyboardMockPage(): MockPage {
   const locator: MockLocator = {
     focus: vi.fn().mockResolvedValue(undefined),
     pressSequentially: vi.fn().mockResolvedValue(undefined),
+    // human.type() now drives an implicit click before typing (so the cursor
+    // moves to the input the way a real user does), which calls
+    // locator.boundingBox() + page.mouse.{move,click}. The fake box is 40×40
+    // at (100, 100) — wide enough that the click-point picker's Gaussian
+    // sampler stays inside its bounds (a tiny box can produce points just
+    // outside the rect, which is fine in production but noisy in tests).
+    boundingBox: vi.fn().mockResolvedValue({ x: 100, y: 100, width: 40, height: 40 }),
   };
   const pressedKeys: string[] = [];
+  const mouseClicks: Array<{ x: number; y: number }> = [];
   const page = {
     goto: vi.fn().mockResolvedValue(null),
     locator: vi.fn().mockReturnValue(locator as unknown as Locator),
@@ -130,8 +139,15 @@ function makeKeyboardMockPage(): MockPage {
         return Promise.resolve();
       }),
     },
+    mouse: {
+      move: vi.fn().mockResolvedValue(undefined),
+      click: vi.fn().mockImplementation((x: number, y: number) => {
+        mouseClicks.push({ x, y });
+        return Promise.resolve();
+      }),
+    },
   } as unknown as Page;
-  return { page, locator, pressedKeys };
+  return { page, locator, pressedKeys, mouseClicks };
 }
 
 /**
@@ -535,21 +551,60 @@ describe('createHuman', () => {
     });
 
     it('handles an empty value as a no-op without focusing', async () => {
-      const { page, locator, pressedKeys } = makeKeyboardMockPage();
+      const { page, locator, pressedKeys, mouseClicks } = makeKeyboardMockPage();
       const human = await createHuman(page);
       await human.type('input', '');
       expect(locator.focus).not.toHaveBeenCalled();
       expect(pressedKeys).toEqual([]);
+      // Empty value also skips the implicit click — no setup needed when
+      // there's nothing to type.
+      expect(mouseClicks).toEqual([]);
+    });
+
+    it('clicks the target before typing in human mode (mouse-led focus, not programmatic)', async () => {
+      // A real user moves their cursor to the input and clicks it; they don't
+      // teleport-focus a field. human.type() drives an implicit click before
+      // delegating to the keyboard executor — same pattern as click's
+      // built-in hover-before-click motion.
+      const { page, mouseClicks } = makeKeyboardMockPage();
+      const human = await createHuman(page);
+      await human.type('input', 'abc');
+      expect(mouseClicks).toHaveLength(1);
+      // Click point is Gaussian-picked near the box center. Asserting the
+      // click landed inside (or very near) the mocked box at (100, 100, 40, 40)
+      // proves the click was driven by the bounding-box read, not by some
+      // other code path that would have used the origin or current mouse pos.
+      const click = mouseClicks[0] ?? { x: 0, y: 0 };
+      expect(click.x).toBeGreaterThan(95);
+      expect(click.x).toBeLessThan(145);
+      expect(click.y).toBeGreaterThan(95);
+      expect(click.y).toBeLessThan(145);
+    });
+
+    it('does NOT emit a separate click timeline event for the implicit click', async () => {
+      // The click is a sub-step of the type action — same schema treatment as
+      // click's hover motion (no 'hover' event). Plugin observers see exactly
+      // one event per human.type() call, regardless of the mouse motion that
+      // happened underneath.
+      const beforeAction = vi.fn();
+      const { page } = makeKeyboardMockPage();
+      const human = await createHuman(page, { plugins: [{ name: 'p', beforeAction }] });
+      await human.type('input', 'abc');
+      const types = beforeAction.mock.calls.map((c) => (c[0] as { type: string }).type);
+      expect(types).toEqual(['type']);
     });
 
     it("uses pressSequentially with delay 0 in 'instant' mode", async () => {
-      const { page, locator, pressedKeys } = makeKeyboardMockPage();
+      const { page, locator, pressedKeys, mouseClicks } = makeKeyboardMockPage();
       const human = await createHuman(page, { speed: 'instant' });
       await human.type('input', 'abc');
       expect(locator.pressSequentially).toHaveBeenCalledWith('abc', { delay: 0 });
       // Per-key press should never be invoked in instant mode.
       expect(pressedKeys).toEqual([]);
       expect(locator.focus).not.toHaveBeenCalled();
+      // Instant mode also skips the implicit click — the whole point of
+      // 'instant' is to bypass humanization for fast CI runs.
+      expect(mouseClicks).toEqual([]);
     });
 
     it("emits a 'type' action with target description and length to plugins", async () => {

--- a/packages/playwright/src/index.test.ts
+++ b/packages/playwright/src/index.test.ts
@@ -550,7 +550,7 @@ describe('createHuman', () => {
       expect(pressedKeys).not.toContain('Backspace');
     });
 
-    it('handles an empty value as a no-op without focusing', async () => {
+    it('handles an empty value as a no-op (no click, no focus, no keys)', async () => {
       const { page, locator, pressedKeys, mouseClicks } = makeKeyboardMockPage();
       const human = await createHuman(page);
       await human.type('input', '');

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -395,6 +395,26 @@ export async function createHuman(page: Page, options: CreateHumanOptions = {}):
       await performAction(
         { type: 'type', params: { target: description, length: value.length } },
         async () => {
+          // Implicit click before typing: a real user moves the cursor to
+          // the input and clicks it; they don't teleport-focus a field. The
+          // click is a sub-step of the type action — not its own timeline
+          // event (executeClick called directly, bypassing performAction),
+          // same pattern as click's built-in hover-before-click motion.
+          //
+          // Skipped in instant mode (the whole point of which is to bypass
+          // humanization) and for empty values (no typing to set up).
+          if (speed !== 'instant' && value.length > 0) {
+            await executeClick(target, {
+              page,
+              personality,
+              rng,
+              speed,
+              getMousePosition: () => lastMousePosition,
+              setMousePosition: (point) => {
+                lastMousePosition = point;
+              },
+            });
+          }
           await executeType(target, value, { page, personality, rng, speed });
         },
       );


### PR DESCRIPTION
## Summary

`human.type()` now moves the cursor to the target and clicks it before typing, instead of using a programmatic `locator.focus()`. A real user doesn't teleport-focus a field — they move their cursor to it, click, then type. This was the last "robotic" tell hiding in HumanJS's most common humanized action.

```ts
await human.type('#email', 'demo@humanjs.dev');
//  → cursor moves along a Bezier path to #email
//  → click event fires (focuses the input naturally)
//  → typing proceeds with realistic per-key rhythm
```

How it's wired 

The implicit click is a sub-step of the type action — not its own timeline event. human.type() still emits exactly one 'type' event, the same way human.click() already does an implicit hover-before-click motion without emitting a separate 'hover' event. This keeps timelines compact and the upcoming toHumanJS() exporter round-trip clean: [type] event → human.type(s, v) code → click+type on replay, no double-click bug.

Skipped when

- speed: 'instant' — the whole point of instant mode is to bypass humanization for fast CI runs.
- The value is empty — no typing to set up.

Migration

Code that called human.type(selector, value) and depended on the cursor staying put will see the cursor move to the input. To opt out of cursor motion for a typing action: use speed: 'instant' (bypasses all humanization) or call page.locator(selector).fill(value) directly — @humanjs/playwright re-exports the Playwright primitives, so no second import is needed.

Quality

- 123 unit tests pass (was 121, +2 new tests for the click-first behavior and the no-separate-event contract).
- 10 integration tests still pass.
- Lint + typecheck clean.
- Three consecutive pnpm test runs locally — no flakes.

Test plan

- [x] pnpm test — all unit tests pass
- [x] pnpm test:integration — chromium-based integration tests pass
- [x] pnpm lint && pnpm typecheck — clean
- [x] pnpm demo:type — local headed run shows the cursor moving to the input and clicking before keys