### PR TITLE
feat(core): personality-driven click placement (MouseProfile.clickSpread)

### DIFF
--- a/.changeset/personality-click-spread.md
+++ b/.changeset/personality-click-spread.md
@@ -1,0 +1,21 @@
+---
+"@humanjs/core": minor
+"@humanjs/playwright": patch
+---
+
+Personality-driven click placement: `MouseProfile` now includes `clickSpread`, controlling how far click points scatter from the target's center.
+
+Previously, every personality used a hardcoded `1/8` spread inside `pickClickPoint`. `careful` and `distracted` clicked buttons identically — broke the personality contract harder than the typing rhythm or scroll cadence differences mattered. Now each preset has its own value:
+
+| Personality | `clickSpread` | What it looks like |
+|---|---|---|
+| `precise` | `0.10` | Tightest cluster near center — expert-user aim. |
+| `careful` | `0.125` | Slight scatter — same as the previous global default, no behavior change for default users. |
+| `fast` | `0.15` | Noticeable scatter — Fitts's Law: speed trades against precision. |
+| `distracted` | `0.17` | Loosest of the four — eye-drift clicks. |
+
+The math: σ = `box.dimension × clickSpread`, separately for X and Y. The result is clamped to the box, so values above ~0.5 start hitting edges constantly (and the presets stay well below that).
+
+`blend()` interpolates `clickSpread` linearly, same as every other personality knob.
+
+**Migration**: custom personalities built with `extends` continue to inherit the preset's value automatically. Personalities built from scratch (no `extends`) need to set `mouse.clickSpread` explicitly — the field is required. A safe default is `0.125` (the previous global behavior).

--- a/packages/core/src/blend/blend.test.ts
+++ b/packages/core/src/blend/blend.test.ts
@@ -61,6 +61,14 @@ describe('blend', () => {
         expected(careful.mouse.travelTimeMs, distracted.mouse.travelTimeMs),
         10,
       );
+      // clickSpread joined the lerp list with the personality-driven click
+      // placement change — guards against the field silently dropping out
+      // of blend's lerp object (TypeScript would catch a missing field but
+      // not an accidental `personalityA.mouse.clickSpread` typo).
+      expect(result.mouse.clickSpread).toBeCloseTo(
+        expected(careful.mouse.clickSpread, distracted.mouse.clickSpread),
+        10,
+      );
       expect(result.typing.thinkPauseMeanMs).toBeCloseTo(
         expected(careful.typing.thinkPauseMeanMs, distracted.typing.thinkPauseMeanMs),
         10,

--- a/packages/core/src/blend/index.ts
+++ b/packages/core/src/blend/index.ts
@@ -54,6 +54,7 @@ export function blend(a: PersonalityConfig, b: PersonalityConfig, ratio: number)
         personalityB.mouse.misclickProbability,
         t,
       ),
+      clickSpread: lerp(personalityA.mouse.clickSpread, personalityB.mouse.clickSpread, t),
     },
     typing: {
       baseDelayMs: lerp(personalityA.typing.baseDelayMs, personalityB.typing.baseDelayMs, t),

--- a/packages/core/src/personality.ts
+++ b/packages/core/src/personality.ts
@@ -40,6 +40,15 @@ export interface MouseProfile {
   readonly overshootProbability: number;
   /** Probability of clicking slightly off-target and correcting (0..1). */
   readonly misclickProbability: number;
+  /**
+   * Click-point spread inside the target's bounding box, as a fraction of
+   * each dimension. The click point is a 2D Gaussian centered on the box,
+   * with standard deviation `dimension × clickSpread`. Higher = looser
+   * cluster (more variation from center); lower = tighter cluster.
+   * Typical range: `0.10` (precise) to `0.20` (distracted). Clamped to the
+   * box, so values above `~0.5` start hitting the edges constantly.
+   */
+  readonly clickSpread: number;
 }
 
 /** Parameters that shape keystroke timing and typing errors. */

--- a/packages/core/src/presets/careful.ts
+++ b/packages/core/src/presets/careful.ts
@@ -13,6 +13,10 @@ export const careful: Personality = {
     travelTimeJitter: 0.15,
     overshootProbability: 0.05,
     misclickProbability: 0.01,
+    // 0.125 (≈ 1/8) is the previous global default — careful users aim
+    // deliberately. Two-thirds of clicks land within the central quarter
+    // of the element.
+    clickSpread: 0.125,
   },
   typing: {
     baseDelayMs: 140,

--- a/packages/core/src/presets/distracted.ts
+++ b/packages/core/src/presets/distracted.ts
@@ -13,6 +13,13 @@ export const distracted: Personality = {
     travelTimeJitter: 0.35,
     overshootProbability: 0.15,
     misclickProbability: 0.05,
+    // 0.17 — the loosest of the four presets. A distracted user clicks
+    // where their eye drifted, not exactly where they intended; clicks
+    // scatter noticeably from center. Tuned down from 0.20: that wider
+    // value occasionally placed clicks within a few px of the button edge
+    // — statistically realistic (5% Gaussian tail), but in a demo where
+    // viewers see one click at a time it reads as "almost missed."
+    clickSpread: 0.17,
   },
   typing: {
     baseDelayMs: 180,

--- a/packages/core/src/presets/fast.ts
+++ b/packages/core/src/presets/fast.ts
@@ -18,6 +18,10 @@ export const fast: Personality = {
     travelTimeJitter: 0.1,
     overshootProbability: 0.03,
     misclickProbability: 0.005,
+    // 0.15 — Fitts's Law: speed trades against precision. Faster users
+    // aim less carefully and scatter more across the target, but stay
+    // visibly inside the safe interior — no edge near-misses.
+    clickSpread: 0.15,
   },
   typing: {
     baseDelayMs: 130,

--- a/packages/core/src/presets/precise.ts
+++ b/packages/core/src/presets/precise.ts
@@ -13,6 +13,10 @@ export const precise: Personality = {
     travelTimeJitter: 0.05,
     overshootProbability: 0.005,
     misclickProbability: 0.001,
+    // 0.10 — tightest cluster of the four presets. An "expert user" aims
+    // for the center and lands there; ~two-thirds of clicks fall within
+    // the central 20% of the element.
+    clickSpread: 0.1,
   },
   typing: {
     baseDelayMs: 110,

--- a/packages/playwright/src/mouse/index.ts
+++ b/packages/playwright/src/mouse/index.ts
@@ -62,7 +62,7 @@ export async function executeClick(
     );
   }
 
-  const targetPoint = pickClickPoint(box, ctx.rng);
+  const targetPoint = pickClickPoint(box, ctx.rng, ctx.personality.mouse.clickSpread);
   const startPoint = ctx.getMousePosition();
 
   const rawPath = bezierPath(startPoint, targetPoint, ctx.rng, {
@@ -115,13 +115,17 @@ interface BoundingBox {
  * majority of clicks land near the visual center but with natural spread.
  * Clamped to never fall outside the element.
  */
-function pickClickPoint(box: BoundingBox, rng: Rng): Point {
+function pickClickPoint(box: BoundingBox, rng: Rng, clickSpread: number): Point {
   const cx = box.x + box.width / 2;
   const cy = box.y + box.height / 2;
-  // Spread is 1/8 of each dimension — most clicks fall within the middle
-  // half of the element, but we never click dead-center deterministically.
-  const x = clamp(cx + rng.nextGaussian(0, box.width / 8), box.x, box.x + box.width);
-  const y = clamp(cy + rng.nextGaussian(0, box.height / 8), box.y, box.y + box.height);
+  // Standard deviation scales with each dimension separately, so wide
+  // elements scatter horizontally and tall elements scatter vertically.
+  // The clickSpread fraction comes from the personality — precise users
+  // cluster near center, distracted users scatter across the target.
+  const sigmaX = box.width * clickSpread;
+  const sigmaY = box.height * clickSpread;
+  const x = clamp(cx + rng.nextGaussian(0, sigmaX), box.x, box.x + box.width);
+  const y = clamp(cy + rng.nextGaussian(0, sigmaY), box.y, box.y + box.height);
   return { x, y };
 }
 


### PR DESCRIPTION
## Summary

Adds a `clickSpread` field to `MouseProfile` and gives each built-in personality its own value. Previously every personality used a hardcoded `1/8` spread inside `pickClickPoint` — so `careful` and `distracted` clicked buttons identically, which broke the personality contract more visibly than the typing-rhythm or scroll-cadence differences mattered.

## Per-personality values

| Personality | `clickSpread` | What it looks like |
|---|---|---|
| `precise` | `0.10` | Tightest cluster near center — expert-user aim |
| `careful` | `0.125` | Slight scatter — same as the previous global default, no behavior change for default users |
| `fast` | `0.15` | Noticeable scatter — Fitts's Law: speed trades against precision |
| `distracted` | `0.17` | Loosest of the four — eye-drift clicks, but visibly inside the safe interior |

## How it's wired

- `MouseProfile.clickSpread: number` — new required field on the public `Personality` shape, documented with a TSdoc block explaining the contract.
- `pickClickPoint(box, rng, clickSpread)` in `@humanjs/playwright` now takes the spread as a parameter; the math is unchanged in shape — σ = `box.dimension × clickSpread`, separately for X and Y, clamped to the box.
- `executeClick` passes `ctx.personality.mouse.clickSpread` through to the picker, so click placement varies per session.
- `blend()` interpolates `clickSpread` linearly, same as every other numeric personality knob.

## Tuning note

Initial draft used `0.20` for distracted and `0.165` for fast. Visual testing surfaced occasional near-edge clicks at those values — statistically realistic (the 5% Gaussian tail) but read as "almost missed" in single-click demos. Tightened to `0.17` and `0.15` so all four personalities stay inside the visibly-safe interior while preserving the differential.

## Migration

- Custom personalities built with `extends: 'careful'` (or any other preset) continue to inherit the preset's `clickSpread` automatically via `resolvePersonality`'s `{ ...base.mouse, ...config.mouse }` merge.
- Personalities built from scratch (no `extends`) need to set `mouse.clickSpread` explicitly — the field is required on `MouseProfile`. A safe default is `0.125` (matches the previous global behavior).

## Quality

- 143 core tests pass + 123 playwright tests pass — `MouseProfile`'s type change flows through every fixture without breakage.
- Added one regression assertion to `blend.test.ts`'s "lerps each numeric field independently" spot-check — guards against `clickSpread` silently dropping out of `blend`'s output object on future refactors (TypeScript would catch a missing field but not an accidental `personalityA.mouse.clickSpread` typo).
- Lint + typecheck clean.

## Test plan

- [x] `pnpm test` — all unit tests pass
- [x] `pnpm test:integration` — chromium-based integration tests pass
- [x] `pnpm lint && pnpm typecheck` — clean
- [x] `pnpm demo:click PERSONALITY=precise` — tight cluster near center
- [x] `pnpm demo:click PERSONALITY=distracted` — visible scatter across the target, no edge clipping
- [x] Compare side-by-side: `precise` vs `distracted` demos should now visibly differ in click placement on the same target