### PR TITLE
refactor(examples): type the compare-demo window extension

### DIFF
--- a/examples/compare-demo.ts
+++ b/examples/compare-demo.ts
@@ -63,6 +63,21 @@ interface PathSegment {
   readonly target: string;
 }
 
+declare global {
+  interface Window {
+    /**
+     * Demo entry point installed by the inline `<script>` inside `makeDemoHtml`
+     * — starts the dual-cursor animation against both lanes' precomputed
+     * segments. Typed here so this file can call `window.__startDemo(...)`
+     * inside `page.evaluate()` without an `as any` cast. Marked optional
+     * because TS can't statically prove the in-page script has run yet;
+     * the optional-call `?.` at the call site handles the unlikely "script
+     * never injected" case gracefully.
+     */
+    __startDemo?: (data: { left: PathSegment[]; right: PathSegment[] }) => void;
+  }
+}
+
 function planSequence(personality: Personality, seed: string): PathSegment[] {
   const rng = createRng(seed);
   const segments: PathSegment[] = [];
@@ -412,8 +427,7 @@ async function main() {
 
     await page.evaluate(
       ({ left, right }) => {
-        // biome-ignore lint/suspicious/noExplicitAny: window extension for the demo
-        (window as any).__startDemo({ left, right });
+        window.__startDemo?.({ left, right });
       },
       { left: segmentsA, right: segmentsB },
     );


### PR DESCRIPTION
## Summary

Drops the lone `as any` cast in the workspace by teaching TypeScript about the demo's custom `window.__startDemo` global via `declare global`. Pre-existing cast lived in `examples/compare-demo.ts:416` with a `biome-ignore` comment; it's now properly typed and the ignore is gone.