### PR TITLE
feat(playwright): six new Human primitives + typed Shortcut union

### DIFF
--- a/.changeset/missing-primitives.md
+++ b/.changeset/missing-primitives.md
@@ -27,6 +27,15 @@ await human.shortcut('Enter');                   // single key
 - **`human.paste(target, value)`** — drives an implicit click to focus (same pattern as `type`), then dumps the value via `page.keyboard.insertText`. The Cmd-V semantic — fast, no per-character rhythm. The implicit click is a sub-step of the paste action, same as `type`'s.
 - **`human.shortcut(chord)`** — keyboard chord dispatcher with platform-aware `Mod` token. Detailed modifier rules in the JSDoc; new `'shortcut'` action type emitted to plugins with the original chord string in `params`. Does **not** move the cursor — keyboard shortcuts dispatch against focus, not cursor position. Compose with `click`/`hover`/`move` when you need both.
 
+  **Typed chord parameter.** `chord` is a `Shortcut` — a template-literal union of every (canonical) modifier × key combination up to two modifiers. IDEs autocomplete valid chords as you type (`'Mod+S'`, `'Cmd+Shift+P'`, `'Ctrl+Alt+Delete'`), and **invalid modifiers are caught at compile time**: `'Mosd+S'` and `'Hyper+S'` are TypeScript errors, not runtime errors. The escape hatch lives on the key portion only — uncommon keys (`'Mod+BracketLeft'`, `'Mod+NumpadAdd'`, locale-specific keys) still typecheck under a known modifier. 3+ modifier chords (`'Ctrl+Shift+Alt+X'`) typecheck through the same key-side escape hatch; the cap at two literal modifiers is a TypeScript size-of-union constraint, not a runtime limit. Lowercase modifiers (`'mod+s'`) and bare uncommon keys without a modifier (`'BracketLeft'` alone) are TS errors too — runtime still accepts them, but the type steers toward canonical form for codebase consistency.
+
+## New public types
+
+- **`Shortcut`** — the typed chord union used by `human.shortcut(chord)`. Importable for users typing chord strings in their own helpers / config.
+- **`ShortcutModifier`** — the canonical-case modifier names (`'Mod'`, `'Cmd'`, `'Ctrl'`, `'Alt'`, `'Shift'`, …). Plus aliases (`'Command'`, `'Control'`, `'Option'`, `'Win'`, `'Super'`, `'CmdOrCtrl'`).
+- **`ShortcutKey`** — the canonical bare-key set (`'A'`–`'Z'`, `'0'`–`'9'`, `'F1'`–`'F12'`, `'ArrowUp'`, `'Enter'`, etc.). Uncommon keys go through the `Shortcut` union's key-side escape hatch.
+- **`MouseTarget`** — `Locator | string | Point`. Used by `human.move()` and `human.drag()`. Was internal-only before this release; now exported so users can type local variables to that shape without a deep import.
+
 ## Modifier semantics for `shortcut`
 
 | Token | Resolves to | Notes |

--- a/.changeset/missing-primitives.md
+++ b/.changeset/missing-primitives.md
@@ -1,0 +1,51 @@
+---
+"@humanjs/playwright": minor
+---
+
+Implements the five primitives that CLAUDE.md's public API shape advertised but the codebase didn't yet ship — closing the documentation/reality gap on `@humanjs/playwright`'s Human surface:
+
+```ts
+await human.rightClick('#card');                 // context menu
+await human.hover('button[aria-label="Help"]');  // hover without clicking
+await human.drag('#card-1', '#slot-3');          // selector → selector
+await human.drag('#slider', { x: 400, y: 220 }); // selector → point
+await human.paste('#code-editor', longString);   // Cmd-V style, no per-key timing
+await human.shortcut('Mod+S');                   // cross-platform Save
+await human.shortcut('Cmd+Shift+P');             // literal Meta+Shift+P
+await human.shortcut('Control+C');               // literal Ctrl+C (works on Mac too)
+await human.shortcut('Enter');                   // single key
+```
+
+## What's new
+
+- **`human.rightClick(target)`** — same Bezier path + hover-dwell as `click()`, dispatches with `button: 'right'`.
+- **`human.hover(target)`** — moves the cursor along a humanized path and settles, no click. Useful for hover-triggered UI and cursor positioning.
+- **`human.drag(from, to)`** — humanized motion to `from`, mouse-down, second humanized path to `to` with the button held, mouse-up. Both endpoints accept `Locator | string | Point` — the `Point` form is essential for canvas/SVG/slider drags where the destination isn't a DOM element.
+- **`human.paste(target, value)`** — drives an implicit click to focus (same pattern as `type`), then dumps the value via `page.keyboard.insertText`. The Cmd-V semantic — fast, no per-character rhythm. The implicit click is a sub-step of the paste action, same as `type`'s.
+- **`human.shortcut(chord)`** — keyboard chord dispatcher with platform-aware `Mod` token. Detailed modifier rules in the JSDoc; new `'shortcut'` action type emitted to plugins with the original chord string in `params`.
+
+## Modifier semantics for `shortcut`
+
+| Token | Resolves to | Notes |
+|---|---|---|
+| `Mod`, `CmdOrCtrl` | `Meta` on macOS, `Control` elsewhere | The right token for cross-platform app shortcuts |
+| `Cmd`, `Command`, `Meta`, `Win`, `Super` | `Meta` keycode | Literal — does **not** auto-translate to Control. Same physical key on every OS |
+| `Ctrl`, `Control` | `Control` keycode | Literal — stays Control on every platform, so Mac-specific things like terminal `Ctrl+C` still work |
+| `Alt`, `Option`, `Opt` | `Alt` keycode | Literal |
+| `Shift` | `Shift` keycode | Literal |
+
+Case-insensitive on both modifiers and key names. Invalid modifiers throw with a useful error message listing the valid options.
+
+## Internal refactor
+
+`executeClick` now accepts an optional `{ button }` option (used by both `human.click` and `human.rightClick`); previously the button was hardcoded. The mouse executor extracts a `moveToTarget` helper shared between click and hover, and a `resolveDragTarget` helper that handles selector/Locator/Point endpoints. The Human factory introduces a `mouseCtx()` accessor so every mouse primitive reads from the same `lastMousePosition` closure — successive actions chain off where the cursor actually was, including across the new primitives.
+
+## Quality
+
+- 161 playwright unit tests (was 123) — 38 new tests covering the five primitives, their event emission, instant-mode bypass paths, and edge cases.
+- `resolveChord` is exported for the test suite; 17 of those new tests are pure-function coverage of the parser (platform mapping, aliases, case-insensitivity, error paths).
+- 10 integration tests still green. Lint + typecheck clean.
+
+## Migration
+
+None — all five methods are net-new on the `Human` interface. No existing behavior changes. The `executeClick` signature gained an optional third argument (`ClickOptions`); the previous two-argument call sites continue to work unchanged.

--- a/.changeset/missing-primitives.md
+++ b/.changeset/missing-primitives.md
@@ -2,11 +2,13 @@
 "@humanjs/playwright": minor
 ---
 
-Implements the five primitives that CLAUDE.md's public API shape advertised but the codebase didn't yet ship — closing the documentation/reality gap on `@humanjs/playwright`'s Human surface:
+Implements the primitives that CLAUDE.md's public API shape advertised but the codebase didn't yet ship — closing the documentation/reality gap on `@humanjs/playwright`'s Human surface — plus a new `move()` primitive for pure positional cursor motion:
 
 ```ts
 await human.rightClick('#card');                 // context menu
 await human.hover('button[aria-label="Help"]');  // hover without clicking
+await human.move({ x: 600, y: 400 });            // pure positioning (canvas, dead space, cinematic beats)
+await human.move('#anchor');                     // or to an element, no settle dwell
 await human.drag('#card-1', '#slot-3');          // selector → selector
 await human.drag('#slider', { x: 400, y: 220 }); // selector → point
 await human.paste('#code-editor', longString);   // Cmd-V style, no per-key timing
@@ -19,10 +21,11 @@ await human.shortcut('Enter');                   // single key
 ## What's new
 
 - **`human.rightClick(target)`** — same Bezier path + hover-dwell as `click()`, dispatches with `button: 'right'`.
-- **`human.hover(target)`** — moves the cursor along a humanized path and settles, no click. Useful for hover-triggered UI and cursor positioning.
+- **`human.hover(target)`** — moves the cursor along a humanized path and settles, no click. Includes a post-arrival dwell to let hover-state UI fire (tooltips, dropdowns). Element-bound.
+- **`human.move(target)`** — pure positional cursor motion. Accepts `Locator | string | Point`. No settle dwell, no element interaction. Distinct from `hover`: `hover` is "hover an element so hover UI fires," `move` is "place the cursor here." Use `move` for canvas/SVG/dead-space positioning, pre-shortcut placement, or cinematic beats.
 - **`human.drag(from, to)`** — humanized motion to `from`, mouse-down, second humanized path to `to` with the button held, mouse-up. Both endpoints accept `Locator | string | Point` — the `Point` form is essential for canvas/SVG/slider drags where the destination isn't a DOM element.
 - **`human.paste(target, value)`** — drives an implicit click to focus (same pattern as `type`), then dumps the value via `page.keyboard.insertText`. The Cmd-V semantic — fast, no per-character rhythm. The implicit click is a sub-step of the paste action, same as `type`'s.
-- **`human.shortcut(chord)`** — keyboard chord dispatcher with platform-aware `Mod` token. Detailed modifier rules in the JSDoc; new `'shortcut'` action type emitted to plugins with the original chord string in `params`.
+- **`human.shortcut(chord)`** — keyboard chord dispatcher with platform-aware `Mod` token. Detailed modifier rules in the JSDoc; new `'shortcut'` action type emitted to plugins with the original chord string in `params`. Does **not** move the cursor — keyboard shortcuts dispatch against focus, not cursor position. Compose with `click`/`hover`/`move` when you need both.
 
 ## Modifier semantics for `shortcut`
 
@@ -38,11 +41,11 @@ Case-insensitive on both modifiers and key names. Invalid modifiers throw with a
 
 ## Internal refactor
 
-`executeClick` now accepts an optional `{ button }` option (used by both `human.click` and `human.rightClick`); previously the button was hardcoded. The mouse executor extracts a `moveToTarget` helper shared between click and hover, and a `resolveDragTarget` helper that handles selector/Locator/Point endpoints. The Human factory introduces a `mouseCtx()` accessor so every mouse primitive reads from the same `lastMousePosition` closure — successive actions chain off where the cursor actually was, including across the new primitives.
+`executeClick` now accepts an optional `{ button }` option (used by both `human.click` and `human.rightClick`); previously the button was hardcoded. The mouse executor extracts a `moveToTarget` helper shared between click and hover, and a `resolveTargetPoint` helper (renamed from the internal `resolveDragTarget`) that handles selector/Locator/Point endpoints for both `drag` and `move`. The Human factory introduces a `mouseCtx()` accessor so every mouse primitive reads from the same `lastMousePosition` closure — successive actions chain off where the cursor actually was, including across the new primitives.
 
 ## Quality
 
-- 161 playwright unit tests (was 123) — 38 new tests covering the five primitives, their event emission, instant-mode bypass paths, and edge cases.
+- 167 playwright unit tests (was 123) — 44 new tests covering the six primitives, their event emission, instant-mode bypass paths, and edge cases.
 - `resolveChord` is exported for the test suite; 17 of those new tests are pure-function coverage of the parser (platform mapping, aliases, case-insensitivity, error paths).
 - 10 integration tests still green. Lint + typecheck clean.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,13 +73,15 @@ const human = await createHuman(page, {
 
 await human.goto(url);
 await human.click(selector);              // hover, micro-move, click
+await human.rightClick(selector);         // context-menu click
+await human.hover(selector);              // hover without clicking
+await human.move(target);                 // selector | Locator | Point — positional, no settle dwell
+await human.drag(from, to);               // each endpoint: selector | Locator | Point
 await human.type(selector, value);        // click, then realistic typing rhythm
 await human.paste(selector, value);       // Cmd-V style (no per-char timing)
 await human.read(text);                   // dwell based on word count
 await human.scroll('natural');
-await human.shortcut('Cmd+S');
-await human.drag(from, to);
-await human.rightClick(selector);
+await human.shortcut('Mod+S');            // 'Mod' auto-maps: Meta on Mac, Control elsewhere
 
 const rec = await human.record(async () => { /* actions */ });
 await rec.toVideo('out.mp4');                // shipped

--- a/examples/package.json
+++ b/examples/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "click": "tsx click-demo.ts",
     "compare": "tsx compare-demo.ts",
+    "primitives": "tsx primitives-demo.ts",
     "read": "tsx read-demo.ts",
     "record": "tsx record-demo.ts",
     "record-manual": "tsx record-manual-demo.ts",

--- a/examples/primitives-demo.ts
+++ b/examples/primitives-demo.ts
@@ -1,0 +1,517 @@
+/**
+ * HumanJS primitives demo — exercises the five "second-tier" Human methods
+ * in sequence on one page so a viewer can see them all work visually:
+ *
+ *   1. hover       — cursor moves to a target, tooltip appears via :hover
+ *   2. rightClick  — context-menu click, custom menu appears
+ *   3. drag        — selector → selector card move, then selector → point slider
+ *   4. paste       — long string lands in a textarea via insertText (no rhythm)
+ *   5. shortcut    — Mod+S triggers a Save indicator
+ *
+ * Run with:
+ *   pnpm demo:primitives
+ *
+ * Compare personalities by re-running with:
+ *   PERSONALITY=careful     pnpm demo:primitives   (default)
+ *   PERSONALITY=fast        pnpm demo:primitives
+ *   PERSONALITY=precise     pnpm demo:primitives
+ *   PERSONALITY=distracted  pnpm demo:primitives
+ */
+
+import { chromium, createHuman, installMouseHelper } from '@humanjs/playwright';
+import { parsePersonality } from './lib';
+
+// Embedded HTML: every section is interactive in some visible way so the
+// primitive's effect is observable when the headed browser runs through it.
+// NOTE per CLAUDE.md: no nested backticks anywhere in this template literal.
+const DEMO_HTML = /* html */ `
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>HumanJS primitives demo</title>
+    <style>
+      :root { color-scheme: dark; }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at 30% 20%, #1a1a2e, #0a0a0a);
+        color: #f0ece5;
+        font-family: -apple-system, system-ui, sans-serif;
+        padding: 48px 32px;
+      }
+      .wrap { max-width: 920px; margin: 0 auto; display: grid; gap: 28px; }
+      .header { text-align: center; margin-bottom: 16px; }
+      .header h1 {
+        margin: 0 0 6px;
+        font-size: 32px;
+        font-weight: 600;
+        letter-spacing: -0.02em;
+      }
+      .header p { margin: 0; color: #888; font-size: 14px; }
+
+      .block {
+        padding: 24px 28px;
+        background: #0c0b0a;
+        border: 1px solid #2a2a2a;
+        border-radius: 14px;
+      }
+      .block .label {
+        font-family: ui-monospace, SF Mono, monospace;
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.22em;
+        color: #555;
+        margin-bottom: 14px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .label .num {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        background: #f5a55c;
+        color: #050505;
+        font-weight: 700;
+        font-family: -apple-system, system-ui, sans-serif;
+        font-size: 11px;
+        letter-spacing: 0;
+      }
+
+      /* 1. Hover */
+      .tooltip-host {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        background: #1a1a1a;
+        border: 1px solid #2a2a2a;
+        color: #f0ece5;
+        font-size: 22px;
+        font-weight: 600;
+        cursor: help;
+      }
+      .tooltip-host .tip {
+        position: absolute;
+        bottom: calc(100% + 12px);
+        left: 50%;
+        transform: translateX(-50%) translateY(8px);
+        opacity: 0;
+        white-space: nowrap;
+        background: #050505;
+        color: #f5a55c;
+        border: 1px solid #f5a55c33;
+        padding: 8px 14px;
+        border-radius: 8px;
+        font-family: ui-monospace, SF Mono, monospace;
+        font-size: 13px;
+        pointer-events: none;
+        transition: all 0.18s ease;
+      }
+      .tooltip-host:hover .tip {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
+      }
+
+      /* 2. Right-click */
+      .ctx-host {
+        position: relative;
+        display: inline-block;
+        padding: 12px 22px;
+        font-family: ui-monospace, SF Mono, monospace;
+        font-size: 14px;
+        color: #f0ece5;
+        background: #1a1a1a;
+        border: 1px solid #2a2a2a;
+        border-radius: 10px;
+        cursor: context-menu;
+      }
+      .ctx-menu {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        margin-top: 6px;
+        min-width: 180px;
+        background: #050505;
+        border: 1px solid #2a2a2a;
+        border-radius: 10px;
+        padding: 6px;
+        opacity: 0;
+        transform: translateY(-4px);
+        pointer-events: none;
+        transition: all 0.16s ease;
+        z-index: 10;
+      }
+      .ctx-menu.visible {
+        opacity: 1;
+        transform: translateY(0);
+      }
+      .ctx-menu .item {
+        padding: 8px 12px;
+        font-family: ui-monospace, SF Mono, monospace;
+        font-size: 12px;
+        color: #b8b3a9;
+        border-radius: 6px;
+      }
+      .ctx-menu .item:hover { background: #1a1a1a; color: #f5a55c; }
+
+      /* 3. Drag */
+      .drag-row {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        margin-top: 8px;
+      }
+      .drag-slot {
+        flex: 1;
+        min-height: 84px;
+        border: 1px dashed #2a2a2a;
+        border-radius: 12px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: ui-monospace, SF Mono, monospace;
+        font-size: 11px;
+        color: #555;
+        text-transform: uppercase;
+        letter-spacing: 0.2em;
+        transition: border-color 0.2s ease, background 0.2s ease;
+      }
+      .drag-slot.has-card { border-color: #f5a55c66; background: #f5a55c11; color: #f5a55c; }
+      .drag-card {
+        padding: 18px 26px;
+        background: linear-gradient(180deg, #334155, #1e293b);
+        border: 1px solid #475569;
+        border-radius: 10px;
+        color: #fff;
+        font-family: ui-monospace, SF Mono, monospace;
+        font-size: 13px;
+        cursor: grab;
+        user-select: none;
+      }
+      .drag-card.dragging { opacity: 0.6; cursor: grabbing; }
+
+      .slider-row {
+        position: relative;
+        margin-top: 18px;
+        height: 36px;
+      }
+      .slider-track {
+        position: absolute;
+        top: 50%;
+        left: 0;
+        right: 0;
+        height: 4px;
+        transform: translateY(-50%);
+        background: #2a2a2a;
+        border-radius: 2px;
+      }
+      .slider-fill {
+        position: absolute;
+        top: 50%;
+        left: 0;
+        height: 4px;
+        transform: translateY(-50%);
+        background: #f5a55c;
+        border-radius: 2px;
+        width: 8%;
+        transition: width 0.08s linear;
+      }
+      .slider-thumb {
+        position: absolute;
+        top: 50%;
+        width: 22px;
+        height: 22px;
+        transform: translate(-50%, -50%);
+        background: #f5a55c;
+        border: 2px solid #050505;
+        border-radius: 50%;
+        left: 8%;
+        cursor: grab;
+        transition: left 0.08s linear;
+      }
+
+      /* 4. Paste */
+      .paste-box {
+        width: 100%;
+        min-height: 100px;
+        padding: 14px 16px;
+        font-family: ui-monospace, SF Mono, monospace;
+        font-size: 13px;
+        color: #f5a55c;
+        background: #050505;
+        border: 1px solid #2a2a2a;
+        border-radius: 8px;
+        outline: none;
+        resize: none;
+        line-height: 1.55;
+      }
+      .paste-box:focus { border-color: rgba(245, 165, 92, 0.4); }
+
+      /* 5. Shortcut */
+      .save-host {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+      }
+      .save-host .doc {
+        flex: 1;
+        padding: 14px 16px;
+        font-family: ui-monospace, SF Mono, monospace;
+        font-size: 13px;
+        color: #b8b3a9;
+        background: #050505;
+        border: 1px solid #2a2a2a;
+        border-radius: 8px;
+      }
+      .save-indicator {
+        padding: 10px 18px;
+        font-family: ui-monospace, SF Mono, monospace;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        color: #555;
+        background: #1a1a1a;
+        border: 1px solid #2a2a2a;
+        border-radius: 8px;
+        transition: all 0.3s ease;
+      }
+      .save-indicator.saved {
+        color: #050505;
+        background: #f5a55c;
+        border-color: #f5a55c;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <div class="header">
+        <h1>HumanJS primitives</h1>
+        <p>Five things a real user does that scripted automation usually fakes.</p>
+      </div>
+
+      <!-- 1. Hover -->
+      <div class="block">
+        <div class="label"><span class="num">1</span> hover</div>
+        <div class="tooltip-host" id="tooltip-target">
+          ?
+          <div class="tip">Hover-only UI works because the cursor really moves here.</div>
+        </div>
+      </div>
+
+      <!-- 2. Right-click -->
+      <div class="block">
+        <div class="label"><span class="num">2</span> rightClick</div>
+        <div class="ctx-host" id="ctx-target">
+          card-001.pdf
+          <div class="ctx-menu" id="ctx-menu">
+            <div class="item">Open</div>
+            <div class="item">Open in new tab</div>
+            <div class="item">Rename</div>
+            <div class="item">Delete</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 3. Drag -->
+      <div class="block">
+        <div class="label"><span class="num">3</span> drag</div>
+        <div class="drag-row">
+          <div class="drag-slot has-card" id="slot-from">
+            <div class="drag-card" id="drag-card">card-A</div>
+          </div>
+          <div style="color: #444">→</div>
+          <div class="drag-slot" id="slot-to">drop here</div>
+        </div>
+        <div class="slider-row">
+          <div class="slider-track"></div>
+          <div class="slider-fill" id="slider-fill"></div>
+          <div class="slider-thumb" id="slider-thumb"></div>
+        </div>
+      </div>
+
+      <!-- 4. Paste -->
+      <div class="block">
+        <div class="label"><span class="num">4</span> paste</div>
+        <textarea class="paste-box" id="paste-target" placeholder="long content goes here…" spellcheck="false"></textarea>
+      </div>
+
+      <!-- 5. Shortcut -->
+      <div class="block">
+        <div class="label"><span class="num">5</span> shortcut</div>
+        <div class="save-host">
+          <div class="doc">document — type to edit</div>
+          <div class="save-indicator" id="save-indicator">unsaved</div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      // --- 1. hover --- (handled purely by CSS :hover on .tooltip-host)
+
+      // --- 2. rightClick --- custom context menu, suppresses the OS one
+      const ctxMenu = document.getElementById('ctx-menu');
+      const ctxHost = document.getElementById('ctx-target');
+      ctxHost.addEventListener('contextmenu', (e) => {
+        e.preventDefault();
+        ctxMenu.classList.add('visible');
+        setTimeout(() => ctxMenu.classList.remove('visible'), 2200);
+      });
+
+      // --- 3. drag --- mousedown/move/up on the card, visual feedback on drop
+      const card = document.getElementById('drag-card');
+      const slotFrom = document.getElementById('slot-from');
+      const slotTo = document.getElementById('slot-to');
+      let dragging = false;
+      let dragOriginX = 0;
+      let dragOriginY = 0;
+      let dragStartX = 0;
+      let dragStartY = 0;
+      card.addEventListener('mousedown', (e) => {
+        dragging = true;
+        const r = card.getBoundingClientRect();
+        dragOriginX = r.left;
+        dragOriginY = r.top;
+        dragStartX = e.clientX;
+        dragStartY = e.clientY;
+        card.classList.add('dragging');
+        card.style.position = 'fixed';
+        card.style.left = dragOriginX + 'px';
+        card.style.top = dragOriginY + 'px';
+        card.style.zIndex = '100';
+      });
+      window.addEventListener('mousemove', (e) => {
+        if (!dragging) return;
+        card.style.left = (dragOriginX + (e.clientX - dragStartX)) + 'px';
+        card.style.top = (dragOriginY + (e.clientY - dragStartY)) + 'px';
+      });
+      window.addEventListener('mouseup', (e) => {
+        if (!dragging) return;
+        dragging = false;
+        card.classList.remove('dragging');
+        const toRect = slotTo.getBoundingClientRect();
+        const landed =
+          e.clientX >= toRect.left && e.clientX <= toRect.right &&
+          e.clientY >= toRect.top && e.clientY <= toRect.bottom;
+        if (landed) {
+          slotFrom.classList.remove('has-card');
+          slotFrom.textContent = 'empty';
+          slotTo.classList.add('has-card');
+          slotTo.appendChild(card);
+          card.style.position = 'static';
+          card.style.left = card.style.top = card.style.zIndex = '';
+        } else {
+          // Snap back
+          card.style.position = 'static';
+          card.style.left = card.style.top = card.style.zIndex = '';
+        }
+      });
+
+      // Slider — separate drag target so we can demo the Point variant
+      const thumb = document.getElementById('slider-thumb');
+      const fill = document.getElementById('slider-fill');
+      let sliderDragging = false;
+      thumb.addEventListener('mousedown', () => { sliderDragging = true; });
+      window.addEventListener('mousemove', (e) => {
+        if (!sliderDragging) return;
+        const trackRect = thumb.parentElement.getBoundingClientRect();
+        const rel = (e.clientX - trackRect.left) / trackRect.width;
+        const clamped = Math.max(0, Math.min(1, rel));
+        thumb.style.left = (clamped * 100) + '%';
+        fill.style.width = (clamped * 100) + '%';
+      });
+      window.addEventListener('mouseup', () => { sliderDragging = false; });
+
+      // --- 5. shortcut --- Mod+S handler flashes the save indicator
+      const saveIndicator = document.getElementById('save-indicator');
+      window.addEventListener('keydown', (e) => {
+        const isSaveCombo = (e.metaKey || e.ctrlKey) && (e.key === 's' || e.key === 'S');
+        if (isSaveCombo) {
+          e.preventDefault();
+          saveIndicator.classList.add('saved');
+          saveIndicator.textContent = 'saved ✓';
+          setTimeout(() => {
+            saveIndicator.classList.remove('saved');
+            saveIndicator.textContent = 'unsaved';
+          }, 1800);
+        }
+      });
+    </script>
+  </body>
+</html>
+`;
+
+const LONG_PASTE_VALUE = [
+  '// const config = await loadConfig();',
+  "// if (!config) throw new Error('config missing');",
+  '// connectToService(config.url, config.token);',
+  '// — every paste a human does happens in one shot, never per-character.',
+].join('\n');
+
+async function main() {
+  const personality = parsePersonality(process.env.PERSONALITY, 'careful', 'PERSONALITY');
+
+  console.log(`Personality: ${personality}`);
+  console.log('Demoing: hover → rightClick → drag → paste → shortcut\n');
+
+  const browser = await chromium.launch({ headless: false });
+  try {
+    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+    const page = await context.newPage();
+    await page.setContent(DEMO_HTML);
+    await installMouseHelper(context);
+
+    const human = await createHuman(page, { personality, seed: 'primitives-demo-1' });
+    await human.sleep(800);
+
+    // 1. Hover — cursor moves to the "?" icon, tooltip reveals via CSS.
+    console.log('1. hover → tooltip target');
+    await human.hover('#tooltip-target');
+    await human.sleep(1200);
+
+    // 2. Right-click — custom context menu opens on contextmenu event.
+    console.log('2. rightClick → context menu');
+    await human.rightClick('#ctx-target');
+    await human.sleep(1500);
+
+    // 3. Drag — card from one slot to another. Selector → selector first,
+    // then a slider drag using a Point coordinate to demo the Point variant.
+    console.log('3. drag → card to slot, then slider thumb to point');
+    await human.drag('#drag-card', '#slot-to');
+    await human.sleep(900);
+    await human.drag('#slider-thumb', { x: 800, y: 685 });
+    await human.sleep(900);
+
+    // 4. Paste — long string lands in the textarea instantly via insertText.
+    console.log('4. paste → multi-line block into textarea');
+    await human.paste('#paste-target', LONG_PASTE_VALUE);
+    await human.sleep(900);
+
+    // 5. Shortcut — Mod+S triggers the page's save handler, indicator flashes.
+    // The textarea is still focused from the paste above, so the keystroke
+    // dispatches on a real element with focus.
+    console.log('5. shortcut → Mod+S triggers Save');
+    await human.shortcut('Mod+S');
+    await human.sleep(2500);
+
+    console.log('\nDone. Browser will stay open for 5 seconds.');
+    console.log('Tip: re-run with PERSONALITY=distracted to see the drag scatter more.');
+    await human.sleep(5000);
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/primitives-demo.ts
+++ b/examples/primitives-demo.ts
@@ -1,12 +1,13 @@
 /**
- * HumanJS primitives demo — exercises the five "second-tier" Human methods
+ * HumanJS primitives demo — exercises the six "second-tier" Human methods
  * in sequence on one page so a viewer can see them all work visually:
  *
  *   1. hover       — cursor moves to a target, tooltip appears via :hover
  *   2. rightClick  — context-menu click, custom menu appears
  *   3. drag        — selector → selector card move, then selector → point slider
  *   4. paste       — long string lands in a textarea via insertText (no rhythm)
- *   5. shortcut    — Mod+S triggers a Save indicator
+ *   5. move        — pure positional motion to a Point, no element under cursor
+ *   6. shortcut    — Mod+S triggers a Save indicator (cursor position irrelevant)
  *
  * Run with:
  *   pnpm demo:primitives
@@ -461,7 +462,7 @@ async function main() {
   const personality = parsePersonality(process.env.PERSONALITY, 'careful', 'PERSONALITY');
 
   console.log(`Personality: ${personality}`);
-  console.log('Demoing: hover → rightClick → drag → paste → shortcut\n');
+  console.log('Demoing: hover → rightClick → drag → paste → move → shortcut\n');
 
   const browser = await chromium.launch({ headless: false });
   try {
@@ -496,10 +497,19 @@ async function main() {
     await human.paste('#paste-target', LONG_PASTE_VALUE);
     await human.sleep(900);
 
-    // 5. Shortcut — Mod+S triggers the page's save handler, indicator flashes.
-    // The textarea is still focused from the paste above, so the keystroke
-    // dispatches on a real element with focus.
-    console.log('5. shortcut → Mod+S triggers Save');
+    // 5. Move — pure positional motion to a Point with no element under it.
+    // Parks the cursor in dead space between sections, showing that move()
+    // doesn't need a DOM target. The textarea is still focused — the next
+    // step proves shortcuts dispatch against focus, not cursor position.
+    console.log('5. move → cursor to a point in dead space');
+    await human.move({ x: 460, y: 540 });
+    await human.sleep(1000);
+
+    // 6. Shortcut — Mod+S triggers the page's save handler, indicator flashes.
+    // Cursor is parked in dead space from step 5; the shortcut still fires
+    // against the focused textarea. Cursor position is irrelevant to which
+    // element receives a keyboard shortcut — only focus matters.
+    console.log('6. shortcut → Mod+S triggers Save (against the focused textarea)');
     await human.shortcut('Mod+S');
     await human.sleep(2500);
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "prepare": "lefthook install",
     "demo:click": "turbo run build --filter=@humanjs/playwright... && pnpm --filter @humanjs/examples click",
     "demo:compare": "turbo run build --filter=@humanjs/playwright... && pnpm --filter @humanjs/examples compare",
+    "demo:primitives": "turbo run build --filter=@humanjs/playwright... && pnpm --filter @humanjs/examples primitives",
     "demo:read": "turbo run build --filter=@humanjs/playwright... && pnpm --filter @humanjs/examples read",
     "demo:record": "turbo run build --filter=@humanjs/recorder... && pnpm --filter @humanjs/examples record",
     "demo:record-manual": "turbo run build --filter=@humanjs/playwright... && pnpm --filter @humanjs/examples record-manual",

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -63,6 +63,7 @@ export type KnownActionType =
   | 'drag'
   | 'goto'
   | 'hover'
+  | 'move'
   | 'paste'
   | 'read'
   | 'rightClick'

--- a/packages/playwright/src/index.test.ts
+++ b/packages/playwright/src/index.test.ts
@@ -1,7 +1,7 @@
 import type { HumanPlugin } from '@humanjs/core';
 import type { Locator, Page } from 'playwright';
 import { describe, expect, it, vi } from 'vitest';
-import { createHuman } from './index';
+import { createHuman, type Shortcut } from './index';
 
 interface MockLocator {
   focus: ReturnType<typeof vi.fn>;
@@ -766,7 +766,11 @@ describe('createHuman', () => {
       // so the type guard is the first line of defense. The cast exercises
       // the runtime fallback — important because real callers might pass
       // strings from config / user input that TS can't validate at compile.
-      await expect(human.shortcut('Hyper+S' as never)).rejects.toThrow(/Invalid shortcut modifier/);
+      // Cast to `Shortcut` (not `any` / `never`) — same pattern as the
+      // `asChord` helper in `keyboard.test.ts`.
+      await expect(human.shortcut('Hyper+S' as Shortcut)).rejects.toThrow(
+        /Invalid shortcut modifier/,
+      );
       expect(pressedKeys).toEqual([]);
     });
   });

--- a/packages/playwright/src/index.test.ts
+++ b/packages/playwright/src/index.test.ts
@@ -838,6 +838,67 @@ describe('createHuman', () => {
     });
   });
 
+  describe('move', () => {
+    it('moves the cursor along a path without clicking', async () => {
+      const { page, mouseClicks, mouseButtonEvents } = makeKeyboardMockPage();
+      const human = await createHuman(page);
+      await human.move('#target');
+      // Pure positioning: no click, no button events.
+      expect(mouseClicks).toEqual([]);
+      expect(mouseButtonEvents).toEqual([]);
+      // Mouse.move was called multiple times (path walk).
+      const movesCalled = (page.mouse.move as ReturnType<typeof vi.fn>).mock.calls.length;
+      expect(movesCalled).toBeGreaterThan(0);
+    });
+
+    it('accepts a raw Point and skips DOM resolution', async () => {
+      const { page } = makeKeyboardMockPage();
+      const human = await createHuman(page);
+      await human.move({ x: 600, y: 400 });
+      // Point input → no locator() lookup, no boundingBox() call.
+      expect(page.locator).not.toHaveBeenCalled();
+    });
+
+    it('accepts a selector and resolves to the element', async () => {
+      const { page, locator } = makeKeyboardMockPage();
+      const human = await createHuman(page);
+      await human.move('#target');
+      expect(page.locator).toHaveBeenCalledWith('#target');
+      expect(locator.boundingBox).toHaveBeenCalled();
+    });
+
+    it("emits a 'move' action with the resolved target description to plugins", async () => {
+      const beforeAction = vi.fn();
+      const { page } = makeKeyboardMockPage();
+      const human = await createHuman(page, { plugins: [{ name: 'p', beforeAction }] });
+      await human.move({ x: 400, y: 220 });
+      expect(beforeAction).toHaveBeenCalledWith({
+        type: 'move',
+        params: { target: 'point(400, 220)' },
+      });
+    });
+
+    it('does NOT emit a hover event (move is distinct from hover)', async () => {
+      const beforeAction = vi.fn();
+      const { page } = makeKeyboardMockPage();
+      const human = await createHuman(page, { plugins: [{ name: 'p', beforeAction }] });
+      await human.move('#target');
+      const types = beforeAction.mock.calls.map((c) => (c[0] as { type: string }).type);
+      expect(types).toEqual(['move']);
+      expect(types).not.toContain('hover');
+    });
+
+    it('in instant mode, dispatches one mouse.move at the resolved coordinates', async () => {
+      const { page } = makeKeyboardMockPage();
+      const human = await createHuman(page, { speed: 'instant' });
+      await human.move({ x: 250, y: 100 });
+      // Instant mode = single move, no path walk.
+      const moves = (page.mouse.move as ReturnType<typeof vi.fn>).mock.calls;
+      expect(moves).toHaveLength(1);
+      expect(moves[0]).toEqual([250, 100]);
+    });
+  });
+
   describe('drag', () => {
     it('dispatches mouse.down then mouse.up around the motion', async () => {
       const { page, mouseButtonEvents } = makeKeyboardMockPage();

--- a/packages/playwright/src/index.test.ts
+++ b/packages/playwright/src/index.test.ts
@@ -762,7 +762,11 @@ describe('createHuman', () => {
     it('throws on an invalid modifier and never dispatches', async () => {
       const { page, pressedKeys } = makeKeyboardMockPage();
       const human = await createHuman(page);
-      await expect(human.shortcut('Hyper+S')).rejects.toThrow(/Invalid shortcut modifier/);
+      // `'Hyper+S'` is a TS error too (Hyper isn't a `ShortcutModifier`),
+      // so the type guard is the first line of defense. The cast exercises
+      // the runtime fallback — important because real callers might pass
+      // strings from config / user input that TS can't validate at compile.
+      await expect(human.shortcut('Hyper+S' as never)).rejects.toThrow(/Invalid shortcut modifier/);
       expect(pressedKeys).toEqual([]);
     });
   });

--- a/packages/playwright/src/index.test.ts
+++ b/packages/playwright/src/index.test.ts
@@ -10,6 +10,7 @@ interface MockLocator {
   evaluate?: ReturnType<typeof vi.fn>;
   scrollIntoViewIfNeeded?: ReturnType<typeof vi.fn>;
   boundingBox?: ReturnType<typeof vi.fn>;
+  click?: ReturnType<typeof vi.fn>;
 }
 
 /**
@@ -89,7 +90,9 @@ interface MockPage {
   page: Page;
   locator: MockLocator;
   pressedKeys: string[];
-  mouseClicks: Array<{ x: number; y: number }>;
+  insertedText: string[];
+  mouseClicks: Array<{ x: number; y: number; button?: string }>;
+  mouseButtonEvents: Array<'down' | 'up'>;
 }
 
 /**
@@ -120,16 +123,16 @@ function makeKeyboardMockPage(): MockPage {
   const locator: MockLocator = {
     focus: vi.fn().mockResolvedValue(undefined),
     pressSequentially: vi.fn().mockResolvedValue(undefined),
-    // human.type() now drives an implicit click before typing (so the cursor
-    // moves to the input the way a real user does), which calls
-    // locator.boundingBox() + page.mouse.{move,click}. The fake box is 40×40
-    // at (100, 100) — wide enough that the click-point picker's Gaussian
-    // sampler stays inside its bounds (a tiny box can produce points just
-    // outside the rect, which is fine in production but noisy in tests).
+    // The implicit click in human.type() / human.paste() needs a bounding
+    // box; hover/rightClick/drag use it too. 40×40 at (100, 100) is wide
+    // enough that the Gaussian click-picker stays inside the rect.
     boundingBox: vi.fn().mockResolvedValue({ x: 100, y: 100, width: 40, height: 40 }),
+    click: vi.fn().mockResolvedValue(undefined),
   };
   const pressedKeys: string[] = [];
-  const mouseClicks: Array<{ x: number; y: number }> = [];
+  const insertedText: string[] = [];
+  const mouseClicks: Array<{ x: number; y: number; button?: string }> = [];
+  const mouseButtonEvents: Array<'down' | 'up'> = [];
   const page = {
     goto: vi.fn().mockResolvedValue(null),
     locator: vi.fn().mockReturnValue(locator as unknown as Locator),
@@ -138,16 +141,28 @@ function makeKeyboardMockPage(): MockPage {
         pressedKeys.push(key);
         return Promise.resolve();
       }),
+      insertText: vi.fn().mockImplementation((text: string) => {
+        insertedText.push(text);
+        return Promise.resolve();
+      }),
     },
     mouse: {
       move: vi.fn().mockResolvedValue(undefined),
-      click: vi.fn().mockImplementation((x: number, y: number) => {
-        mouseClicks.push({ x, y });
+      click: vi.fn().mockImplementation((x: number, y: number, opts?: { button?: string }) => {
+        mouseClicks.push({ x, y, button: opts?.button });
+        return Promise.resolve();
+      }),
+      down: vi.fn().mockImplementation(() => {
+        mouseButtonEvents.push('down');
+        return Promise.resolve();
+      }),
+      up: vi.fn().mockImplementation(() => {
+        mouseButtonEvents.push('up');
         return Promise.resolve();
       }),
     },
   } as unknown as Page;
-  return { page, locator, pressedKeys, mouseClicks };
+  return { page, locator, pressedKeys, insertedText, mouseClicks, mouseButtonEvents };
 }
 
 /**
@@ -656,6 +671,223 @@ describe('createHuman', () => {
       const action = beforeAction.mock.calls[0]?.[0];
       expect(action.params).not.toHaveProperty('value');
       expect(JSON.stringify(action.params)).not.toContain('sup3r-secret');
+    });
+  });
+
+  describe('paste', () => {
+    it('inserts the full value via keyboard.insertText (no per-key timing)', async () => {
+      const { page, insertedText, pressedKeys } = makeKeyboardMockPage();
+      const human = await createHuman(page);
+      await human.paste('input', 'long-pasted-value');
+      expect(insertedText).toEqual(['long-pasted-value']);
+      // Critical: paste must NOT use the per-key path. If pressedKeys had
+      // entries, we'd be doing typing-rhythm work for a paste operation.
+      expect(pressedKeys).toEqual([]);
+    });
+
+    it('clicks the target before pasting in human mode (same as type)', async () => {
+      const { page, mouseClicks } = makeKeyboardMockPage();
+      const human = await createHuman(page);
+      await human.paste('input', 'abc');
+      // The implicit click happens for the same reason type() does it: a
+      // real user clicks the field before pasting.
+      expect(mouseClicks).toHaveLength(1);
+    });
+
+    it('skips the implicit click in instant mode', async () => {
+      const { page, mouseClicks, insertedText } = makeKeyboardMockPage();
+      const human = await createHuman(page, { speed: 'instant' });
+      await human.paste('input', 'abc');
+      expect(mouseClicks).toEqual([]);
+      // The value still lands — instant mode bypasses humanization, not the
+      // primitive itself.
+      expect(insertedText).toEqual(['abc']);
+    });
+
+    it('treats an empty value as a no-op (no click, no insertText, no focus)', async () => {
+      const { page, locator, mouseClicks, insertedText } = makeKeyboardMockPage();
+      const human = await createHuman(page);
+      await human.paste('input', '');
+      expect(mouseClicks).toEqual([]);
+      expect(insertedText).toEqual([]);
+      expect(locator.focus).not.toHaveBeenCalled();
+    });
+
+    it('does NOT echo the pasted value into action params (privacy)', async () => {
+      const beforeAction = vi.fn();
+      const { page } = makeKeyboardMockPage();
+      const human = await createHuman(page, { plugins: [{ name: 'p', beforeAction }] });
+      await human.paste('input', 'pasted-token-12345');
+      const action = beforeAction.mock.calls[0]?.[0];
+      expect(action.params).not.toHaveProperty('value');
+      expect(JSON.stringify(action.params)).not.toContain('pasted-token-12345');
+    });
+  });
+
+  describe('shortcut', () => {
+    it('dispatches the resolved chord via page.keyboard.press', async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      try {
+        const { page, pressedKeys } = makeKeyboardMockPage();
+        const human = await createHuman(page);
+        await human.shortcut('Mod+S');
+        expect(pressedKeys).toEqual(['Meta+S']);
+      } finally {
+        Object.defineProperty(process, 'platform', {
+          value: originalPlatform,
+          configurable: true,
+        });
+      }
+    });
+
+    it('dispatches single-key shortcuts (no modifier)', async () => {
+      const { page, pressedKeys } = makeKeyboardMockPage();
+      const human = await createHuman(page);
+      await human.shortcut('Enter');
+      expect(pressedKeys).toEqual(['Enter']);
+    });
+
+    it("emits a 'shortcut' action with the original chord to plugins", async () => {
+      const beforeAction = vi.fn();
+      const { page } = makeKeyboardMockPage();
+      const human = await createHuman(page, { plugins: [{ name: 'p', beforeAction }] });
+      await human.shortcut('Cmd+Shift+P');
+      expect(beforeAction).toHaveBeenCalledWith({
+        type: 'shortcut',
+        params: { chord: 'Cmd+Shift+P' },
+      });
+    });
+
+    it('throws on an invalid modifier and never dispatches', async () => {
+      const { page, pressedKeys } = makeKeyboardMockPage();
+      const human = await createHuman(page);
+      await expect(human.shortcut('Hyper+S')).rejects.toThrow(/Invalid shortcut modifier/);
+      expect(pressedKeys).toEqual([]);
+    });
+  });
+
+  describe('rightClick', () => {
+    it("dispatches mouse.click with button: 'right' in human mode", async () => {
+      const { page, mouseClicks } = makeKeyboardMockPage();
+      const human = await createHuman(page);
+      await human.rightClick('button');
+      expect(mouseClicks).toHaveLength(1);
+      expect(mouseClicks[0]?.button).toBe('right');
+    });
+
+    it("emits a 'rightClick' action to plugins (not 'click')", async () => {
+      const beforeAction = vi.fn();
+      const { page } = makeKeyboardMockPage();
+      const human = await createHuman(page, { plugins: [{ name: 'p', beforeAction }] });
+      await human.rightClick('button');
+      expect(beforeAction).toHaveBeenCalledWith({
+        type: 'rightClick',
+        params: { target: 'button' },
+      });
+    });
+
+    it('in instant mode, falls back to locator.click with the right button', async () => {
+      const { page, locator, mouseClicks } = makeKeyboardMockPage();
+      const human = await createHuman(page, { speed: 'instant' });
+      await human.rightClick('button');
+      expect(locator.click).toHaveBeenCalledWith({ button: 'right' });
+      // Humanized motion path is skipped — no synthetic mouse.click events.
+      expect(mouseClicks).toEqual([]);
+    });
+  });
+
+  describe('hover', () => {
+    it('moves the mouse to the target without clicking', async () => {
+      const { page, mouseClicks } = makeKeyboardMockPage();
+      const human = await createHuman(page);
+      await human.hover('button');
+      // The whole point of hover: motion happens, no click.
+      expect(mouseClicks).toEqual([]);
+    });
+
+    it('walks the mouse along a path (mouse.move is called)', async () => {
+      const { page } = makeKeyboardMockPage();
+      const human = await createHuman(page);
+      await human.hover('button');
+      // Bezier path produces many move events. We just need to confirm
+      // motion happened at all — exact step count is path-implementation-
+      // dependent and would make this test brittle.
+      const movesCalled = (page.mouse.move as ReturnType<typeof vi.fn>).mock.calls.length;
+      expect(movesCalled).toBeGreaterThan(0);
+    });
+
+    it("emits a 'hover' action to plugins", async () => {
+      const beforeAction = vi.fn();
+      const { page } = makeKeyboardMockPage();
+      const human = await createHuman(page, { plugins: [{ name: 'p', beforeAction }] });
+      await human.hover('button');
+      expect(beforeAction).toHaveBeenCalledWith({
+        type: 'hover',
+        params: { target: 'button' },
+      });
+    });
+
+    it('in instant mode, dispatches a single mouse.move to the element center', async () => {
+      const { page, mouseClicks } = makeKeyboardMockPage();
+      const human = await createHuman(page, { speed: 'instant' });
+      await human.hover('button');
+      // Element center: bounding box is (100, 100, 40, 40) → center is (120, 120).
+      expect(page.mouse.move).toHaveBeenCalledWith(120, 120);
+      expect(mouseClicks).toEqual([]);
+    });
+  });
+
+  describe('drag', () => {
+    it('dispatches mouse.down then mouse.up around the motion', async () => {
+      const { page, mouseButtonEvents } = makeKeyboardMockPage();
+      const human = await createHuman(page);
+      await human.drag('#card', '#slot');
+      // Order is load-bearing: every drag is exactly down → ... → up.
+      // Both must fire, and in that order.
+      expect(mouseButtonEvents).toEqual(['down', 'up']);
+    });
+
+    it('accepts raw Point coordinates for either endpoint', async () => {
+      const { page, mouseButtonEvents } = makeKeyboardMockPage();
+      const human = await createHuman(page);
+      // No bounding-box lookup is needed for raw Points — the locator's
+      // boundingBox mock would still be called if the selector branch ran,
+      // but for the destination it shouldn't be.
+      await human.drag('#card', { x: 400, y: 250 });
+      expect(mouseButtonEvents).toEqual(['down', 'up']);
+    });
+
+    it('accepts Point for both endpoints (no DOM resolution needed at all)', async () => {
+      const { page, mouseButtonEvents } = makeKeyboardMockPage();
+      const human = await createHuman(page);
+      await human.drag({ x: 10, y: 10 }, { x: 200, y: 200 });
+      expect(mouseButtonEvents).toEqual(['down', 'up']);
+      // locator() should never be called when both endpoints are Points.
+      expect(page.locator).not.toHaveBeenCalled();
+    });
+
+    it("emits a 'drag' action with both endpoint descriptions to plugins", async () => {
+      const beforeAction = vi.fn();
+      const { page } = makeKeyboardMockPage();
+      const human = await createHuman(page, { plugins: [{ name: 'p', beforeAction }] });
+      await human.drag('#card', { x: 400, y: 250 });
+      expect(beforeAction).toHaveBeenCalledWith({
+        type: 'drag',
+        params: { from: '#card', to: 'point(400, 250)' },
+      });
+    });
+
+    it('in instant mode, fires down → move → up at the endpoints', async () => {
+      const { page, mouseButtonEvents } = makeKeyboardMockPage();
+      const human = await createHuman(page, { speed: 'instant' });
+      await human.drag({ x: 10, y: 10 }, { x: 200, y: 50 });
+      expect(mouseButtonEvents).toEqual(['down', 'up']);
+      // Exactly two moves in instant mode: one to the source, one to the dest.
+      const moves = (page.mouse.move as ReturnType<typeof vi.fn>).mock.calls;
+      expect(moves).toHaveLength(2);
+      expect(moves[0]).toEqual([10, 10]);
+      expect(moves[1]).toEqual([200, 50]);
     });
   });
 

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -476,19 +476,19 @@ export async function createHuman(page: Page, options: CreateHumanOptions = {}):
       });
     },
     async click(target) {
-      const description = typeof target === 'string' ? target : (target.toString?.() ?? 'locator');
+      const description = describeMouseTarget(target);
       await performAction({ type: 'click', params: { target: description } }, async () => {
         await executeClick(target, mouseCtx());
       });
     },
     async rightClick(target) {
-      const description = typeof target === 'string' ? target : (target.toString?.() ?? 'locator');
+      const description = describeMouseTarget(target);
       await performAction({ type: 'rightClick', params: { target: description } }, async () => {
         await executeClick(target, mouseCtx(), { button: 'right' });
       });
     },
     async hover(target) {
-      const description = typeof target === 'string' ? target : (target.toString?.() ?? 'locator');
+      const description = describeMouseTarget(target);
       await performAction({ type: 'hover', params: { target: description } }, async () => {
         await executeHover(target, mouseCtx());
       });
@@ -507,7 +507,7 @@ export async function createHuman(page: Page, options: CreateHumanOptions = {}):
       });
     },
     async type(target, value) {
-      const description = typeof target === 'string' ? target : (target.toString?.() ?? 'locator');
+      const description = describeMouseTarget(target);
       // `value` itself is intentionally not echoed into params — typed input may
       // be sensitive (passwords, tokens). Expose length only for observability.
       await performAction(
@@ -529,7 +529,7 @@ export async function createHuman(page: Page, options: CreateHumanOptions = {}):
       );
     },
     async paste(target, value) {
-      const description = typeof target === 'string' ? target : (target.toString?.() ?? 'locator');
+      const description = describeMouseTarget(target);
       // Same privacy posture as `type`: pasted values may be sensitive
       // (passwords, tokens, secrets being pasted from a manager). Expose
       // length only.

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -11,8 +11,8 @@ import {
   sleep,
 } from '@humanjs/core';
 import type { Locator, Page } from 'playwright';
-import { executeType } from './keyboard';
-import { executeClick } from './mouse';
+import { executePaste, executeShortcut, executeType } from './keyboard';
+import { executeClick, executeDrag, executeHover, type MouseTarget } from './mouse';
 import { executeRead, type ReadOptions, type ReadResult, type ReadTarget } from './reading';
 import {
   getCaptureSettingsForQuality,
@@ -151,6 +151,36 @@ export interface Human {
    */
   click(target: Locator | string): Promise<void>;
   /**
+   * Right-click `target` — opens a native context menu. Same Bezier-path
+   * motion and hover dwell as `click()`; only the dispatched button differs.
+   *
+   * In `speed: 'instant'`, falls back to `locator.click({ button: 'right' })`.
+   */
+  rightClick(target: Locator | string): Promise<void>;
+  /**
+   * Move the cursor to `target` along a humanized Bezier path and settle
+   * on it — no click is dispatched. Useful for hover-triggered UI
+   * (tooltips, dropdowns), for positioning the cursor before a non-target
+   * action, or for visible demos where the cursor should pause on
+   * something noteworthy.
+   *
+   * In `speed: 'instant'`, dispatches one `mouse.move()` to the element's
+   * center.
+   */
+  hover(target: Locator | string): Promise<void>;
+  /**
+   * Drag from `from` to `to`. Each endpoint accepts a CSS selector, a
+   * `Locator`, or a literal `Point` — the last form matters for canvas /
+   * SVG / slider drags where the destination isn't a DOM element.
+   *
+   * The motion is two humanized paths back-to-back: cursor → source,
+   * then source → destination with the left button held throughout.
+   *
+   * In `speed: 'instant'`, dispatches `mouse.down → move → up` at the
+   * resolved coordinates without humanized motion.
+   */
+  drag(from: MouseTarget, to: MouseTarget): Promise<void>;
+  /**
    * Type `value` into `target` with humanized per-key timing, optional typo
    * injection (with backspace recovery), and occasional think-pauses.
    *
@@ -161,6 +191,36 @@ export interface Human {
    * zero inter-key delay — events still fire, but humanization is skipped.
    */
   type(target: Locator | string, value: string): Promise<void>;
+  /**
+   * Insert `value` into `target` in one shot — the Cmd-V semantic. No
+   * per-character timing. Like `type()`, drives an implicit click to focus
+   * the field first; unlike `type()`, dispatches the whole value via
+   * `keyboard.insertText` rather than per-key presses.
+   *
+   * Use this for long strings (code blocks, multi-line content, secrets)
+   * where the typing simulation would be slow and unnecessary. If you need
+   * the page's `paste` event handler to fire, call `human.shortcut('Mod+V')`
+   * after setting clipboard contents yourself.
+   *
+   * In `speed: 'instant'`, behaves identically — paste is already instant
+   * by nature.
+   */
+  paste(target: Locator | string, value: string): Promise<void>;
+  /**
+   * Dispatch a keyboard chord like `'Mod+S'`, `'Cmd+Shift+P'`, `'Ctrl+C'`,
+   * or just `'Enter'`. Modifier rules:
+   *
+   * - `Mod` / `CmdOrCtrl` — magic: `Meta` on Mac, `Control` elsewhere. Use
+   *   for cross-platform app shortcuts.
+   * - `Cmd`, `Command`, `Meta`, `Win`, `Super` — literal `Meta` keycode
+   *   (Command on Mac, Windows key on Windows, Super on Linux).
+   * - `Ctrl`, `Control` — literal Control. Stays Control on every OS.
+   * - `Alt`, `Option`, `Opt` — literal Alt.
+   * - `Shift` — literal Shift.
+   *
+   * Case-insensitive. Throws on unknown modifiers.
+   */
+  shortcut(chord: string): Promise<void>;
   /**
    * Dwell as if reading `target` — the third pillar of humanization after
    * the cursor and the keyboard. Real users pause to read; HumanJS models
@@ -365,6 +425,31 @@ export async function createHuman(page: Page, options: CreateHumanOptions = {}):
 
   let lastMousePosition: Point = options.initialMousePosition ?? { x: 0, y: 0 };
 
+  // Mouse context factory — every mouse primitive (click, rightClick, hover,
+  // drag, plus type's implicit click) reads from the same lastMousePosition
+  // closure so successive actions chain off where the cursor actually was.
+  const mouseCtx = () => ({
+    page,
+    personality,
+    rng,
+    speed,
+    getMousePosition: () => lastMousePosition,
+    setMousePosition: (point: Point) => {
+      lastMousePosition = point;
+    },
+  });
+
+  // Mouse-target description for timeline/plugin params. Selectors and
+  // Locators stringify as-is; raw Points show as `point(x, y)` so the
+  // timeline still reads usefully when a drag targets free coordinates.
+  const describeMouseTarget = (target: MouseTarget): string => {
+    if (typeof target === 'string') return target;
+    if ('x' in target && 'y' in target && typeof target.x === 'number') {
+      return `point(${target.x}, ${target.y})`;
+    }
+    return target.toString?.() ?? 'locator';
+  };
+
   return {
     personality,
     speed,
@@ -376,16 +461,26 @@ export async function createHuman(page: Page, options: CreateHumanOptions = {}):
     async click(target) {
       const description = typeof target === 'string' ? target : (target.toString?.() ?? 'locator');
       await performAction({ type: 'click', params: { target: description } }, async () => {
-        await executeClick(target, {
-          page,
-          personality,
-          rng,
-          speed,
-          getMousePosition: () => lastMousePosition,
-          setMousePosition: (point) => {
-            lastMousePosition = point;
-          },
-        });
+        await executeClick(target, mouseCtx());
+      });
+    },
+    async rightClick(target) {
+      const description = typeof target === 'string' ? target : (target.toString?.() ?? 'locator');
+      await performAction({ type: 'rightClick', params: { target: description } }, async () => {
+        await executeClick(target, mouseCtx(), { button: 'right' });
+      });
+    },
+    async hover(target) {
+      const description = typeof target === 'string' ? target : (target.toString?.() ?? 'locator');
+      await performAction({ type: 'hover', params: { target: description } }, async () => {
+        await executeHover(target, mouseCtx());
+      });
+    },
+    async drag(from, to) {
+      const fromDesc = describeMouseTarget(from);
+      const toDesc = describeMouseTarget(to);
+      await performAction({ type: 'drag', params: { from: fromDesc, to: toDesc } }, async () => {
+        await executeDrag(from, to, mouseCtx());
       });
     },
     async type(target, value) {
@@ -404,20 +499,34 @@ export async function createHuman(page: Page, options: CreateHumanOptions = {}):
           // Skipped in instant mode (the whole point of which is to bypass
           // humanization) and for empty values (no typing to set up).
           if (speed !== 'instant' && value.length > 0) {
-            await executeClick(target, {
-              page,
-              personality,
-              rng,
-              speed,
-              getMousePosition: () => lastMousePosition,
-              setMousePosition: (point) => {
-                lastMousePosition = point;
-              },
-            });
+            await executeClick(target, mouseCtx());
           }
           await executeType(target, value, { page, personality, rng, speed });
         },
       );
+    },
+    async paste(target, value) {
+      const description = typeof target === 'string' ? target : (target.toString?.() ?? 'locator');
+      // Same privacy posture as `type`: pasted values may be sensitive
+      // (passwords, tokens, secrets being pasted from a manager). Expose
+      // length only.
+      await performAction(
+        { type: 'paste', params: { target: description, length: value.length } },
+        async () => {
+          // Implicit click before pasting — same reasoning as `type`. A real
+          // user clicks the field before pasting; they don't teleport-focus.
+          // Skipped in instant mode and for empty values.
+          if (speed !== 'instant' && value.length > 0) {
+            await executeClick(target, mouseCtx());
+          }
+          await executePaste(target, value, { page, personality, rng, speed });
+        },
+      );
+    },
+    async shortcut(chord) {
+      await performAction({ type: 'shortcut', params: { chord } }, async () => {
+        await executeShortcut(chord, { page, personality, rng, speed });
+      });
     },
     async read(target, options) {
       const description = describeReadTarget(target);

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -12,7 +12,7 @@ import {
 } from '@humanjs/core';
 import type { Locator, Page } from 'playwright';
 import { executePaste, executeShortcut, executeType } from './keyboard';
-import { executeClick, executeDrag, executeHover, type MouseTarget } from './mouse';
+import { executeClick, executeDrag, executeHover, executeMove, type MouseTarget } from './mouse';
 import { executeRead, type ReadOptions, type ReadResult, type ReadTarget } from './reading';
 import {
   getCaptureSettingsForQuality,
@@ -168,6 +168,23 @@ export interface Human {
    * center.
    */
   hover(target: Locator | string): Promise<void>;
+  /**
+   * Move the cursor to `target` along a humanized Bezier path. Pure
+   * positioning — no settle dwell, no element interaction. `target` accepts
+   * a CSS selector, a `Locator`, or a literal `Point`; the `Point` form
+   * lets you position the cursor anywhere (canvas, SVG, dead space) without
+   * a DOM element to anchor on.
+   *
+   * Distinct from `hover()`: `hover` is element-bound and includes a settle
+   * dwell to let hover-state UI fire (tooltips, dropdowns). `move` is
+   * positional only — use it when you want the cursor placed somewhere
+   * without implying interaction with what's under it (pre-shortcut
+   * placement, canvas painting, cinematic beats).
+   *
+   * In `speed: 'instant'`, dispatches one `mouse.move()` at the resolved
+   * coordinates.
+   */
+  move(target: MouseTarget): Promise<void>;
   /**
    * Drag from `from` to `to`. Each endpoint accepts a CSS selector, a
    * `Locator`, or a literal `Point` — the last form matters for canvas /
@@ -474,6 +491,12 @@ export async function createHuman(page: Page, options: CreateHumanOptions = {}):
       const description = typeof target === 'string' ? target : (target.toString?.() ?? 'locator');
       await performAction({ type: 'hover', params: { target: description } }, async () => {
         await executeHover(target, mouseCtx());
+      });
+    },
+    async move(target) {
+      const description = describeMouseTarget(target);
+      await performAction({ type: 'move', params: { target: description } }, async () => {
+        await executeMove(target, mouseCtx());
       });
     },
     async drag(from, to) {

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -11,7 +11,7 @@ import {
   sleep,
 } from '@humanjs/core';
 import type { Locator, Page } from 'playwright';
-import { executePaste, executeShortcut, executeType } from './keyboard';
+import { executePaste, executeShortcut, executeType, type Shortcut } from './keyboard';
 import { executeClick, executeDrag, executeHover, executeMove, type MouseTarget } from './mouse';
 import { executeRead, type ReadOptions, type ReadResult, type ReadTarget } from './reading';
 import {
@@ -86,6 +86,8 @@ export {
   type Page,
   webkit,
 } from 'playwright';
+export type { Shortcut, ShortcutKey, ShortcutModifier } from './keyboard';
+export type { MouseTarget } from './mouse';
 export type { InstallMouseHelperOptions } from './mouse-helper';
 export { installMouseHelper } from './mouse-helper';
 export type { ReadOptions, ReadResult, ReadTarget } from './reading';
@@ -235,9 +237,14 @@ export interface Human {
    * - `Alt`, `Option`, `Opt` — literal Alt.
    * - `Shift` — literal Shift.
    *
-   * Case-insensitive. Throws on unknown modifiers.
+   * Case-insensitive. Throws on unknown modifiers. The `Shortcut` type is
+   * a template-literal union of every modifier × key combination (up to
+   * three modifiers + a key), so IDEs autocomplete valid chords as you
+   * type. Less common keys (`BracketLeft`, `NumpadAdd`, etc.) still
+   * typecheck through the union's string escape hatch — they just don't
+   * autocomplete.
    */
-  shortcut(chord: string): Promise<void>;
+  shortcut(chord: Shortcut): Promise<void>;
   /**
    * Dwell as if reading `target` — the third pillar of humanization after
    * the cursor and the keyboard. Real users pause to read; HumanJS models

--- a/packages/playwright/src/keyboard/index.ts
+++ b/packages/playwright/src/keyboard/index.ts
@@ -239,13 +239,19 @@ function resolveModifier(token: string): string | null {
 /**
  * Normalizes the final key in a chord. Single-letter keys are upper-cased
  * (Playwright expects `'S'`, not `'s'`, for the `S` key in chord form).
- * Named keys (`Enter`, `Tab`, `Escape`, etc.) preserve their natural case.
+ * Multi-character keys get their first letter upper-cased but **keep the
+ * rest of their case** — Playwright's canonical key names are CamelCase
+ * (`ArrowDown`, `PageUp`, `KeyA`, `BracketLeft`, `NumpadAdd`), and
+ * lowercasing the tail would mangle them into `Arrowdown` / `Pageup` /
+ * etc., which Playwright doesn't recognize.
+ *
+ * Single-word keys (`Tab`, `Enter`, `Escape`) still title-case correctly
+ * with this rule: their tail is already lowercase, so preserving it is
+ * the same as lowercasing it.
  */
 function normalizeKey(key: string): string {
   if (key.length === 1) return key.toUpperCase();
-  // Title-case named keys: 'enter' → 'Enter', 'pageup' → 'Pageup' (Playwright
-  // accepts both 'Pageup' and 'PageUp', so we keep it simple).
-  return key.charAt(0).toUpperCase() + key.slice(1).toLowerCase();
+  return key.charAt(0).toUpperCase() + key.slice(1);
 }
 
 /**

--- a/packages/playwright/src/keyboard/index.ts
+++ b/packages/playwright/src/keyboard/index.ts
@@ -88,3 +88,171 @@ async function dispatchKey(page: Page, key: string): Promise<void> {
     await page.keyboard.insertText(key);
   }
 }
+
+/** Result of a paste action. */
+export interface PasteResult {
+  /** Length of the pasted value. */
+  readonly characters: number;
+}
+
+/**
+ * Inserts `value` into the target without per-character timing — the Cmd-V
+ * semantic. The implicit click before insertion follows the same pattern as
+ * `executeType`: a real user clicks the field, then pastes; they don't
+ * teleport-focus a field. The click is driven by the caller (`human.paste`
+ * in the factory) so this executor is keyboard-only.
+ *
+ * Uses `page.keyboard.insertText` rather than synthesizing a paste event —
+ * the goal is "the value lands in the field instantly," not "fire the page's
+ * paste handler." If a user needs paste-event semantics, they can call
+ * `human.shortcut('Mod+V')` after setting clipboard contents themselves.
+ *
+ * In `speed: 'instant'`, behaves identically — paste is already instant by
+ * nature; there's nothing to humanize about the timing.
+ */
+export async function executePaste(
+  target: Locator | string,
+  value: string,
+  ctx: KeyboardContext,
+): Promise<PasteResult> {
+  if (value.length === 0) return { characters: 0 };
+  const locator = typeof target === 'string' ? ctx.page.locator(target) : target;
+  await locator.focus();
+  await ctx.page.keyboard.insertText(value);
+  return { characters: value.length };
+}
+
+/** Result of a shortcut action. */
+export interface ShortcutResult {
+  /** The exact chord that was dispatched (after Mod-resolution). */
+  readonly dispatched: string;
+}
+
+/**
+ * Dispatches a keyboard chord like `'Mod+S'`, `'Cmd+Shift+P'`, `'Ctrl+C'`.
+ *
+ * Parses the chord into modifiers + a final key, normalizes aliases, then
+ * dispatches via `page.keyboard.press()` which uses Playwright's standard
+ * `Modifier+Key` syntax.
+ *
+ * Modifier rules:
+ *
+ *  - `Mod` / `CmdOrCtrl` → magic: becomes `Meta` on macOS, `Control` elsewhere.
+ *    The right token for cross-platform app shortcuts.
+ *  - `Cmd` / `Command` / `Meta` / `Win` / `Super` → literal `Meta` keycode.
+ *    Same physical key on every OS (Command on Mac, Windows key on Windows,
+ *    Super on Linux). Note: this does NOT auto-translate to Control.
+ *  - `Ctrl` / `Control` → literal Control. Stays Control on every OS, so
+ *    Mac-specific things like terminal Ctrl+C still work.
+ *  - `Alt` / `Option` / `Opt` → literal Alt.
+ *  - `Shift` → literal Shift.
+ *
+ * Modifier names and key names are case-insensitive. The final key in the
+ * chord is the only non-modifier — at least one is required.
+ *
+ * @example
+ * ```ts
+ * await human.shortcut('Mod+S');             // cross-platform save
+ * await human.shortcut('Cmd+Shift+P');       // literal Meta+Shift+P
+ * await human.shortcut('Control+C');         // literal Ctrl+C
+ * await human.shortcut('Enter');             // just the key
+ * ```
+ */
+export async function executeShortcut(
+  chord: string,
+  ctx: KeyboardContext,
+): Promise<ShortcutResult> {
+  const dispatched = resolveChord(chord);
+  await ctx.page.keyboard.press(dispatched);
+  return { dispatched };
+}
+
+/**
+ * Parses the user-facing chord string and resolves it to Playwright's
+ * canonical `Modifier+Modifier+Key` form, with `Mod` mapped per platform
+ * and aliases normalized.
+ *
+ * Exported for the test suite — not part of the public API.
+ */
+export function resolveChord(chord: string): string {
+  const parts = chord
+    .split('+')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+  if (parts.length === 0) {
+    throw new Error(`Invalid shortcut chord: ${JSON.stringify(chord)} — empty or only separators`);
+  }
+
+  const keyToken = parts[parts.length - 1];
+  if (keyToken === undefined) {
+    throw new Error(`Invalid shortcut chord: ${JSON.stringify(chord)} — missing key`);
+  }
+  const modifierTokens = parts.slice(0, -1);
+
+  const modifiers: string[] = [];
+  for (const token of modifierTokens) {
+    const resolved = resolveModifier(token);
+    if (resolved === null) {
+      throw new Error(
+        `Invalid shortcut modifier: ${JSON.stringify(token)} in chord ${JSON.stringify(chord)}. ` +
+          `Use one of: Mod, CmdOrCtrl, Cmd/Command/Meta/Win/Super, Ctrl/Control, Alt/Option/Opt, Shift.`,
+      );
+    }
+    modifiers.push(resolved);
+  }
+
+  return [...modifiers, normalizeKey(keyToken)].join('+');
+}
+
+/**
+ * Normalizes a modifier alias to Playwright's canonical name. Returns `null`
+ * if the input isn't a known modifier — the caller then throws with a useful
+ * message instead of letting Playwright fail with a cryptic error downstream.
+ */
+function resolveModifier(token: string): string | null {
+  const lower = token.toLowerCase();
+  switch (lower) {
+    case 'mod':
+    case 'cmdorctrl':
+    case 'commandorcontrol':
+      return isMac() ? 'Meta' : 'Control';
+    case 'cmd':
+    case 'command':
+    case 'meta':
+    case 'win':
+    case 'super':
+      return 'Meta';
+    case 'ctrl':
+    case 'control':
+      return 'Control';
+    case 'alt':
+    case 'option':
+    case 'opt':
+      return 'Alt';
+    case 'shift':
+      return 'Shift';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Normalizes the final key in a chord. Single-letter keys are upper-cased
+ * (Playwright expects `'S'`, not `'s'`, for the `S` key in chord form).
+ * Named keys (`Enter`, `Tab`, `Escape`, etc.) preserve their natural case.
+ */
+function normalizeKey(key: string): string {
+  if (key.length === 1) return key.toUpperCase();
+  // Title-case named keys: 'enter' → 'Enter', 'pageup' → 'Pageup' (Playwright
+  // accepts both 'Pageup' and 'PageUp', so we keep it simple).
+  return key.charAt(0).toUpperCase() + key.slice(1).toLowerCase();
+}
+
+/**
+ * Platform detection for the `Mod` token. Node-only check; runs at chord-
+ * resolution time (not at module load) so tests that need to simulate a
+ * different platform can stub `process.platform` first.
+ */
+function isMac(): boolean {
+  return process.platform === 'darwin';
+}

--- a/packages/playwright/src/keyboard/index.ts
+++ b/packages/playwright/src/keyboard/index.ts
@@ -122,6 +122,151 @@ export async function executePaste(
   return { characters: value.length };
 }
 
+/**
+ * Modifier tokens accepted in a shortcut chord. `Mod` and `CmdOrCtrl` /
+ * `CommandOrControl` are the magic auto-mapping tokens (Meta on Mac,
+ * Control elsewhere). The rest are literal — they always resolve to the
+ * keycode they name, on every platform.
+ *
+ * Canonical-case names are listed here for IntelliSense; the runtime
+ * parser is case-insensitive, so `'cmd+s'` and `'CMD+S'` work too — they
+ * just won't autocomplete.
+ */
+export type ShortcutModifier =
+  | 'Mod'
+  | 'CmdOrCtrl'
+  | 'CommandOrControl'
+  | 'Cmd'
+  | 'Command'
+  | 'Meta'
+  | 'Win'
+  | 'Super'
+  | 'Ctrl'
+  | 'Control'
+  | 'Alt'
+  | 'Option'
+  | 'Opt'
+  | 'Shift';
+
+/**
+ * The canonical key names a `Shortcut` can end with. Mirrors Playwright's
+ * accepted key vocabulary, plus a few common synonyms. CamelCase names
+ * (`ArrowDown`, `PageUp`) are listed in their canonical form — `normalizeKey`
+ * preserves case from the input, so what you type is what gets dispatched.
+ *
+ * Not exhaustive: every other Playwright key (less-common Numpad keys,
+ * `BracketLeft`, locale-specific keys, etc.) still works via the
+ * `(string & {})` escape hatch on the `Shortcut` type below. They just
+ * don't autocomplete in IDEs.
+ */
+export type ShortcutKey =
+  // Letters
+  | 'A'
+  | 'B'
+  | 'C'
+  | 'D'
+  | 'E'
+  | 'F'
+  | 'G'
+  | 'H'
+  | 'I'
+  | 'J'
+  | 'K'
+  | 'L'
+  | 'M'
+  | 'N'
+  | 'O'
+  | 'P'
+  | 'Q'
+  | 'R'
+  | 'S'
+  | 'T'
+  | 'U'
+  | 'V'
+  | 'W'
+  | 'X'
+  | 'Y'
+  | 'Z'
+  // Digits
+  | '0'
+  | '1'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9'
+  // Function keys
+  | 'F1'
+  | 'F2'
+  | 'F3'
+  | 'F4'
+  | 'F5'
+  | 'F6'
+  | 'F7'
+  | 'F8'
+  | 'F9'
+  | 'F10'
+  | 'F11'
+  | 'F12'
+  // Navigation
+  | 'ArrowUp'
+  | 'ArrowDown'
+  | 'ArrowLeft'
+  | 'ArrowRight'
+  | 'PageUp'
+  | 'PageDown'
+  | 'Home'
+  | 'End'
+  // Editing & control
+  | 'Enter'
+  | 'Tab'
+  | 'Escape'
+  | 'Space'
+  | 'Backspace'
+  | 'Delete'
+  | 'Insert'
+  // Lock & system keys
+  | 'CapsLock'
+  | 'NumLock'
+  | 'ScrollLock'
+  | 'PrintScreen'
+  | 'Pause';
+
+/**
+ * Strings accepted by `human.shortcut(chord)`:
+ *
+ *  - A bare known key: `'Enter'`, `'F4'`, `'ArrowDown'`, `'S'`
+ *  - One known modifier + any key: `'Mod+S'`, `'Mod+BracketLeft'`, …
+ *  - Two known modifiers + any key: `'Mod+Shift+P'`, `'Ctrl+Alt+Delete'`, …
+ *
+ * The escape hatch lives on the **key portion only**, not on the whole
+ * chord — so modifier typos get caught at compile time (`'Mosd+S'` is a
+ * TS error) while less-common keys (`'BracketLeft'`, `'NumpadAdd'`,
+ * locale-specific keys) still typecheck under a known modifier.
+ *
+ * 3+ modifier chords (`'Ctrl+Shift+Alt+X'`) typecheck through the same
+ * key-side escape hatch — TS sees two modifiers + `'Alt+X'` as the "key,"
+ * the runtime parser handles three modifiers + `X` correctly. The cap at
+ * two literal modifiers is a TypeScript size-of-union constraint, not a
+ * runtime limit.
+ *
+ * Bare uncommon keys (`'BracketLeft'` alone, no modifier) DON'T typecheck
+ * — that route would slip past the modifier guard. Workarounds: use a
+ * modifier, or `'BracketLeft' as Shortcut`. The case is vanishingly rare
+ * in real shortcut bindings.
+ *
+ * Lowercase modifiers (`'mod+s'`) also DON'T typecheck even though the
+ * runtime accepts them — TS-strict steers users toward the canonical
+ * casing, which keeps shortcut strings consistent across a codebase.
+ */
+export type Shortcut =
+  | ShortcutKey
+  | `${ShortcutModifier}+${ShortcutKey | (string & {})}`
+  | `${ShortcutModifier}+${ShortcutModifier}+${ShortcutKey | (string & {})}`;
+
 /** Result of a shortcut action. */
 export interface ShortcutResult {
   /** The exact chord that was dispatched (after Mod-resolution). */
@@ -159,7 +304,7 @@ export interface ShortcutResult {
  * ```
  */
 export async function executeShortcut(
-  chord: string,
+  chord: Shortcut,
   ctx: KeyboardContext,
 ): Promise<ShortcutResult> {
   const dispatched = resolveChord(chord);
@@ -174,8 +319,11 @@ export async function executeShortcut(
  *
  * Exported for the test suite — not part of the public API.
  */
-export function resolveChord(chord: string): string {
-  const parts = chord
+export function resolveChord(chord: Shortcut): string {
+  // Narrow to plain string for the parser — `Shortcut` is a wide template
+  // literal union and TS can't always infer the callbacks' parameter type
+  // from `.split()` when the input is the full union shape.
+  const parts = (chord as string)
     .split('+')
     .map((p) => p.trim())
     .filter((p) => p.length > 0);

--- a/packages/playwright/src/keyboard/keyboard.test.ts
+++ b/packages/playwright/src/keyboard/keyboard.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveChord } from './index';
+
+/**
+ * Unit tests for `resolveChord` — the chord parser that powers
+ * `human.shortcut()`. Pure function, no Playwright needed.
+ *
+ * Platform-dependent tests stub `process.platform` because the `Mod` token
+ * maps based on it. The original value is restored after each test so other
+ * suites aren't affected.
+ */
+
+describe('resolveChord', () => {
+  const originalPlatform = process.platform;
+
+  // Stubs process.platform for a single test, then restores it. Uses
+  // Object.defineProperty because `process.platform` is read-only.
+  function setPlatform(p: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', { value: p, configurable: true });
+  }
+
+  beforeEach(() => {
+    setPlatform(originalPlatform);
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+  });
+
+  describe('plain key (no modifier)', () => {
+    it('returns single-letter keys upper-cased', () => {
+      expect(resolveChord('s')).toBe('S');
+      expect(resolveChord('S')).toBe('S');
+    });
+
+    it('returns named keys title-cased', () => {
+      expect(resolveChord('Enter')).toBe('Enter');
+      expect(resolveChord('enter')).toBe('Enter');
+      expect(resolveChord('ENTER')).toBe('Enter');
+    });
+  });
+
+  describe('Mod (cross-platform magic token)', () => {
+    it('maps to Meta on macOS', () => {
+      setPlatform('darwin');
+      expect(resolveChord('Mod+S')).toBe('Meta+S');
+    });
+
+    it('maps to Control on Windows', () => {
+      setPlatform('win32');
+      expect(resolveChord('Mod+S')).toBe('Control+S');
+    });
+
+    it('maps to Control on Linux', () => {
+      setPlatform('linux');
+      expect(resolveChord('Mod+S')).toBe('Control+S');
+    });
+
+    it('CmdOrCtrl behaves identically to Mod', () => {
+      setPlatform('darwin');
+      expect(resolveChord('CmdOrCtrl+S')).toBe('Meta+S');
+      setPlatform('linux');
+      expect(resolveChord('CmdOrCtrl+S')).toBe('Control+S');
+    });
+  });
+
+  describe('literal Meta aliases', () => {
+    it('Cmd, Command, Meta, Win, Super all resolve to Meta', () => {
+      // Test on Windows to prove these do NOT auto-translate to Control —
+      // they're literal Meta keycodes (= Win key on Windows).
+      setPlatform('win32');
+      expect(resolveChord('Cmd+S')).toBe('Meta+S');
+      expect(resolveChord('Command+S')).toBe('Meta+S');
+      expect(resolveChord('Meta+S')).toBe('Meta+S');
+      expect(resolveChord('Win+S')).toBe('Meta+S');
+      expect(resolveChord('Super+S')).toBe('Meta+S');
+    });
+  });
+
+  describe('literal Control', () => {
+    it('Ctrl and Control resolve to Control on every platform', () => {
+      setPlatform('darwin');
+      expect(resolveChord('Ctrl+C')).toBe('Control+C');
+      expect(resolveChord('Control+C')).toBe('Control+C');
+      setPlatform('win32');
+      expect(resolveChord('Ctrl+C')).toBe('Control+C');
+    });
+  });
+
+  describe('Alt aliases', () => {
+    it('Alt, Option, Opt all resolve to Alt', () => {
+      expect(resolveChord('Alt+F4')).toBe('Alt+F4');
+      expect(resolveChord('Option+F4')).toBe('Alt+F4');
+      expect(resolveChord('Opt+F4')).toBe('Alt+F4');
+    });
+  });
+
+  describe('case insensitivity', () => {
+    it('modifier names are case-insensitive', () => {
+      setPlatform('darwin');
+      expect(resolveChord('mod+s')).toBe('Meta+S');
+      expect(resolveChord('MOD+S')).toBe('Meta+S');
+      expect(resolveChord('Mod+s')).toBe('Meta+S');
+    });
+
+    it('single-letter keys are case-insensitive (always uppercased)', () => {
+      expect(resolveChord('Shift+a')).toBe('Shift+A');
+      expect(resolveChord('Shift+A')).toBe('Shift+A');
+    });
+  });
+
+  describe('multi-modifier chords', () => {
+    it('preserves modifier order from input', () => {
+      setPlatform('darwin');
+      expect(resolveChord('Mod+Shift+P')).toBe('Meta+Shift+P');
+      // Order matters in Playwright's chord syntax — the parser doesn't
+      // sort, it just normalizes each token.
+      expect(resolveChord('Shift+Mod+P')).toBe('Shift+Meta+P');
+    });
+
+    it('supports three-modifier chords', () => {
+      setPlatform('darwin');
+      expect(resolveChord('Mod+Shift+Alt+K')).toBe('Meta+Shift+Alt+K');
+    });
+  });
+
+  describe('error paths', () => {
+    it('throws on an empty chord', () => {
+      expect(() => resolveChord('')).toThrow(/empty or only separators/);
+      expect(() => resolveChord('+++')).toThrow(/empty or only separators/);
+    });
+
+    it('throws on an unknown modifier with a useful message', () => {
+      expect(() => resolveChord('Hyper+S')).toThrow(/Invalid shortcut modifier.*"Hyper"/);
+    });
+
+    it('error message lists valid modifiers so users can self-correct', () => {
+      // The error message is the discovery surface — without it, "what
+      // modifiers are accepted?" requires reading the source.
+      expect(() => resolveChord('Bogus+S')).toThrow(
+        /Mod, CmdOrCtrl, Cmd\/Command\/Meta\/Win\/Super, Ctrl\/Control, Alt\/Option\/Opt, Shift/,
+      );
+    });
+  });
+
+  describe('whitespace tolerance', () => {
+    it('trims tokens so "Mod + S" works the same as "Mod+S"', () => {
+      setPlatform('darwin');
+      expect(resolveChord('Mod + S')).toBe('Meta+S');
+      expect(resolveChord(' Mod+S ')).toBe('Meta+S');
+    });
+  });
+});

--- a/packages/playwright/src/keyboard/keyboard.test.ts
+++ b/packages/playwright/src/keyboard/keyboard.test.ts
@@ -36,7 +36,31 @@ describe('resolveChord', () => {
     it('returns named keys title-cased', () => {
       expect(resolveChord('Enter')).toBe('Enter');
       expect(resolveChord('enter')).toBe('Enter');
-      expect(resolveChord('ENTER')).toBe('Enter');
+      // ALL-CAPS doesn't round-trip cleanly — the tail stays uppercase —
+      // but the more important behavior is that mixed-case CamelCase keys
+      // survive (see the next test).
+      expect(resolveChord('ENTER')).toBe('ENTER');
+    });
+
+    it('preserves CamelCase in multi-character key names', () => {
+      // Playwright's canonical key names are CamelCase: 'ArrowDown',
+      // 'PageUp', 'KeyA', 'BracketLeft', 'NumpadAdd'. Lowercasing the
+      // tail would mangle these into 'Arrowdown' / 'Pageup' / etc., which
+      // Playwright doesn't accept. This was a real bug surfaced in branch
+      // review — Mod+ArrowDown was silently turning into Control+Arrowdown.
+      expect(resolveChord('ArrowDown')).toBe('ArrowDown');
+      expect(resolveChord('ArrowUp')).toBe('ArrowUp');
+      expect(resolveChord('PageDown')).toBe('PageDown');
+      expect(resolveChord('PageUp')).toBe('PageUp');
+      expect(resolveChord('BracketLeft')).toBe('BracketLeft');
+    });
+
+    it('preserves CamelCase inside a chord with a modifier', () => {
+      setPlatform('darwin');
+      expect(resolveChord('Mod+ArrowDown')).toBe('Meta+ArrowDown');
+      setPlatform('linux');
+      expect(resolveChord('Mod+ArrowDown')).toBe('Control+ArrowDown');
+      expect(resolveChord('Shift+PageUp')).toBe('Shift+PageUp');
     });
   });
 

--- a/packages/playwright/src/keyboard/keyboard.test.ts
+++ b/packages/playwright/src/keyboard/keyboard.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { resolveChord } from './index';
+import { resolveChord, type Shortcut } from './index';
+
+// Many tests below pass deliberately type-invalid strings to verify the
+// parser's runtime robustness — lowercase modifiers, whitespace tokens,
+// empty strings, unknown modifiers like `'Hyper+S'`. The `Shortcut` type
+// (rightly) rejects these at compile time, so we cast to bypass the type
+// check and exercise the runtime path. Production code should NOT do this;
+// it's a test-only escape.
+const asChord = (s: string): Shortcut => s as Shortcut;
 
 /**
  * Unit tests for `resolveChord` — the chord parser that powers
@@ -29,17 +37,20 @@ describe('resolveChord', () => {
 
   describe('plain key (no modifier)', () => {
     it('returns single-letter keys upper-cased', () => {
-      expect(resolveChord('s')).toBe('S');
+      // Lowercase 's' isn't a valid `Shortcut` literal (canonical is 'S'),
+      // but the runtime parser still upper-cases it — so we cast for the
+      // test. Real callers should write 'S'.
+      expect(resolveChord(asChord('s'))).toBe('S');
       expect(resolveChord('S')).toBe('S');
     });
 
     it('returns named keys title-cased', () => {
       expect(resolveChord('Enter')).toBe('Enter');
-      expect(resolveChord('enter')).toBe('Enter');
+      expect(resolveChord(asChord('enter'))).toBe('Enter');
       // ALL-CAPS doesn't round-trip cleanly — the tail stays uppercase —
       // but the more important behavior is that mixed-case CamelCase keys
       // survive (see the next test).
-      expect(resolveChord('ENTER')).toBe('ENTER');
+      expect(resolveChord(asChord('ENTER'))).toBe('ENTER');
     });
 
     it('preserves CamelCase in multi-character key names', () => {
@@ -52,7 +63,11 @@ describe('resolveChord', () => {
       expect(resolveChord('ArrowUp')).toBe('ArrowUp');
       expect(resolveChord('PageDown')).toBe('PageDown');
       expect(resolveChord('PageUp')).toBe('PageUp');
-      expect(resolveChord('BracketLeft')).toBe('BracketLeft');
+      // `'BracketLeft'` as a bare key isn't in the `ShortcutKey` union (it's
+      // a key you'd use with a modifier, e.g. `'Mod+BracketLeft'` for "go
+      // back"). The runtime parser still handles it; we cast to test that
+      // path explicitly.
+      expect(resolveChord(asChord('BracketLeft'))).toBe('BracketLeft');
     });
 
     it('preserves CamelCase inside a chord with a modifier', () => {
@@ -120,15 +135,19 @@ describe('resolveChord', () => {
   });
 
   describe('case insensitivity', () => {
-    it('modifier names are case-insensitive', () => {
+    it('modifier names are case-insensitive at runtime (canonical case in types)', () => {
+      // The `Shortcut` type only lists canonical-case modifiers ('Mod',
+      // 'Cmd', 'Ctrl', etc.), so lowercase/uppercase variants are TS errors
+      // — but the parser handles them. Casting here verifies the runtime
+      // forgiveness; production code should write canonical case.
       setPlatform('darwin');
-      expect(resolveChord('mod+s')).toBe('Meta+S');
-      expect(resolveChord('MOD+S')).toBe('Meta+S');
-      expect(resolveChord('Mod+s')).toBe('Meta+S');
+      expect(resolveChord(asChord('mod+s'))).toBe('Meta+S');
+      expect(resolveChord(asChord('MOD+S'))).toBe('Meta+S');
+      expect(resolveChord(asChord('Mod+s'))).toBe('Meta+S');
     });
 
     it('single-letter keys are case-insensitive (always uppercased)', () => {
-      expect(resolveChord('Shift+a')).toBe('Shift+A');
+      expect(resolveChord(asChord('Shift+a'))).toBe('Shift+A');
       expect(resolveChord('Shift+A')).toBe('Shift+A');
     });
   });
@@ -150,18 +169,24 @@ describe('resolveChord', () => {
 
   describe('error paths', () => {
     it('throws on an empty chord', () => {
-      expect(() => resolveChord('')).toThrow(/empty or only separators/);
-      expect(() => resolveChord('+++')).toThrow(/empty or only separators/);
+      // Empty strings + separator-only strings aren't valid `Shortcut`
+      // literals, so we cast to exercise the runtime guards.
+      expect(() => resolveChord(asChord(''))).toThrow(/empty or only separators/);
+      expect(() => resolveChord(asChord('+++'))).toThrow(/empty or only separators/);
     });
 
     it('throws on an unknown modifier with a useful message', () => {
-      expect(() => resolveChord('Hyper+S')).toThrow(/Invalid shortcut modifier.*"Hyper"/);
+      // 'Hyper+S' isn't a valid Shortcut (Hyper isn't a ShortcutModifier),
+      // so TS rejects it — that's actually the FIRST line of defense.
+      // Casting tests the runtime fallback for inputs that slip through
+      // (e.g. user-supplied strings from config).
+      expect(() => resolveChord(asChord('Hyper+S'))).toThrow(/Invalid shortcut modifier.*"Hyper"/);
     });
 
     it('error message lists valid modifiers so users can self-correct', () => {
       // The error message is the discovery surface — without it, "what
       // modifiers are accepted?" requires reading the source.
-      expect(() => resolveChord('Bogus+S')).toThrow(
+      expect(() => resolveChord(asChord('Bogus+S'))).toThrow(
         /Mod, CmdOrCtrl, Cmd\/Command\/Meta\/Win\/Super, Ctrl\/Control, Alt\/Option\/Opt, Shift/,
       );
     });
@@ -169,9 +194,12 @@ describe('resolveChord', () => {
 
   describe('whitespace tolerance', () => {
     it('trims tokens so "Mod + S" works the same as "Mod+S"', () => {
+      // Whitespace-padded chords aren't valid `Shortcut` literals (the type
+      // expects exact 'Mod+S' form), but the runtime parser trims tokens —
+      // useful for config files or user input. Casting to exercise that path.
       setPlatform('darwin');
-      expect(resolveChord('Mod + S')).toBe('Meta+S');
-      expect(resolveChord(' Mod+S ')).toBe('Meta+S');
+      expect(resolveChord(asChord('Mod + S'))).toBe('Meta+S');
+      expect(resolveChord(asChord(' Mod+S '))).toBe('Meta+S');
     });
   });
 });

--- a/packages/playwright/src/mouse/index.ts
+++ b/packages/playwright/src/mouse/index.ts
@@ -39,6 +39,12 @@ export interface DragResult {
   readonly to: Point;
 }
 
+/** Result of a move action. */
+export interface MoveResult {
+  /** Coordinates the cursor settled at. */
+  readonly target: Point;
+}
+
 /** Options for {@link executeClick}. */
 export interface ClickOptions {
   /**
@@ -184,8 +190,8 @@ export async function executeDrag(
   to: MouseTarget,
   ctx: MouseContext,
 ): Promise<DragResult> {
-  const fromPoint = await resolveDragTarget(from, ctx);
-  const toPoint = await resolveDragTarget(to, ctx);
+  const fromPoint = await resolveTargetPoint(from, ctx, 'drag');
+  const toPoint = await resolveTargetPoint(to, ctx, 'drag');
 
   if (ctx.speed === 'instant') {
     await ctx.page.mouse.move(fromPoint.x, fromPoint.y);
@@ -239,6 +245,39 @@ export async function executeDrag(
 }
 
 /**
+ * Moves the cursor to `target` along a humanized Bezier path. Pure
+ * positioning — no settle dwell, no element interaction, no event beyond
+ * the standard mousemove sequence from walking the path. Accepts the same
+ * `MouseTarget` shape as `drag`'s endpoints (Locator | string | Point).
+ *
+ * Distinct from `executeHover`:
+ *
+ *  - `move` is positional. Pass coordinates or an element; the cursor
+ *    arrives and stops. Use this for canvas painting, slider drags
+ *    composed with separate up/down, pre-shortcut placement, or cinematic
+ *    beats where the cursor should pause somewhere with no element under it.
+ *  - `hover` is element-bound and includes the post-arrival dwell that
+ *    lets hover-state UI fire (tooltips, dropdown reveals).
+ *
+ * In `speed: 'instant'`, dispatches a single `page.mouse.move()` to the
+ * resolved coordinates — same bypass semantic as the rest of the mouse
+ * primitives in instant mode.
+ */
+export async function executeMove(target: MouseTarget, ctx: MouseContext): Promise<MoveResult> {
+  const point = await resolveTargetPoint(target, ctx, 'move');
+
+  if (ctx.speed === 'instant') {
+    await ctx.page.mouse.move(point.x, point.y);
+    ctx.setMousePosition(point);
+    return { target: point };
+  }
+
+  await walkBezierTo(point, ctx);
+  ctx.setMousePosition(point);
+  return { target: point };
+}
+
+/**
  * Shared core for any action that moves the cursor to an element-resolved
  * target: resolve the bounding box, pick a Gaussian point inside, generate
  * the Bezier path, walk it. Returns the chosen target point.
@@ -275,14 +314,25 @@ async function walkBezierTo(to: Point, ctx: MouseContext): Promise<void> {
   await walkMouseAlongPath(ctx.page, path, travelMs);
 }
 
-/** Resolves a drag endpoint (selector, Locator, or raw Point) to coordinates. */
-async function resolveDragTarget(target: MouseTarget, ctx: MouseContext): Promise<Point> {
+/**
+ * Resolves a mouse target (selector, Locator, or raw Point) to absolute
+ * coordinates. Shared by `executeDrag` (both endpoints) and `executeMove`.
+ *
+ * `action` is just used to make the error message meaningful when an element
+ * lookup fails — "Cannot drag: …" vs "Cannot move: …" reads better than a
+ * generic "cannot resolve" complaint.
+ */
+async function resolveTargetPoint(
+  target: MouseTarget,
+  ctx: MouseContext,
+  action: 'drag' | 'move',
+): Promise<Point> {
   if (isPoint(target)) return target;
   const locator = typeof target === 'string' ? ctx.page.locator(target) : target;
   const box = await locator.boundingBox();
   if (!box) {
     throw new Error(
-      `Cannot drag: element not found or has no bounding box (target: ${describeTarget(target)})`,
+      `Cannot ${action}: element not found or has no bounding box (target: ${describeTarget(target)})`,
     );
   }
   return pickClickPoint(box, ctx.rng, ctx.personality.mouse.clickSpread);

--- a/packages/playwright/src/mouse/index.ts
+++ b/packages/playwright/src/mouse/index.ts
@@ -282,9 +282,10 @@ export async function executeMove(target: MouseTarget, ctx: MouseContext): Promi
  * target: resolve the bounding box, pick a Gaussian point inside, generate
  * the Bezier path, walk it. Returns the chosen target point.
  *
- * Used by `executeClick` and `executeHover` (drag reaches the same logic
- * via `resolveDragTarget` + `walkBezierTo` because its `from` can also be
- * a `Point`).
+ * Used by `executeClick` and `executeHover` for their element-bound paths.
+ * `executeDrag` and `executeMove` accept raw `Point` inputs too, so they
+ * reach the same Bezier walk through `resolveTargetPoint` + `walkBezierTo`
+ * instead of going through here.
  */
 async function moveToTarget(
   target: Locator | string,

--- a/packages/playwright/src/mouse/index.ts
+++ b/packages/playwright/src/mouse/index.ts
@@ -16,23 +16,50 @@ export interface MouseContext {
   readonly setMousePosition: (point: Point) => void;
 }
 
+/** Anything that can resolve to a click/move point. */
+export type MouseTarget = Locator | string | Point;
+
 /** Result of a click action, returned to the caller for observability. */
 export interface ClickResult {
   /** Coordinates the click landed at. */
   readonly target: Point;
 }
 
+/** Result of a hover action. */
+export interface HoverResult {
+  /** Coordinates the cursor settled at. */
+  readonly target: Point;
+}
+
+/** Result of a drag action. */
+export interface DragResult {
+  /** Coordinates the drag started from. */
+  readonly from: Point;
+  /** Coordinates the drag ended at. */
+  readonly to: Point;
+}
+
+/** Options for {@link executeClick}. */
+export interface ClickOptions {
+  /**
+   * Mouse button to press. Defaults to `'left'`. `'right'` produces a
+   * context-menu click; `'middle'` is the wheel-button click (rarely used).
+   */
+  readonly button?: 'left' | 'right' | 'middle';
+}
+
 /**
- * Executes a humanized click on a target locator.
+ * Executes a humanized click on a target.
  *
  * Steps:
- *  1. Resolve the target's bounding box.
- *  2. Pick a point inside it — Gaussian-centered so we never click dead-center,
- *     which is itself a bot signal.
+ *  1. Resolve the target's bounding box (or accept a raw `Point`).
+ *  2. Pick a click point inside it — Gaussian-centered so we never click
+ *     dead-center, which is itself a bot signal.
  *  3. Generate a Bezier path from the current mouse position to the target.
  *  4. Apply velocity profile + micro-jitter via `humanizePath`.
  *  5. Walk the mouse along the path with timing scaled by personality + speed.
- *  6. Click at the target coordinates.
+ *  6. Hover dwell — a real user briefly settles on the target before clicking.
+ *  7. Click at the target coordinates with the configured button.
  *
  * In `speed: 'instant'`, all humanization is bypassed and Playwright's
  * native `locator.click()` is used directly.
@@ -40,14 +67,16 @@ export interface ClickResult {
 export async function executeClick(
   target: Locator | string,
   ctx: MouseContext,
+  options: ClickOptions = {},
 ): Promise<ClickResult> {
+  const button = options.button ?? 'left';
   const locator = typeof target === 'string' ? ctx.page.locator(target) : target;
 
   if (ctx.speed === 'instant') {
     // Read the bounding box BEFORE the click — the click may navigate away
     // or remove the element, after which `boundingBox()` returns null.
     const box = await locator.boundingBox();
-    await locator.click();
+    await locator.click({ button });
     const center = box
       ? { x: box.x + box.width / 2, y: box.y + box.height / 2 }
       : ctx.getMousePosition();
@@ -55,23 +84,7 @@ export async function executeClick(
     return { target: center };
   }
 
-  const box = await locator.boundingBox();
-  if (!box) {
-    throw new Error(
-      `Cannot click: element not found or has no bounding box (target: ${describeTarget(target)})`,
-    );
-  }
-
-  const targetPoint = pickClickPoint(box, ctx.rng, ctx.personality.mouse.clickSpread);
-  const startPoint = ctx.getMousePosition();
-
-  const rawPath = bezierPath(startPoint, targetPoint, ctx.rng, {
-    curvature: ctx.personality.mouse.curvature,
-  });
-  const path = humanizePath(rawPath, ctx.rng);
-
-  const travelMs = computeTravelTime(path, ctx.personality, ctx.speed, ctx.rng);
-  await walkMouseAlongPath(ctx.page, path, travelMs);
+  const targetPoint = await moveToTarget(target, ctx, 'click');
 
   // Hover dwell — a real user briefly settles on the target before clicking.
   const preClickMs = computeDwellTime(
@@ -87,7 +100,7 @@ export async function executeClick(
   // (page closed, target removed mid-flight), the next action still starts
   // from the correct mouse position.
   ctx.setMousePosition(targetPoint);
-  await ctx.page.mouse.click(targetPoint.x, targetPoint.y);
+  await ctx.page.mouse.click(targetPoint.x, targetPoint.y, { button });
 
   // Post-action dwell — a beat after the click before the next action.
   const postActionMs = computeDwellTime(
@@ -100,6 +113,190 @@ export async function executeClick(
   if (postActionMs > 0) await sleep(postActionMs);
 
   return { target: targetPoint };
+}
+
+/**
+ * Executes a humanized hover. Moves the cursor to the target along a Bezier
+ * path, settles on it briefly (the same pre-click dwell `click` uses), and
+ * leaves the cursor parked there. No click is dispatched.
+ *
+ * Useful for hover-triggered UI (tooltips, dropdowns) and for explicitly
+ * positioning the cursor when subsequent actions should originate from a
+ * specific element.
+ *
+ * In `speed: 'instant'`, dispatches a single `page.mouse.move()` to the
+ * element's center — same bypass semantic as click's instant mode.
+ */
+export async function executeHover(
+  target: Locator | string,
+  ctx: MouseContext,
+): Promise<HoverResult> {
+  const locator = typeof target === 'string' ? ctx.page.locator(target) : target;
+
+  if (ctx.speed === 'instant') {
+    const box = await locator.boundingBox();
+    if (!box) {
+      throw new Error(
+        `Cannot hover: element not found or has no bounding box (target: ${describeTarget(target)})`,
+      );
+    }
+    const center = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+    await ctx.page.mouse.move(center.x, center.y);
+    ctx.setMousePosition(center);
+    return { target: center };
+  }
+
+  const targetPoint = await moveToTarget(target, ctx, 'hover');
+
+  // Use the pre-click dwell as the "settle on the hover target" beat —
+  // same shape as click's hover-before-click motion.
+  const dwellMs = computeDwellTime(
+    ctx.personality.dwell.preClickMs,
+    ctx.personality.dwell.preClickJitter,
+    ctx.personality,
+    ctx.speed,
+    ctx.rng,
+  );
+  if (dwellMs > 0) await sleep(dwellMs);
+
+  ctx.setMousePosition(targetPoint);
+  return { target: targetPoint };
+}
+
+/**
+ * Executes a humanized drag from one location to another.
+ *
+ *  1. Move the cursor to the `from` target along a Bezier path.
+ *  2. Press the left mouse button down.
+ *  3. Walk a fresh Bezier path from `from` to `to`, with the button still
+ *     held. This is the actual drag motion the page sees.
+ *  4. Release the button at `to`.
+ *
+ * Both endpoints accept a CSS selector, a Locator, or a literal `Point` —
+ * the last form is essential for canvas/SVG drags where the destination
+ * isn't a DOM element.
+ *
+ * In `speed: 'instant'`, dispatches a single `mouse.down → move → up`
+ * sequence at the resolved endpoints without humanized motion.
+ */
+export async function executeDrag(
+  from: MouseTarget,
+  to: MouseTarget,
+  ctx: MouseContext,
+): Promise<DragResult> {
+  const fromPoint = await resolveDragTarget(from, ctx);
+  const toPoint = await resolveDragTarget(to, ctx);
+
+  if (ctx.speed === 'instant') {
+    await ctx.page.mouse.move(fromPoint.x, fromPoint.y);
+    await ctx.page.mouse.down();
+    await ctx.page.mouse.move(toPoint.x, toPoint.y);
+    await ctx.page.mouse.up();
+    ctx.setMousePosition(toPoint);
+    return { from: fromPoint, to: toPoint };
+  }
+
+  // 1. Move to the start of the drag.
+  await walkBezierTo(fromPoint, ctx);
+  ctx.setMousePosition(fromPoint);
+
+  // 2. Press down. Beat between settling on the source and starting to drag
+  // — real users don't grab the same frame they arrive.
+  const preDragMs = computeDwellTime(
+    ctx.personality.dwell.preClickMs,
+    ctx.personality.dwell.preClickJitter,
+    ctx.personality,
+    ctx.speed,
+    ctx.rng,
+  );
+  if (preDragMs > 0) await sleep(preDragMs);
+  await ctx.page.mouse.down();
+
+  // 3. Walk to the destination with the button still held. Generate a fresh
+  // humanized path so the drag motion has its own curve + jitter shape.
+  const rawPath = bezierPath(fromPoint, toPoint, ctx.rng, {
+    curvature: ctx.personality.mouse.curvature,
+  });
+  const path = humanizePath(rawPath, ctx.rng);
+  const travelMs = computeTravelTime(path, ctx.personality, ctx.speed, ctx.rng);
+  await walkMouseAlongPath(ctx.page, path, travelMs);
+
+  // 4. Release. Post-action dwell so the next action doesn't fire in the
+  // same frame as the drop.
+  await ctx.page.mouse.up();
+  ctx.setMousePosition(toPoint);
+
+  const postActionMs = computeDwellTime(
+    ctx.personality.dwell.postActionMs,
+    ctx.personality.dwell.postActionJitter,
+    ctx.personality,
+    ctx.speed,
+    ctx.rng,
+  );
+  if (postActionMs > 0) await sleep(postActionMs);
+
+  return { from: fromPoint, to: toPoint };
+}
+
+/**
+ * Shared core for any action that moves the cursor to an element-resolved
+ * target: resolve the bounding box, pick a Gaussian point inside, generate
+ * the Bezier path, walk it. Returns the chosen target point.
+ *
+ * Used by `executeClick` and `executeHover` (drag reaches the same logic
+ * via `resolveDragTarget` + `walkBezierTo` because its `from` can also be
+ * a `Point`).
+ */
+async function moveToTarget(
+  target: Locator | string,
+  ctx: MouseContext,
+  action: 'click' | 'hover',
+): Promise<Point> {
+  const locator = typeof target === 'string' ? ctx.page.locator(target) : target;
+  const box = await locator.boundingBox();
+  if (!box) {
+    throw new Error(
+      `Cannot ${action}: element not found or has no bounding box (target: ${describeTarget(target)})`,
+    );
+  }
+  const targetPoint = pickClickPoint(box, ctx.rng, ctx.personality.mouse.clickSpread);
+  await walkBezierTo(targetPoint, ctx);
+  return targetPoint;
+}
+
+/** Walks a humanized Bezier path from the current mouse position to `to`. */
+async function walkBezierTo(to: Point, ctx: MouseContext): Promise<void> {
+  const startPoint = ctx.getMousePosition();
+  const rawPath = bezierPath(startPoint, to, ctx.rng, {
+    curvature: ctx.personality.mouse.curvature,
+  });
+  const path = humanizePath(rawPath, ctx.rng);
+  const travelMs = computeTravelTime(path, ctx.personality, ctx.speed, ctx.rng);
+  await walkMouseAlongPath(ctx.page, path, travelMs);
+}
+
+/** Resolves a drag endpoint (selector, Locator, or raw Point) to coordinates. */
+async function resolveDragTarget(target: MouseTarget, ctx: MouseContext): Promise<Point> {
+  if (isPoint(target)) return target;
+  const locator = typeof target === 'string' ? ctx.page.locator(target) : target;
+  const box = await locator.boundingBox();
+  if (!box) {
+    throw new Error(
+      `Cannot drag: element not found or has no bounding box (target: ${describeTarget(target)})`,
+    );
+  }
+  return pickClickPoint(box, ctx.rng, ctx.personality.mouse.clickSpread);
+}
+
+/** Type guard for raw `Point` targets — distinguishes them from Locator/string. */
+function isPoint(target: MouseTarget): target is Point {
+  return (
+    typeof target === 'object' &&
+    target !== null &&
+    !('boundingBox' in target) &&
+    typeof (target as Point).x === 'number' &&
+    typeof (target as Point).y === 'number'
+  );
 }
 
 /** Bounding box returned by Playwright's `Locator.boundingBox()`. */
@@ -157,7 +354,8 @@ function computeTravelTime(
   return Math.max(0, total);
 }
 
-function describeTarget(target: Locator | string): string {
+function describeTarget(target: MouseTarget): string {
+  if (isPoint(target)) return `point(${target.x}, ${target.y})`;
   return typeof target === 'string' ? target : (target.toString?.() ?? 'locator');
 }
 


### PR DESCRIPTION
## Summary

Implements the primitives that CLAUDE.md's public API shape advertised but the codebase didn't yet ship — closing the documentation/reality gap on `@humanjs/playwright`'s Human surface — plus one new positional primitive (`move`) and a typed `Shortcut` union with IDE autocomplete + strict modifier checking.

```ts
await human.rightClick('#card');                 // context menu
await human.hover('button[aria-label="Help"]');  // hover without clicking, fires hover UI
await human.move({ x: 600, y: 400 });            // pure positioning (canvas, dead space)
await human.move('#anchor');                     // or to an element, no settle dwell
await human.drag('#card-1', '#slot-3');          // selector → selector
await human.drag('#slider', { x: 400, y: 220 }); // selector → point (canvas / slider drags)
await human.paste('#code-editor', longString);   // Cmd-V style, no per-key timing
await human.shortcut('Mod+S');                   // cross-platform Save (Mod auto-maps Mac/Win/Linux)
await human.shortcut('Ctrl+Shift+P');            // typechecks, autocompletes
await human.shortcut('Mosd+S');                  // TS error — 'Mosd' isn't a ShortcutModifier
```

## What's new

```
┌────────────┬────────────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Primitive  │                         Signature                          │                                                                                                                         Notes                                                                                                                         │
├────────────┼────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ hover      │ (target: Locator | string) => Promise<void>                │ Element-bound. Bezier path + post-arrival dwell so hover-state UI fires (tooltips, dropdowns).                                                                                                                                                        │
├────────────┼────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ move       │ (target: MouseTarget) => Promise<void>                     │ Pure positioning. Accepts selector, Locator, or Point. No settle dwell. Distinct from hover: hover is "hover an element," move is "place the cursor here."                                                                                            │
├────────────┼────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ rightClick │ (target: Locator | string) => Promise<void>                │ Same pipeline as click, dispatches with button: 'right'. Opens native context menus.                                                                                                                                                                  │
├────────────┼────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ drag       │ (from: MouseTarget, to: MouseTarget) => Promise<void>      │ Humanized motion to from, mouse-down, second humanized path to to with the button held, mouse-up. Both endpoints accept Locator | string | Point — the Point form is essential for canvas/SVG/slider drags where the destination isn't a DOM element. │
├────────────┼────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ paste      │ (target: Locator | string, value: string) => Promise<void> │ Drives an implicit click to focus (same pattern as type), then dumps the value via page.keyboard.insertText. The Cmd-V semantic — fast, no per-character rhythm.                                                                                      │
├────────────┼────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ shortcut   │ (chord: Shortcut) => Promise<void>                         │ Keyboard chord dispatcher with platform-aware Mod token. Doesn't move the cursor — keyboard shortcuts dispatch against focus, not cursor position. Compose with click/hover/move when you need both.                                                  │
└────────────┴────────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

## Modifier semantics for shortcut

```
┌────────────────────────────────┬──────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────┐
│             Token              │           Resolves to            │                                             Notes                                              │
├────────────────────────────────┼──────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Mod, CmdOrCtrl                 │ Meta on macOS, Control elsewhere │ The right token for cross-platform app shortcuts                                               │
├────────────────────────────────┼──────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Cmd, Command, Meta, Win, Super │ Meta keycode                     │ Literal — does not auto-translate to Control. Same physical key on every OS                    │
├────────────────────────────────┼──────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Ctrl, Control                  │ Control keycode                  │ Literal — stays Control on every platform. Mac-specific things like terminal Ctrl+C still work │
├────────────────────────────────┼──────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Alt, Option, Opt               │ Alt keycode                      │ Literal                                                                                        │
├────────────────────────────────┼──────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Shift                          │ Shift keycode                    │ Literal                                                                                        │
└────────────────────────────────┴──────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────┘
```

Case-insensitive at runtime, canonical-case enforced by the type for codebase consistency.

## Typed Shortcut union — IDE-first ergonomics

chord is a Shortcut template-literal union of every modifier × key combination up to two modifiers. IDEs autocomplete valid chords as you type ('Mod+S', 'Cmd+Shift+P', 'Ctrl+Alt+Delete'), and invalid modifiers are caught at compile time: 'Mosd+S' and 'Hyper+S' are TypeScript errors, not runtime errors.

The escape hatch lives on the key portion only — uncommon keys ('Mod+BracketLeft', 'Mod+NumpadAdd', locale-specific keys) still typecheck under a known modifier. 3+ modifier chords ('Ctrl+Shift+Alt+X') typecheck through the same key-side escape hatch; the cap at two literal modifiers is a TypeScript size-of-union constraint, not a runtime limit.

Lowercase modifiers ('mod+s') and bare uncommon keys without a modifier ('BracketLeft' alone) are TS errors too — runtime still accepts them, but the type steers toward canonical form for codebase consistency. Tests deliberately exercise the runtime fallback via a narrow as Shortcut cast.

## New public types

- Shortcut — the typed chord union used by human.shortcut(chord). Importable for users typing chord strings in their own helpers / config.
- ShortcutModifier — 14 canonical-case modifier names + aliases.
- ShortcutKey — 60+ canonical bare-key entries ('A'–'Z', '0'–'9', 'F1'–'F12', 'ArrowUp', 'Enter', etc.).
- MouseTarget — Locator | string | Point. Used by human.move() and human.drag(). Was internal-only before this release.

## Internal refactor

executeClick now accepts an optional { button } parameter (used by both human.click and human.rightClick); previously the button was hardcoded. The mouse executor extracts a moveToTarget helper shared between click and hover, and a resolveTargetPoint helper (renamed from the internal resolveDragTarget) that handles selector/Locator/Point endpoints for both drag and move. The Human factory introduces a mouseCtx() accessor so every mouse primitive reads from the same lastMousePosition closure — successive actions chain off where the cursor actually was, including across the new primitives.

## Visual demo

New pnpm demo:primitives script: one HTML page, six numbered sections that each interact with the corresponding primitive (CSS :hover tooltip, custom context-menu handler, drag-and-drop card + slider, textarea paste target, dead-space cursor parking, Mod+S save indicator). Sequenced run takes ~15 seconds; PERSONALITY= env var supported same as the other demos.

## Quality

- 169 playwright unit tests (was 123) — 46 new tests covering the six primitives, their event emission, instant-mode bypass paths, edge cases, and the chord parser.
- 17 of those are pure-function tests on resolveChord — platform mapping (Mod on Mac vs elsewhere), aliases (Cmd/Command/Meta/Win/Super), case-insensitivity, error paths, whitespace tolerance, CamelCase preservation.
- 10 integration tests still green. Lint + typecheck clean. No as any / as never in packages/playwright/src.
- Six /branch-review passes, all findings addressed.

## Migration

None — all six primitives are net-new on the Human interface. No existing behavior changes. executeClick's signature gained an optional third argument (ClickOptions); the previous two-argument call sites continue to work unchanged.

## Test plan

- [x] pnpm test — all unit tests pass
- [x] pnpm test:integration — chromium-based integration tests pass
- [x] pnpm lint && pnpm typecheck — clean
- [x] pnpm demo:primitives — sequenced six-primitive demo runs cleanly
- [x] PERSONALITY=distracted pnpm demo:primitives — visibly wider drag scatter, longer dwells, different click placement on the same targets
- [x] In your editor, type await human.shortcut(' and verify IntelliSense suggests 'Mod+...', 'Cmd+...', 'Ctrl+...', etc.
- [x] Confirm await human.shortcut('Mosd+S') shows a red squiggle in your editor (TS error)