### PR TITLE
feat(playwright): human.press supersedes human.shortcut

### DIFF
--- a/.changeset/press-supersedes-shortcut.md
+++ b/.changeset/press-supersedes-shortcut.md
@@ -33,19 +33,20 @@ A single key like `Tab` isn't a "shortcut," and forcing users through `human.sho
 | Action params `{ type: 'shortcut', params: { chord } }` | `{ type: 'press', params: { key } }` |
 | Runtime error: `"Invalid shortcut modifier: ..."` | `"Invalid key modifier: ..."` |
 
-## Type changes
+## Type behavior (unchanged from `Shortcut`)
 
-The `KeyOrChord` union adds a `(string & {})` escape hatch at the bare-key position, so uncommon keys (`'BracketLeft'`, `'NumpadAdd'`, locale-specific keys, …) typecheck without a modifier:
+`KeyOrChord` keeps the same compile-time guarantees as the previous `Shortcut` type:
 
 ```ts
-await human.press('BracketLeft');   // ✓ now typechecks (was a TS error under Shortcut)
-await human.press('Mod+S');         // ✓
 await human.press('Tab');           // ✓ autocompletes from KeyName
-await human.press('Mosd+S');        // ✗ TS error — modifier still strictly closed
+await human.press('Mod+S');         // ✓
+await human.press('Mod+BracketLeft'); // ✓ — key-side escape hatch under a modifier
+await human.press('Mosd+S');        // ✗ TS error — modifier strictly closed
 await human.press('Hyper+S');       // ✗ TS error
+await human.press('BracketLeft');   // ✗ TS error — bare uncommon keys need a cast
 ```
 
-Modifier-typo protection is preserved: modifier names remain a closed union, so `'Mosd+S'` / `'Hyper+S'` / etc. are still caught at compile time.
+TypeScript's template-literal types can't express "any bare string, but not one shaped like a chord," so allowing `'BracketLeft'` at the bare position would also let `'Mosd+S'` slip through. Modifier-typo protection is the more valuable half — uncommon bare keys (rare in real bindings) require `'BracketLeft' as KeyOrChord`.
 
 ## Migration
 

--- a/.changeset/press-supersedes-shortcut.md
+++ b/.changeset/press-supersedes-shortcut.md
@@ -1,0 +1,66 @@
+---
+"@humanjs/playwright": minor
+"@humanjs/core": patch
+---
+
+**Breaking:** `human.shortcut(chord)` is renamed to `human.press(key)`, and now accepts bare keys in addition to chords.
+
+```ts
+// Before
+await human.shortcut('Mod+S');
+await human.shortcut('Enter');   // worked, but the name read wrong
+
+// After
+await human.press('Mod+S');      // chord
+await human.press('Tab');        // bare key — what `shortcut('Tab')` always meant
+await human.press('Enter');
+await human.press('Escape');
+```
+
+## Why
+
+A single key like `Tab` isn't a "shortcut," and forcing users through `human.shortcut('Tab')` was a real readability smell. `press` matches Playwright's own `keyboard.press()` — one method that accepts either a bare key or a `Modifier+Key` chord — and removes the API duplication.
+
+## What changed
+
+| Old | New |
+|---|---|
+| `human.shortcut(chord)` | `human.press(key)` |
+| `Shortcut` type | `KeyOrChord` |
+| `ShortcutKey` type | `KeyName` |
+| `ShortcutModifier` type | `KeyModifier` |
+| `ShortcutResult` type | `PressResult` |
+| Action params `{ type: 'shortcut', params: { chord } }` | `{ type: 'press', params: { key } }` |
+| Runtime error: `"Invalid shortcut modifier: ..."` | `"Invalid key modifier: ..."` |
+
+## Type changes
+
+The `KeyOrChord` union adds a `(string & {})` escape hatch at the bare-key position, so uncommon keys (`'BracketLeft'`, `'NumpadAdd'`, locale-specific keys, …) typecheck without a modifier:
+
+```ts
+await human.press('BracketLeft');   // ✓ now typechecks (was a TS error under Shortcut)
+await human.press('Mod+S');         // ✓
+await human.press('Tab');           // ✓ autocompletes from KeyName
+await human.press('Mosd+S');        // ✗ TS error — modifier still strictly closed
+await human.press('Hyper+S');       // ✗ TS error
+```
+
+Modifier-typo protection is preserved: modifier names remain a closed union, so `'Mosd+S'` / `'Hyper+S'` / etc. are still caught at compile time.
+
+## Migration
+
+Pure renames — no behavior changes beyond accepting bare uncommon keys:
+
+```diff
+- import { type Shortcut } from '@humanjs/playwright';
++ import { type KeyOrChord } from '@humanjs/playwright';
+
+- await human.shortcut('Mod+S');
++ await human.press('Mod+S');
+
+  // Plugin handler:
+- if (action.type === 'shortcut') { console.log(action.params.chord); }
++ if (action.type === 'press') { console.log(action.params.key); }
+```
+
+`@humanjs/core`'s `KnownActionType` swapped `'shortcut'` for `'press'` to match. The `(string & {})` widening on `ActionType` means custom adapters emitting `'shortcut'` still typecheck against the loose form, but they won't autocomplete.

--- a/.changeset/press-supersedes-shortcut.md
+++ b/.changeset/press-supersedes-shortcut.md
@@ -3,7 +3,7 @@
 "@humanjs/core": patch
 ---
 
-**Breaking:** `human.shortcut(chord)` is renamed to `human.press(key)`, and now accepts bare keys in addition to chords.
+**Breaking:** `human.shortcut(chord)` is renamed to `human.press(key)` — `shortcut('Tab')` always typechecked, but the name read wrong for single keys. `press` is what Playwright's own `keyboard.press()` does, and reads naturally for both bare keys and chords.
 
 ```ts
 // Before
@@ -58,7 +58,7 @@ We tried a `(string & {})` escape hatch on the key portion of chords to make the
 
 ## Migration
 
-Pure renames — no behavior changes beyond accepting bare uncommon keys:
+Most call sites are a pure rename:
 
 ```diff
 - import { type Shortcut } from '@humanjs/playwright';
@@ -67,9 +67,26 @@ Pure renames — no behavior changes beyond accepting bare uncommon keys:
 - await human.shortcut('Mod+S');
 + await human.press('Mod+S');
 
-  // Plugin handler:
+  // Plugin handler — silent failure mode without this update:
 - if (action.type === 'shortcut') { console.log(action.params.chord); }
 + if (action.type === 'press') { console.log(action.params.key); }
 ```
 
-`@humanjs/core`'s `KnownActionType` swapped `'shortcut'` for `'press'` to match. The `(string & {})` widening on `ActionType` means custom adapters emitting `'shortcut'` still typecheck against the loose form, but they won't autocomplete.
+**Stricter type — note for uncommon-key chords.** The old `Shortcut` type included a `(string & {})` escape hatch on the key portion of chords, so `human.shortcut('Mod+BracketLeft')` typechecked without a cast. `KeyOrChord` is fully enumerated for IntelliSense (so `'Shift+'` autocompletes every `Shift+<key>` combo), and the trade-off is that uncommon-key chords now need an explicit cast:
+
+```diff
+- await human.shortcut('Mod+BracketLeft');
++ await human.press('Mod+BracketLeft' as KeyOrChord);
+
+- await human.shortcut('Ctrl+Shift+Alt+K');
++ await human.press('Ctrl+Shift+Alt+K' as KeyOrChord);
+```
+
+If you have a lot of these in one codebase, a tiny local helper keeps the cast contained:
+
+```ts
+const press = (k: string) => human.press(k as KeyOrChord);
+await press('Mod+BracketLeft');
+```
+
+`@humanjs/core`'s `KnownActionType` swapped `'shortcut'` for `'press'` to match. The `(string & {})` widening on `ActionType` means custom adapters emitting `'shortcut'` still typecheck against the loose form, but they won't autocomplete and they won't match `action.type === 'press'`-style plugin handlers.

--- a/.changeset/press-supersedes-shortcut.md
+++ b/.changeset/press-supersedes-shortcut.md
@@ -33,20 +33,28 @@ A single key like `Tab` isn't a "shortcut," and forcing users through `human.sho
 | Action params `{ type: 'shortcut', params: { chord } }` | `{ type: 'press', params: { key } }` |
 | Runtime error: `"Invalid shortcut modifier: ..."` | `"Invalid key modifier: ..."` |
 
-## Type behavior (unchanged from `Shortcut`)
+## Type behavior
 
-`KeyOrChord` keeps the same compile-time guarantees as the previous `Shortcut` type:
+`KeyOrChord` is fully enumerated — `KeyName | ${KeyModifier}+${KeyName} | ${KeyModifier}+${KeyModifier}+${KeyName}` — so every `Modifier+Key` combination is an autocomplete-able literal. Type `'Shift+'` in your IDE and you get the full `Shift+A`, `Shift+B`, …, `Shift+Tab` list as completions.
 
 ```ts
-await human.press('Tab');           // ✓ autocompletes from KeyName
-await human.press('Mod+S');         // ✓
-await human.press('Mod+BracketLeft'); // ✓ — key-side escape hatch under a modifier
-await human.press('Mosd+S');        // ✗ TS error — modifier strictly closed
-await human.press('Hyper+S');       // ✗ TS error
-await human.press('BracketLeft');   // ✗ TS error — bare uncommon keys need a cast
+await human.press('Tab');             // ✓ autocompletes from KeyName
+await human.press('Mod+S');           // ✓ autocompletes from Modifier × KeyName
+await human.press('Shift+ArrowDown'); // ✓
+await human.press('Mod+Shift+P');     // ✓ two-modifier chord
+await human.press('Mosd+S');          // ✗ TS error — modifier closed set
+await human.press('Hyper+S');         // ✗ TS error
+await human.press('BracketLeft');     // ✗ TS error — outside KeyName
 ```
 
-TypeScript's template-literal types can't express "any bare string, but not one shaped like a chord," so allowing `'BracketLeft'` at the bare position would also let `'Mosd+S'` slip through. Modifier-typo protection is the more valuable half — uncommon bare keys (rare in real bindings) require `'BracketLeft' as KeyOrChord`.
+**Escape hatch.** Uncommon keys (`'BracketLeft'`, `'NumpadAdd'`, locale keys) and 3+ modifier chords (`'Ctrl+Shift+Alt+K'`) need a cast at the call site — the runtime parser handles them, the type just doesn't enumerate them:
+
+```ts
+await human.press('Mod+BracketLeft' as KeyOrChord);
+await human.press('Ctrl+Shift+Alt+K' as KeyOrChord);
+```
+
+We tried a `(string & {})` escape hatch on the key portion of chords to make these work without a cast, but the cost was unacceptable: any `(string & {})` member in the union collapses TypeScript's template-literal IntelliSense to a single wide template, so completions for `'Shift+...'` / `'Mod+...'` disappear entirely. Autocomplete for the 95% case is the killer feature; the cast for rare keys is a worthwhile trade.
 
 ## Migration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,8 @@ await human.type(selector, value);        // click, then realistic typing rhythm
 await human.paste(selector, value);       // Cmd-V style (no per-char timing)
 await human.read(text);                   // dwell based on word count
 await human.scroll('natural');
-await human.shortcut('Mod+S');            // 'Mod' auto-maps: Meta on Mac, Control elsewhere
+await human.press('Mod+S');               // chord — 'Mod' auto-maps: Meta on Mac, Control elsewhere
+await human.press('Tab');                  // bare key — single keys work too
 
 const rec = await human.record(async () => { /* actions */ });
 await rec.toVideo('out.mp4');                // shipped

--- a/examples/primitives-demo.ts
+++ b/examples/primitives-demo.ts
@@ -7,7 +7,7 @@
  *    3. rightClick  — context-menu click, custom menu appears
  *    4. drag        — selector → selector card move, then selector → Point slider
  *    5. type        — humanized per-key rhythm into an input
- *    6. shortcut    — Mod+S triggers a Save indicator (cursor position irrelevant)
+ *    6. press       — Mod+S triggers a Save indicator (cursor position irrelevant)
  *    7. paste       — long string lands in a textarea via insertText (no rhythm).
  *                     The paste section deliberately lives below the fold so
  *                     this step exercises the auto-scroll path before typing.
@@ -462,7 +462,7 @@ const DEMO_HTML = /* html */ `
 
       <!-- 6. Shortcut -->
       <div class="block">
-        <div class="label"><span class="num">6</span> shortcut</div>
+        <div class="label"><span class="num">6</span> press</div>
         <div class="save-host">
           <div class="doc">document — type to edit</div>
           <div class="save-indicator" id="save-indicator">unsaved</div>
@@ -583,7 +583,7 @@ const DEMO_HTML = /* html */ `
       });
       window.addEventListener('mouseup', () => { sliderDragging = false; });
 
-      // --- 7. shortcut --- Mod+S handler flashes the save indicator
+      // --- 6. press --- Mod+S handler flashes the save indicator
       const saveIndicator = document.getElementById('save-indicator');
       window.addEventListener('keydown', (e) => {
         const isSaveCombo = (e.metaKey || e.ctrlKey) && (e.key === 's' || e.key === 'S');
@@ -629,7 +629,7 @@ async function main() {
 
   console.log(`Personality: ${personality}`);
   console.log(
-    'Demoing: hover → click → rightClick → drag → type → shortcut → paste → read → move → scroll\n',
+    'Demoing: hover → click → rightClick → drag → type → press → paste → read → move → scroll\n',
   );
 
   const browser = await chromium.launch({ headless: false });
@@ -673,11 +673,11 @@ async function main() {
     await human.type('#type-input', 'demo@humanjs.dev');
     await human.sleep(900);
 
-    // 6. Shortcut — Mod+S triggers the page's save handler, indicator flashes.
+    // 6. Press — Mod+S triggers the page's save handler, indicator flashes.
     // The input from step 5 is still focused; cursor position is irrelevant
-    // to which element receives a keyboard shortcut — only focus matters.
-    console.log('6. shortcut → Mod+S triggers Save (against the focused input)');
-    await human.shortcut('Mod+S');
+    // to which element receives a key press — only focus matters.
+    console.log('6. press → Mod+S triggers Save (against the focused input)');
+    await human.press('Mod+S');
     await human.sleep(2000);
 
     // 7. Paste — the paste section lives below an 820px spacer, so its

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -68,7 +68,7 @@ export type KnownActionType =
   | 'read'
   | 'rightClick'
   | 'scroll'
-  | 'shortcut'
+  | 'press'
   | 'sleep'
   | 'type';
 

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -46,6 +46,65 @@ await human.type('input[name="email"]', 'gonzalo@example.com');
 
 Pass a `seed` and every random decision (path curvature, typo placement, keystroke jitter) becomes reproducible. Same seed + same personality + same value = same keystrokes.
 
+### Primitives
+
+The full `Human` surface, at a glance. Each one fires real DOM events through Playwright; the humanization wraps the timing and the path, not the dispatch.
+
+| Primitive | Purpose |
+|---|---|
+| `goto(url)` | Navigate the page. |
+| `click(target)` | Bezier path → pre-click hover dwell → click. |
+| `rightClick(target)` | Same as `click` but with `button: 'right'`. Fires `contextmenu`. |
+| `hover(target)` | Walk to the element and settle. No click. Hover-state UI (tooltips, dropdowns) fires. |
+| `move(target)` | Walk to a `Locator \| string \| Point`. Pure positional motion. No dwell, no element interaction — use this when you want the cursor parked somewhere with no implied click. |
+| `drag(from, to)` | Two-phase Bezier (to start → mouse down → curve to end → mouse up). Both endpoints accept `Locator \| string \| Point` — `Point` is essential for canvas / SVG / slider drags. |
+| `type(target, value)` | Clicks the field for focus, then per-key rhythm with optional typos + Backspace recovery. |
+| `paste(target, value)` | Clicks the field for focus, then `insertText` — instant insertion, no per-character timing. Cmd-V semantic. |
+| `press(key)` | Single key (`'Tab'`) or chord (`'Mod+S'`). See [Keyboard](#keyboard) below. |
+| `read(target)` | Dwell as a reader would. Cursor scans across the text in humanized mode. See [Reading](#reading). |
+| `scroll(target?)` | Multi-segment wheel motion, bell-curve velocity, optional mid-scroll pauses. See [Scrolling](#scrolling). |
+| `sleep(ms)` | Re-exported from `@humanjs/core` for convenience. |
+| `record(fn)` | Wrap a block and export as mp4 / gif / JSON. See [Recording](#recording). |
+
+Targets accept a CSS selector string or a Playwright `Locator`. `move` and `drag` additionally accept raw `Point` coordinates. Auto-scroll fires for any element-bound primitive when the target is outside the viewport — humanized scroll in normal speed modes, `scrollIntoViewIfNeeded` in `'instant'`.
+
+### Keyboard
+
+```ts
+await human.press('Tab');               // single key
+await human.press('Mod+S');             // cross-platform save (Meta on Mac, Control elsewhere)
+await human.press('Cmd+Shift+P');       // literal Meta+Shift+P on every OS
+await human.press('Control+C');         // literal Ctrl+C
+await human.press('Shift+ArrowDown');   // extend selection down
+```
+
+`press` accepts a single key or a keyboard chord. IDE autocomplete enumerates every `Modifier+Key` combination — type `'Shift+'` and you get `Shift+A`, `Shift+B`, …, `Shift+Tab`, etc. as completions.
+
+**Modifier rules:**
+
+| Token | Resolves to | Notes |
+|---|---|---|
+| `Mod` / `CmdOrCtrl` / `CommandOrControl` | `Meta` on macOS, `Control` elsewhere | The right token for cross-platform app shortcuts. All three are aliases; `Mod` is shortest. |
+| `Cmd` / `Command` / `Meta` / `Win` / `Super` | `Meta` keycode | Literal — does **not** auto-translate to `Control`. Same physical key on every OS. |
+| `Ctrl` / `Control` | `Control` keycode | Literal — stays `Control` everywhere, so Mac-specific things like terminal `Ctrl+C` still work. |
+| `Alt` / `Option` / `Opt` | `Alt` keycode | Literal. |
+| `Shift` | `Shift` keycode | Literal. |
+
+Case-insensitive at runtime. Modifier typos (`'Mosd+S'`) are caught at compile time — the modifier union is closed.
+
+**Escape hatch for uncommon keys.** Uncommon keys (`'BracketLeft'`, `'NumpadAdd'`, locale-specific keys) and 3+ modifier chords aren't in the typed `KeyOrChord` union. Cast at the call site — the runtime parser handles them:
+
+```ts
+import type { KeyOrChord } from '@humanjs/playwright';
+
+await human.press('Mod+BracketLeft' as KeyOrChord);
+await human.press('Ctrl+Shift+Alt+K' as KeyOrChord);
+```
+
+Why a cast? Including a `(string & {})` escape hatch in the type collapses TypeScript's literal-template IntelliSense, so `'Shift+...'` completions disappear. Autocomplete wins for the 95% case; the cast handles the 5%.
+
+**Press does NOT move the cursor** — keyboard input dispatches against focus, not cursor position. Compose with `click` / `hover` / `move` when you need both.
+
 ### Reading
 
 ```ts

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -105,6 +105,53 @@ Why a cast? Including a `(string & {})` escape hatch in the type collapses TypeS
 
 **Press does NOT move the cursor** — keyboard input dispatches against focus, not cursor position. Compose with `click` / `hover` / `move` when you need both.
 
+### Typing
+
+```ts
+await human.type('input[name="email"]', 'gonzalo@example.com');
+```
+
+`type` simulates a real keyboard. Per-key delays scale with the personality's typing speed (with jitter); the `distracted` personality occasionally injects QWERTY typos and recovers them with `Backspace`. Single ASCII characters route through Playwright's `keyboard.press` so per-key handlers (autocomplete, validation) fire; non-ASCII characters fall back to `keyboard.insertText` since `press` is keyboard-layout-aware and can't reliably synthesize `é` or `🎉` on every layout.
+
+Like every other element-bound primitive, `type` clicks the field first to focus it — a real user moves the cursor to the input and clicks; they don't teleport-focus a field. The implicit click is a sub-step of the `'type'` action, not its own timeline event.
+
+**Privacy.** The typed value is never echoed to plugin params. The `'type'` action surfaces only `{ target, length }` — by design, since this argument may carry passwords, tokens, or other secrets.
+
+In `'instant'` speed mode, the humanized loop is bypassed for Playwright's `locator.pressSequentially(value, { delay: 0 })` — per-key events still fire, just without the timing.
+
+### Pasting
+
+```ts
+await human.paste('textarea', longCodeBlock);
+```
+
+The Cmd-V semantic. `paste` clicks the field for focus (same mouse-led pattern as `type`), then dispatches the value via `page.keyboard.insertText` — instant, no per-character timing, the value lands in the field in a single beat.
+
+When to use which:
+
+- **`type`** — short strings where the per-key rhythm is the showcase (form fills, search queries, demo content). Slow on long input by design.
+- **`paste`** — long content where humanized typing would be slow and uninformative (code blocks, multi-paragraph text, anything you'd realistically Cmd-V into the field).
+
+`paste` does NOT fire the page's `paste` event. If you need that, drive it yourself: write to the clipboard, focus the field, then `human.press('Mod+V')`.
+
+**Privacy.** Same posture as `type` — `{ target, length }` only.
+
+### Dragging
+
+```ts
+await human.drag('#card-1', '#slot-3');                       // selector → selector
+await human.drag('#slider-thumb', { x: 800, y: 450 });        // selector → Point
+await human.drag('#card', locator);                           // any combination
+```
+
+Two-phase Bezier motion: walk to `from`, press the left button, curve to `to` with the button held, release. Each endpoint accepts a `Locator`, a CSS selector, or a raw `Point` coordinate.
+
+The `Point` form is essential for canvas / SVG drags where the destination isn't a DOM element — sliders, signature pads, freehand drawing tools. The selector-to-Point shape is the canonical "drag this thumb to that position" pattern.
+
+Both Bezier paths (start-to-`from` and `from`-to-`to`) are humanized independently with their own curvature and jitter, so drags don't trace robotic straight lines mid-flight.
+
+Auto-scroll fires on both endpoints when needed — if the destination is below the fold, the cursor scrolls to bring it into view before releasing, the way a real user would scroll-to-grab then scroll-to-drop. Raw `Point` endpoints opt out of auto-scroll (explicit coordinates are the caller's responsibility).
+
 ### Reading
 
 ```ts

--- a/packages/playwright/src/index.test.ts
+++ b/packages/playwright/src/index.test.ts
@@ -1,7 +1,7 @@
 import type { HumanPlugin } from '@humanjs/core';
 import type { Locator, Page } from 'playwright';
 import { describe, expect, it, vi } from 'vitest';
-import { createHuman, type Shortcut } from './index';
+import { createHuman, type KeyOrChord } from './index';
 
 interface MockLocator {
   focus: ReturnType<typeof vi.fn>;
@@ -731,14 +731,14 @@ describe('createHuman', () => {
     });
   });
 
-  describe('shortcut', () => {
+  describe('press', () => {
     it('dispatches the resolved chord via page.keyboard.press', async () => {
       const originalPlatform = process.platform;
       Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
       try {
         const { page, pressedKeys } = makeKeyboardMockPage();
         const human = await createHuman(page);
-        await human.shortcut('Mod+S');
+        await human.press('Mod+S');
         expect(pressedKeys).toEqual(['Meta+S']);
       } finally {
         Object.defineProperty(process, 'platform', {
@@ -748,36 +748,34 @@ describe('createHuman', () => {
       }
     });
 
-    it('dispatches single-key shortcuts (no modifier)', async () => {
+    it('dispatches a single key with no modifier', async () => {
       const { page, pressedKeys } = makeKeyboardMockPage();
       const human = await createHuman(page);
-      await human.shortcut('Enter');
+      await human.press('Enter');
       expect(pressedKeys).toEqual(['Enter']);
     });
 
-    it("emits a 'shortcut' action with the original chord to plugins", async () => {
+    it("emits a 'press' action with the original key to plugins", async () => {
       const beforeAction = vi.fn();
       const { page } = makeKeyboardMockPage();
       const human = await createHuman(page, { plugins: [{ name: 'p', beforeAction }] });
-      await human.shortcut('Cmd+Shift+P');
+      await human.press('Cmd+Shift+P');
       expect(beforeAction).toHaveBeenCalledWith({
-        type: 'shortcut',
-        params: { chord: 'Cmd+Shift+P' },
+        type: 'press',
+        params: { key: 'Cmd+Shift+P' },
       });
     });
 
     it('throws on an invalid modifier and never dispatches', async () => {
       const { page, pressedKeys } = makeKeyboardMockPage();
       const human = await createHuman(page);
-      // `'Hyper+S'` is a TS error too (Hyper isn't a `ShortcutModifier`),
-      // so the type guard is the first line of defense. The cast exercises
+      // `'Hyper+S'` is a TS error too (Hyper isn't a `KeyModifier`), so
+      // the type guard is the first line of defense. The cast exercises
       // the runtime fallback — important because real callers might pass
       // strings from config / user input that TS can't validate at compile.
-      // Cast to `Shortcut` (not `any` / `never`) — same pattern as the
+      // Cast to `KeyOrChord` (not `any` / `never`) — same pattern as the
       // `asChord` helper in `keyboard.test.ts`.
-      await expect(human.shortcut('Hyper+S' as Shortcut)).rejects.toThrow(
-        /Invalid shortcut modifier/,
-      );
+      await expect(human.press('Hyper+S' as KeyOrChord)).rejects.toThrow(/Invalid key modifier/);
       expect(pressedKeys).toEqual([]);
     });
   });

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -11,7 +11,7 @@ import {
   sleep,
 } from '@humanjs/core';
 import type { Locator, Page } from 'playwright';
-import { executePaste, executeShortcut, executeType, type Shortcut } from './keyboard';
+import { executePaste, executePress, executeType, type KeyOrChord } from './keyboard';
 import { executeClick, executeDrag, executeHover, executeMove, type MouseTarget } from './mouse';
 import { executeRead, type ReadOptions, type ReadResult, type ReadTarget } from './reading';
 import {
@@ -86,7 +86,7 @@ export {
   type Page,
   webkit,
 } from 'playwright';
-export type { Shortcut, ShortcutKey, ShortcutModifier } from './keyboard';
+export type { KeyModifier, KeyName, KeyOrChord, PressResult } from './keyboard';
 export type { MouseTarget } from './mouse';
 export type { InstallMouseHelperOptions } from './mouse-helper';
 export { installMouseHelper } from './mouse-helper';
@@ -180,7 +180,7 @@ export interface Human {
    * Distinct from `hover()`: `hover` is element-bound and includes a settle
    * dwell to let hover-state UI fire (tooltips, dropdowns). `move` is
    * positional only — use it when you want the cursor placed somewhere
-   * without implying interaction with what's under it (pre-shortcut
+   * without implying interaction with what's under it (pre-press
    * placement, canvas painting, cinematic beats).
    *
    * In `speed: 'instant'`, dispatches one `mouse.move()` at the resolved
@@ -218,7 +218,7 @@ export interface Human {
    *
    * Use this for long strings (code blocks, multi-line content, secrets)
    * where the typing simulation would be slow and unnecessary. If you need
-   * the page's `paste` event handler to fire, call `human.shortcut('Mod+V')`
+   * the page's `paste` event handler to fire, call `human.press('Mod+V')`
    * after setting clipboard contents yourself.
    *
    * In `speed: 'instant'`, behaves identically — paste is already instant
@@ -226,8 +226,10 @@ export interface Human {
    */
   paste(target: Locator | string, value: string): Promise<void>;
   /**
-   * Dispatch a keyboard chord like `'Mod+S'`, `'Cmd+Shift+P'`, `'Ctrl+C'`,
-   * or just `'Enter'`. Modifier rules:
+   * Press a single key (`'Tab'`, `'Enter'`, `'Escape'`, `'ArrowDown'`, …)
+   * or a keyboard chord (`'Mod+S'`, `'Cmd+Shift+P'`, `'Ctrl+C'`, …).
+   *
+   * Modifier rules:
    *
    * - `Mod` / `CmdOrCtrl` — magic: `Meta` on Mac, `Control` elsewhere. Use
    *   for cross-platform app shortcuts.
@@ -237,14 +239,18 @@ export interface Human {
    * - `Alt`, `Option`, `Opt` — literal Alt.
    * - `Shift` — literal Shift.
    *
-   * Case-insensitive. Throws on unknown modifiers. The `Shortcut` type is
-   * a template-literal union of every modifier × key combination (up to
-   * three modifiers + a key), so IDEs autocomplete valid chords as you
-   * type. Less common keys (`BracketLeft`, `NumpadAdd`, etc.) still
-   * typecheck through the union's string escape hatch — they just don't
-   * autocomplete.
+   * Case-insensitive. Throws on unknown modifiers. The `KeyOrChord` type
+   * is a template-literal union of every modifier × key combination (up to
+   * two literal modifiers + a key), so IDEs autocomplete common bare keys
+   * and chords as you type. Less common keys (`BracketLeft`, `NumpadAdd`,
+   * locale-specific keys) still typecheck through the union's string
+   * escape hatch — they just don't autocomplete.
+   *
+   * Does **not** move the cursor — keyboard input dispatches against
+   * focus, not cursor position. Compose with `click` / `hover` / `move`
+   * when you need both.
    */
-  shortcut(chord: Shortcut): Promise<void>;
+  press(key: KeyOrChord): Promise<void>;
   /**
    * Dwell as if reading `target` — the third pillar of humanization after
    * the cursor and the keyboard. Real users pause to read; HumanJS models
@@ -553,9 +559,9 @@ export async function createHuman(page: Page, options: CreateHumanOptions = {}):
         },
       );
     },
-    async shortcut(chord) {
-      await performAction({ type: 'shortcut', params: { chord } }, async () => {
-        await executeShortcut(chord, { page, personality, rng, speed });
+    async press(key) {
+      await performAction({ type: 'press', params: { key } }, async () => {
+        await executePress(key, { page, personality, rng, speed });
       });
     },
     async read(target, options) {

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -231,8 +231,9 @@ export interface Human {
    *
    * Modifier rules:
    *
-   * - `Mod` / `CmdOrCtrl` — magic: `Meta` on Mac, `Control` elsewhere. Use
-   *   for cross-platform app shortcuts.
+   * - `Mod` / `CmdOrCtrl` / `CommandOrControl` — magic: `Meta` on Mac,
+   *   `Control` elsewhere. Use for cross-platform app shortcuts. The three
+   *   are aliases; `Mod` is shortest.
    * - `Cmd`, `Command`, `Meta`, `Win`, `Super` — literal `Meta` keycode
    *   (Command on Mac, Windows key on Windows, Super on Linux).
    * - `Ctrl`, `Control` — literal Control. Stays Control on every OS.

--- a/packages/playwright/src/keyboard/index.ts
+++ b/packages/playwright/src/keyboard/index.ts
@@ -240,15 +240,14 @@ export type KeyName =
  * Strings accepted by `human.press(key)`:
  *
  *  - A bare known key: `'Enter'`, `'F4'`, `'ArrowDown'`, `'S'`, …
- *  - Any other bare key via escape hatch: `'BracketLeft'`, `'NumpadAdd'`,
- *    locale-specific keys — they typecheck, they just don't autocomplete.
  *  - One known modifier + any key: `'Mod+S'`, `'Mod+BracketLeft'`, …
  *  - Two known modifiers + any key: `'Mod+Shift+P'`, `'Ctrl+Alt+Delete'`, …
  *
- * The escape hatch lives on the **key portions only**, never on modifiers —
- * so modifier typos get caught at compile time (`'Mosd+S'` is a TS error)
- * while less-common keys (`'BracketLeft'`, `'NumpadAdd'`, locale keys)
- * typecheck under both bare-key and `Modifier+...` paths.
+ * The escape hatch lives on the **key portion of a chord**, never at the
+ * bare-key position and never on the modifier — so modifier typos get
+ * caught at compile time (`'Mosd+S'` is a TS error) while less-common
+ * keys (`'BracketLeft'`, `'NumpadAdd'`, locale-specific keys) still
+ * typecheck under a known modifier.
  *
  * 3+ modifier chords (`'Ctrl+Shift+Alt+X'`) typecheck through the same
  * key-side escape hatch — TS sees two modifiers + `'Alt+X'` as the "key,"
@@ -256,13 +255,18 @@ export type KeyName =
  * two literal modifiers in the type is a TypeScript size-of-union
  * constraint, not a runtime limit.
  *
- * Lowercase modifiers (`'mod+s'`) DON'T typecheck even though the runtime
- * accepts them — TS-strict steers users toward the canonical casing,
- * which keeps key strings consistent across a codebase.
+ * Bare uncommon keys (`'BracketLeft'` alone, no modifier) DON'T typecheck
+ * — that route would slip past the modifier guard, since TypeScript can't
+ * express "any string not containing `+`." Workarounds: use a modifier,
+ * or `'BracketLeft' as KeyOrChord`. The case is vanishingly rare in real
+ * bindings; modifier-typo protection is the more valuable half.
+ *
+ * Lowercase modifiers (`'mod+s'`) also DON'T typecheck even though the
+ * runtime accepts them — TS-strict steers users toward the canonical
+ * casing, which keeps key strings consistent across a codebase.
  */
 export type KeyOrChord =
   | KeyName
-  | (string & {})
   | `${KeyModifier}+${KeyName | (string & {})}`
   | `${KeyModifier}+${KeyModifier}+${KeyName | (string & {})}`;
 

--- a/packages/playwright/src/keyboard/index.ts
+++ b/packages/playwright/src/keyboard/index.ts
@@ -156,9 +156,11 @@ export type KeyModifier =
  * what gets dispatched.
  *
  * Not exhaustive: every other Playwright key (less-common Numpad keys,
- * `BracketLeft`, locale-specific keys, etc.) still works via the
- * `(string & {})` escape hatch on the `KeyOrChord` type below. They just
- * don't autocomplete in IDEs.
+ * `BracketLeft`, locale-specific keys, etc.) is outside the typed union
+ * and needs a cast at the call site (`'BracketLeft' as KeyOrChord`). The
+ * runtime parser handles them — the type just doesn't enumerate them,
+ * because adding a `(string & {})` escape hatch would collapse TypeScript's
+ * template-literal IntelliSense for the chord autocompletes.
  */
 export type KeyName =
   // Letters

--- a/packages/playwright/src/keyboard/index.ts
+++ b/packages/playwright/src/keyboard/index.ts
@@ -294,8 +294,10 @@ export interface PressResult {
  *
  * Modifier rules:
  *
- *  - `Mod` / `CmdOrCtrl` → magic: becomes `Meta` on macOS, `Control` elsewhere.
- *    The right token for cross-platform app shortcuts.
+ *  - `Mod` / `CmdOrCtrl` / `CommandOrControl` → magic: becomes `Meta` on
+ *    macOS, `Control` elsewhere. The right token for cross-platform app
+ *    shortcuts. All three are aliases; `Mod` is shortest, the others come
+ *    from the Electron / Mousetrap convention.
  *  - `Cmd` / `Command` / `Meta` / `Win` / `Super` → literal `Meta` keycode.
  *    Same physical key on every OS (Command on Mac, Windows key on Windows,
  *    Super on Linux). Note: this does NOT auto-translate to Control.
@@ -352,7 +354,7 @@ export function resolveChord(key: KeyOrChord): string {
     if (resolved === null) {
       throw new Error(
         `Invalid key modifier: ${JSON.stringify(token)} in ${JSON.stringify(key)}. ` +
-          `Use one of: Mod, CmdOrCtrl, Cmd/Command/Meta/Win/Super, Ctrl/Control, Alt/Option/Opt, Shift.`,
+          `Use one of: Mod/CmdOrCtrl/CommandOrControl, Cmd/Command/Meta/Win/Super, Ctrl/Control, Alt/Option/Opt, Shift.`,
       );
     }
     modifiers.push(resolved);

--- a/packages/playwright/src/keyboard/index.ts
+++ b/packages/playwright/src/keyboard/index.ts
@@ -105,7 +105,7 @@ export interface PasteResult {
  * Uses `page.keyboard.insertText` rather than synthesizing a paste event —
  * the goal is "the value lands in the field instantly," not "fire the page's
  * paste handler." If a user needs paste-event semantics, they can call
- * `human.shortcut('Mod+V')` after setting clipboard contents themselves.
+ * `human.press('Mod+V')` after setting clipboard contents themselves.
  *
  * In `speed: 'instant'`, behaves identically — paste is already instant by
  * nature; there's nothing to humanize about the timing.
@@ -123,7 +123,7 @@ export async function executePaste(
 }
 
 /**
- * Modifier tokens accepted in a shortcut chord. `Mod` and `CmdOrCtrl` /
+ * Modifier tokens accepted in a `human.press()` chord. `Mod` and `CmdOrCtrl` /
  * `CommandOrControl` are the magic auto-mapping tokens (Meta on Mac,
  * Control elsewhere). The rest are literal — they always resolve to the
  * keycode they name, on every platform.
@@ -132,7 +132,7 @@ export async function executePaste(
  * parser is case-insensitive, so `'cmd+s'` and `'CMD+S'` work too — they
  * just won't autocomplete.
  */
-export type ShortcutModifier =
+export type KeyModifier =
   | 'Mod'
   | 'CmdOrCtrl'
   | 'CommandOrControl'
@@ -149,17 +149,18 @@ export type ShortcutModifier =
   | 'Shift';
 
 /**
- * The canonical key names a `Shortcut` can end with. Mirrors Playwright's
- * accepted key vocabulary, plus a few common synonyms. CamelCase names
- * (`ArrowDown`, `PageUp`) are listed in their canonical form — `normalizeKey`
- * preserves case from the input, so what you type is what gets dispatched.
+ * The canonical key names that autocomplete in a `KeyOrChord`. Mirrors
+ * Playwright's accepted key vocabulary, plus a few common synonyms.
+ * CamelCase names (`ArrowDown`, `PageUp`) are listed in their canonical
+ * form — `normalizeKey` preserves case from the input, so what you type is
+ * what gets dispatched.
  *
  * Not exhaustive: every other Playwright key (less-common Numpad keys,
  * `BracketLeft`, locale-specific keys, etc.) still works via the
- * `(string & {})` escape hatch on the `Shortcut` type below. They just
+ * `(string & {})` escape hatch on the `KeyOrChord` type below. They just
  * don't autocomplete in IDEs.
  */
-export type ShortcutKey =
+export type KeyName =
   // Letters
   | 'A'
   | 'B'
@@ -236,49 +237,48 @@ export type ShortcutKey =
   | 'Pause';
 
 /**
- * Strings accepted by `human.shortcut(chord)`:
+ * Strings accepted by `human.press(key)`:
  *
- *  - A bare known key: `'Enter'`, `'F4'`, `'ArrowDown'`, `'S'`
+ *  - A bare known key: `'Enter'`, `'F4'`, `'ArrowDown'`, `'S'`, …
+ *  - Any other bare key via escape hatch: `'BracketLeft'`, `'NumpadAdd'`,
+ *    locale-specific keys — they typecheck, they just don't autocomplete.
  *  - One known modifier + any key: `'Mod+S'`, `'Mod+BracketLeft'`, …
  *  - Two known modifiers + any key: `'Mod+Shift+P'`, `'Ctrl+Alt+Delete'`, …
  *
- * The escape hatch lives on the **key portion only**, not on the whole
- * chord — so modifier typos get caught at compile time (`'Mosd+S'` is a
- * TS error) while less-common keys (`'BracketLeft'`, `'NumpadAdd'`,
- * locale-specific keys) still typecheck under a known modifier.
+ * The escape hatch lives on the **key portions only**, never on modifiers —
+ * so modifier typos get caught at compile time (`'Mosd+S'` is a TS error)
+ * while less-common keys (`'BracketLeft'`, `'NumpadAdd'`, locale keys)
+ * typecheck under both bare-key and `Modifier+...` paths.
  *
  * 3+ modifier chords (`'Ctrl+Shift+Alt+X'`) typecheck through the same
  * key-side escape hatch — TS sees two modifiers + `'Alt+X'` as the "key,"
  * the runtime parser handles three modifiers + `X` correctly. The cap at
- * two literal modifiers is a TypeScript size-of-union constraint, not a
- * runtime limit.
+ * two literal modifiers in the type is a TypeScript size-of-union
+ * constraint, not a runtime limit.
  *
- * Bare uncommon keys (`'BracketLeft'` alone, no modifier) DON'T typecheck
- * — that route would slip past the modifier guard. Workarounds: use a
- * modifier, or `'BracketLeft' as Shortcut`. The case is vanishingly rare
- * in real shortcut bindings.
- *
- * Lowercase modifiers (`'mod+s'`) also DON'T typecheck even though the
- * runtime accepts them — TS-strict steers users toward the canonical
- * casing, which keeps shortcut strings consistent across a codebase.
+ * Lowercase modifiers (`'mod+s'`) DON'T typecheck even though the runtime
+ * accepts them — TS-strict steers users toward the canonical casing,
+ * which keeps key strings consistent across a codebase.
  */
-export type Shortcut =
-  | ShortcutKey
-  | `${ShortcutModifier}+${ShortcutKey | (string & {})}`
-  | `${ShortcutModifier}+${ShortcutModifier}+${ShortcutKey | (string & {})}`;
+export type KeyOrChord =
+  | KeyName
+  | (string & {})
+  | `${KeyModifier}+${KeyName | (string & {})}`
+  | `${KeyModifier}+${KeyModifier}+${KeyName | (string & {})}`;
 
-/** Result of a shortcut action. */
-export interface ShortcutResult {
+/** Result of a `press` action. */
+export interface PressResult {
   /** The exact chord that was dispatched (after Mod-resolution). */
   readonly dispatched: string;
 }
 
 /**
- * Dispatches a keyboard chord like `'Mod+S'`, `'Cmd+Shift+P'`, `'Ctrl+C'`.
+ * Dispatches a single key or keyboard chord — `'Tab'`, `'Enter'`, `'Mod+S'`,
+ * `'Cmd+Shift+P'`, `'Ctrl+C'`, …
  *
- * Parses the chord into modifiers + a final key, normalizes aliases, then
- * dispatches via `page.keyboard.press()` which uses Playwright's standard
- * `Modifier+Key` syntax.
+ * Parses the input into zero-or-more modifiers + a final key, normalizes
+ * aliases, then dispatches via `page.keyboard.press()` which uses
+ * Playwright's standard `Modifier+Key` syntax (or just `Key` for bare keys).
  *
  * Modifier rules:
  *
@@ -292,48 +292,45 @@ export interface ShortcutResult {
  *  - `Alt` / `Option` / `Opt` → literal Alt.
  *  - `Shift` → literal Shift.
  *
- * Modifier names and key names are case-insensitive. The final key in the
- * chord is the only non-modifier — at least one is required.
+ * Modifier names and key names are case-insensitive.
  *
  * @example
  * ```ts
- * await human.shortcut('Mod+S');             // cross-platform save
- * await human.shortcut('Cmd+Shift+P');       // literal Meta+Shift+P
- * await human.shortcut('Control+C');         // literal Ctrl+C
- * await human.shortcut('Enter');             // just the key
+ * await human.press('Tab');                // bare key
+ * await human.press('Enter');              // bare key
+ * await human.press('Mod+S');              // cross-platform save
+ * await human.press('Cmd+Shift+P');        // literal Meta+Shift+P
+ * await human.press('Control+C');          // literal Ctrl+C
  * ```
  */
-export async function executeShortcut(
-  chord: Shortcut,
-  ctx: KeyboardContext,
-): Promise<ShortcutResult> {
-  const dispatched = resolveChord(chord);
+export async function executePress(key: KeyOrChord, ctx: KeyboardContext): Promise<PressResult> {
+  const dispatched = resolveChord(key);
   await ctx.page.keyboard.press(dispatched);
   return { dispatched };
 }
 
 /**
- * Parses the user-facing chord string and resolves it to Playwright's
- * canonical `Modifier+Modifier+Key` form, with `Mod` mapped per platform
- * and aliases normalized.
+ * Parses the user-facing key string and resolves it to Playwright's
+ * canonical `Modifier+...+Key` form (or just `Key` for bare keys), with
+ * `Mod` mapped per platform and aliases normalized.
  *
  * Exported for the test suite — not part of the public API.
  */
-export function resolveChord(chord: Shortcut): string {
-  // Narrow to plain string for the parser — `Shortcut` is a wide template
+export function resolveChord(key: KeyOrChord): string {
+  // Narrow to plain string for the parser — `KeyOrChord` is a wide template
   // literal union and TS can't always infer the callbacks' parameter type
   // from `.split()` when the input is the full union shape.
-  const parts = (chord as string)
+  const parts = (key as string)
     .split('+')
     .map((p) => p.trim())
     .filter((p) => p.length > 0);
   if (parts.length === 0) {
-    throw new Error(`Invalid shortcut chord: ${JSON.stringify(chord)} — empty or only separators`);
+    throw new Error(`Invalid key: ${JSON.stringify(key)} — empty or only separators`);
   }
 
   const keyToken = parts[parts.length - 1];
   if (keyToken === undefined) {
-    throw new Error(`Invalid shortcut chord: ${JSON.stringify(chord)} — missing key`);
+    throw new Error(`Invalid key: ${JSON.stringify(key)} — missing key`);
   }
   const modifierTokens = parts.slice(0, -1);
 
@@ -342,7 +339,7 @@ export function resolveChord(chord: Shortcut): string {
     const resolved = resolveModifier(token);
     if (resolved === null) {
       throw new Error(
-        `Invalid shortcut modifier: ${JSON.stringify(token)} in chord ${JSON.stringify(chord)}. ` +
+        `Invalid key modifier: ${JSON.stringify(token)} in ${JSON.stringify(key)}. ` +
           `Use one of: Mod, CmdOrCtrl, Cmd/Command/Meta/Win/Super, Ctrl/Control, Alt/Option/Opt, Shift.`,
       );
     }

--- a/packages/playwright/src/keyboard/index.ts
+++ b/packages/playwright/src/keyboard/index.ts
@@ -240,35 +240,43 @@ export type KeyName =
  * Strings accepted by `human.press(key)`:
  *
  *  - A bare known key: `'Enter'`, `'F4'`, `'ArrowDown'`, `'S'`, …
- *  - One known modifier + any key: `'Mod+S'`, `'Mod+BracketLeft'`, …
- *  - Two known modifiers + any key: `'Mod+Shift+P'`, `'Ctrl+Alt+Delete'`, …
+ *  - One known modifier + a known key: `'Mod+S'`, `'Shift+ArrowDown'`, …
+ *  - Two known modifiers + a known key: `'Mod+Shift+P'`, `'Ctrl+Alt+Tab'`, …
  *
- * The escape hatch lives on the **key portion of a chord**, never at the
- * bare-key position and never on the modifier — so modifier typos get
- * caught at compile time (`'Mosd+S'` is a TS error) while less-common
- * keys (`'BracketLeft'`, `'NumpadAdd'`, locale-specific keys) still
- * typecheck under a known modifier.
+ * Every member of the union is a fully-enumerated literal, which is what
+ * makes IDE autocomplete work — type `'Shift+'` and you get every
+ * `Shift+<key>` combination as a completion. Adding a `(string & {})`
+ * escape hatch anywhere would collapse that down to a single wide
+ * template member, killing the completion list.
  *
- * 3+ modifier chords (`'Ctrl+Shift+Alt+X'`) typecheck through the same
- * key-side escape hatch — TS sees two modifiers + `'Alt+X'` as the "key,"
- * the runtime parser handles three modifiers + `X` correctly. The cap at
- * two literal modifiers in the type is a TypeScript size-of-union
- * constraint, not a runtime limit.
+ * Modifier typos (`'Mosd+S'`) and uncommon-key typos (`'Mod+BraketLeft'`)
+ * are both TS errors at the call site — the closed sets on both sides
+ * give you compile-time protection that Playwright's plain `string` key
+ * type can't.
  *
- * Bare uncommon keys (`'BracketLeft'` alone, no modifier) DON'T typecheck
- * — that route would slip past the modifier guard, since TypeScript can't
- * express "any string not containing `+`." Workarounds: use a modifier,
- * or `'BracketLeft' as KeyOrChord`. The case is vanishingly rare in real
- * bindings; modifier-typo protection is the more valuable half.
+ * **Escape hatch for uncommon keys.** Less-common Playwright keys
+ * (`'BracketLeft'`, `'NumpadAdd'`, locale-specific keys, …) and 3+
+ * modifier chords (`'Ctrl+Shift+Alt+K'`) aren't in the union and need a
+ * cast at the call site:
  *
- * Lowercase modifiers (`'mod+s'`) also DON'T typecheck even though the
+ * ```ts
+ * await human.press('Mod+BracketLeft' as KeyOrChord);
+ * await human.press('Ctrl+Shift+Alt+K' as KeyOrChord);
+ * ```
+ *
+ * The runtime parser handles these fine — the cast just acknowledges
+ * "I'm using a key outside the autocomplete vocabulary." If you find
+ * yourself casting often for a specific key, propose adding it to
+ * `KeyName` in a PR.
+ *
+ * Lowercase modifiers (`'mod+s'`) also don't typecheck even though the
  * runtime accepts them — TS-strict steers users toward the canonical
  * casing, which keeps key strings consistent across a codebase.
  */
 export type KeyOrChord =
   | KeyName
-  | `${KeyModifier}+${KeyName | (string & {})}`
-  | `${KeyModifier}+${KeyModifier}+${KeyName | (string & {})}`;
+  | `${KeyModifier}+${KeyName}`
+  | `${KeyModifier}+${KeyModifier}+${KeyName}`;
 
 /** Result of a `press` action. */
 export interface PressResult {

--- a/packages/playwright/src/keyboard/keyboard.test.ts
+++ b/packages/playwright/src/keyboard/keyboard.test.ts
@@ -1,17 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { resolveChord, type Shortcut } from './index';
+import { type KeyOrChord, resolveChord } from './index';
 
 // Many tests below pass deliberately type-invalid strings to verify the
 // parser's runtime robustness — lowercase modifiers, whitespace tokens,
-// empty strings, unknown modifiers like `'Hyper+S'`. The `Shortcut` type
+// empty strings, unknown modifiers like `'Hyper+S'`. The `KeyOrChord` type
 // (rightly) rejects these at compile time, so we cast to bypass the type
 // check and exercise the runtime path. Production code should NOT do this;
 // it's a test-only escape.
-const asChord = (s: string): Shortcut => s as Shortcut;
+const asChord = (s: string): KeyOrChord => s as KeyOrChord;
 
 /**
- * Unit tests for `resolveChord` — the chord parser that powers
- * `human.shortcut()`. Pure function, no Playwright needed.
+ * Unit tests for `resolveChord` — the parser that powers `human.press()`.
+ * Pure function, no Playwright needed. (Function name is historical — it
+ * resolves any key string, bare or chord; a bare key is just a chord with
+ * zero modifiers.)
  *
  * Platform-dependent tests stub `process.platform` because the `Mod` token
  * maps based on it. The original value is restored after each test so other
@@ -37,7 +39,7 @@ describe('resolveChord', () => {
 
   describe('plain key (no modifier)', () => {
     it('returns single-letter keys upper-cased', () => {
-      // Lowercase 's' isn't a valid `Shortcut` literal (canonical is 'S'),
+      // Lowercase 's' isn't a valid `KeyOrChord` literal (canonical is 'S'),
       // but the runtime parser still upper-cases it — so we cast for the
       // test. Real callers should write 'S'.
       expect(resolveChord(asChord('s'))).toBe('S');
@@ -63,7 +65,7 @@ describe('resolveChord', () => {
       expect(resolveChord('ArrowUp')).toBe('ArrowUp');
       expect(resolveChord('PageDown')).toBe('PageDown');
       expect(resolveChord('PageUp')).toBe('PageUp');
-      // `'BracketLeft'` as a bare key isn't in the `ShortcutKey` union (it's
+      // `'BracketLeft'` as a bare key isn't in the `KeyName` union (it's
       // a key you'd use with a modifier, e.g. `'Mod+BracketLeft'` for "go
       // back"). The runtime parser still handles it; we cast to test that
       // path explicitly.
@@ -136,7 +138,7 @@ describe('resolveChord', () => {
 
   describe('case insensitivity', () => {
     it('modifier names are case-insensitive at runtime (canonical case in types)', () => {
-      // The `Shortcut` type only lists canonical-case modifiers ('Mod',
+      // The `KeyOrChord` type only lists canonical-case modifiers ('Mod',
       // 'Cmd', 'Ctrl', etc.), so lowercase/uppercase variants are TS errors
       // — but the parser handles them. Casting here verifies the runtime
       // forgiveness; production code should write canonical case.
@@ -169,18 +171,18 @@ describe('resolveChord', () => {
 
   describe('error paths', () => {
     it('throws on an empty chord', () => {
-      // Empty strings + separator-only strings aren't valid `Shortcut`
+      // Empty strings + separator-only strings aren't valid `KeyOrChord`
       // literals, so we cast to exercise the runtime guards.
       expect(() => resolveChord(asChord(''))).toThrow(/empty or only separators/);
       expect(() => resolveChord(asChord('+++'))).toThrow(/empty or only separators/);
     });
 
     it('throws on an unknown modifier with a useful message', () => {
-      // 'Hyper+S' isn't a valid Shortcut (Hyper isn't a ShortcutModifier),
+      // 'Hyper+S' isn't a valid Shortcut (Hyper isn't a KeyModifier),
       // so TS rejects it — that's actually the FIRST line of defense.
       // Casting tests the runtime fallback for inputs that slip through
       // (e.g. user-supplied strings from config).
-      expect(() => resolveChord(asChord('Hyper+S'))).toThrow(/Invalid shortcut modifier.*"Hyper"/);
+      expect(() => resolveChord(asChord('Hyper+S'))).toThrow(/Invalid key modifier.*"Hyper"/);
     });
 
     it('error message lists valid modifiers so users can self-correct', () => {
@@ -194,7 +196,7 @@ describe('resolveChord', () => {
 
   describe('whitespace tolerance', () => {
     it('trims tokens so "Mod + S" works the same as "Mod+S"', () => {
-      // Whitespace-padded chords aren't valid `Shortcut` literals (the type
+      // Whitespace-padded chords aren't valid `KeyOrChord` literals (the type
       // expects exact 'Mod+S' form), but the runtime parser trims tokens —
       // useful for config files or user input. Casting to exercise that path.
       setPlatform('darwin');

--- a/packages/playwright/src/keyboard/keyboard.test.ts
+++ b/packages/playwright/src/keyboard/keyboard.test.ts
@@ -193,7 +193,7 @@ describe('resolveChord', () => {
       // The error message is the discovery surface — without it, "what
       // modifiers are accepted?" requires reading the source.
       expect(() => resolveChord(asChord('Bogus+S'))).toThrow(
-        /Mod, CmdOrCtrl, Cmd\/Command\/Meta\/Win\/Super, Ctrl\/Control, Alt\/Option\/Opt, Shift/,
+        /Mod\/CmdOrCtrl\/CommandOrControl, Cmd\/Command\/Meta\/Win\/Super, Ctrl\/Control, Alt\/Option\/Opt, Shift/,
       );
     });
   });

--- a/packages/playwright/src/keyboard/keyboard.test.ts
+++ b/packages/playwright/src/keyboard/keyboard.test.ts
@@ -163,9 +163,13 @@ describe('resolveChord', () => {
       expect(resolveChord('Shift+Mod+P')).toBe('Shift+Meta+P');
     });
 
-    it('supports three-modifier chords', () => {
+    it('supports three-modifier chords (via cast — outside the typed union)', () => {
+      // Three-modifier chords like 'Ctrl+Shift+Alt+K' aren't in the typed
+      // `KeyOrChord` union (the cap at 2 literal modifiers is a TS
+      // size-of-union constraint). The runtime parser handles them fine,
+      // so users opt in with `as KeyOrChord`.
       setPlatform('darwin');
-      expect(resolveChord('Mod+Shift+Alt+K')).toBe('Meta+Shift+Alt+K');
+      expect(resolveChord(asChord('Mod+Shift+Alt+K'))).toBe('Meta+Shift+Alt+K');
     });
   });
 

--- a/packages/playwright/src/mouse/index.ts
+++ b/packages/playwright/src/mouse/index.ts
@@ -260,7 +260,7 @@ export async function executeDrag(
  *
  *  - `move` is positional. Pass coordinates or an element; the cursor
  *    arrives and stops. Use this for canvas painting, slider drags
- *    composed with separate up/down, pre-press placement, or cinematic
+ *    composed with separate up/down, placement before a keyboard press, or cinematic
  *    beats where the cursor should pause somewhere with no element under it.
  *  - `hover` is element-bound and includes the post-arrival dwell that
  *    lets hover-state UI fire (tooltips, dropdown reveals).

--- a/packages/playwright/src/mouse/index.ts
+++ b/packages/playwright/src/mouse/index.ts
@@ -260,7 +260,7 @@ export async function executeDrag(
  *
  *  - `move` is positional. Pass coordinates or an element; the cursor
  *    arrives and stops. Use this for canvas painting, slider drags
- *    composed with separate up/down, pre-shortcut placement, or cinematic
+ *    composed with separate up/down, pre-press placement, or cinematic
  *    beats where the cursor should pause somewhere with no element under it.
  *  - `hover` is element-bound and includes the post-arrival dwell that
  *    lets hover-state UI fire (tooltips, dropdown reveals).


### PR DESCRIPTION
## Summary

- Renames `human.shortcut(chord)` → `human.press(key)` with matching type renames (`Shortcut` → `KeyOrChord`, `ShortcutKey` → `KeyName`, `ShortcutModifier` → `KeyModifier`, `ShortcutResult` → `PressResult`).
- Plugin action contract: `{ type: 'shortcut', params: { chord } }` → `{ type: 'press', params: { key } }`. `@humanjs/core`'s `KnownActionType` updated to match.
- `KeyOrChord` is fully enumerated for IntelliSense — typing `'Shift+'` now autocompletes every `Shift+<key>` combination. Modifier typos (`'Mosd+S'`) and uncommon-key typos (`'Mod+BraketLeft'`) are both caught at compile time.
- README gets a primitives reference table + dedicated sections for `press`, `type`, `paste`, `drag`.

## Why

`human.shortcut('Tab')` always worked, but the name read wrong — a single key isn't a "shortcut." `press` matches Playwright's own `keyboard.press()` mental model: one method that handles both bare keys (`'Tab'`, `'Enter'`, `'Escape'`) and chords (`'Mod+S'`, `'Cmd+Shift+P'`). Removes the API duplication and reads naturally for both shapes.

## Type design — the trade-off

The previous `Shortcut` type included `(string & {})` on the key portion of chords, so `'Mod+BracketLeft'` typechecked without a cast. That looked friendly, but it collapsed TypeScript's template-literal IntelliSense: typing `'Shift+'` produced zero `Shift+<key>` completions because the wide `(string & {})` member dominated the union.

`KeyOrChord` drops the escape hatch and is fully enumerated (`KeyName | ${KeyModifier}+${KeyName} | ${KeyModifier}+${KeyModifier}+${KeyName}` — about 14k literal members, well within TS's union limits). Autocomplete works perfectly. The cost is that uncommon keys and 3+ modifier chords need an explicit cast:

```ts
await human.press('Mod+BracketLeft' as KeyOrChord);
await human.press('Ctrl+Shift+Alt+K' as KeyOrChord);
```

The runtime parser handles them — the type just doesn't enumerate them. For codebases with many such bindings, a tiny local helper keeps the cast contained:

```ts
const press = (k: string) => human.press(k as KeyOrChord);
```

Trade-off lands on the autocomplete side: 95% of usage gets first-class completions; the 5% gets a one-line cast.

## Modifier rules (unchanged behavior, clearer docs)

| Token | Resolves to |
|---|---|
| `Mod` / `CmdOrCtrl` / `CommandOrControl` | `Meta` on macOS, `Control` elsewhere |
| `Cmd` / `Command` / `Meta` / `Win` / `Super` | `Meta` keycode (literal, doesn't auto-translate) |
| `Ctrl` / `Control` | `Control` keycode (literal) |
| `Alt` / `Option` / `Opt` | `Alt` keycode |
| `Shift` | `Shift` keycode |

All three `Mod` aliases kept as-is — `Mod` is canonical, `CmdOrCtrl` / `CommandOrControl` are familiar from Electron / Mousetrap. Runtime error message now lists `CommandOrControl` too (it was missing).

## README

New sections in `packages/playwright/README.md`:

- **`### Primitives`** — one-row-per-primitive reference table covering all 13 methods on the `Human` interface, including the auto-scroll behavior note.
- **`### Keyboard`** — full `press()` documentation: examples, modifier-rules table, the `as KeyOrChord` escape hatch with reasoning.
- **`### Typing`** — per-key rhythm, typos, the implicit click for focus, privacy posture, instant-mode bypass.
- **`### Pasting`** — Cmd-V semantic, when to use vs `type`, the "fire the paste event yourself with `press('Mod+V')`" pattern.
- **`### Dragging`** — two-phase Bezier, `Point` endpoints for canvas/SVG, auto-scroll on both endpoints.

Existing `Reading` / `Scrolling` / `Recording` sections untouched. Trivial primitives (`click` / `hover` / `move` / `sleep`) deliberately don't get dedicated sections — the reference table covers them; restating the signature in prose would be bloat.

## Migration

Most call sites:

```diff
- import { type Shortcut } from '@humanjs/playwright';
+ import { type KeyOrChord } from '@humanjs/playwright';

- await human.shortcut('Mod+S');
+ await human.press('Mod+S');

  // Plugin handler — silent failure mode without this update:
- if (action.type === 'shortcut') { console.log(action.params.chord); }
+ if (action.type === 'press') { console.log(action.params.key); }
```

Uncommon-key chords need a new cast (see "Type design" above).

## Test plan

- [x] `pnpm --filter @humanjs/playwright test` — 173 tests pass (existing `shortcut` describe renamed to `press`, assertions updated).
- [x] `pnpm --filter @humanjs/core test` — 143 tests pass (`KnownActionType` change).
- [x] Strict `tsc --noEmit -p packages/playwright/tsconfig.json` clean.
- [x] `pnpm demo:primitives` headed — step 6 (press) fires `Mod+S` against the focused input from step 5, save indicator flashes.
- [x] In an code editor, typing `human.press('Shift+'` shows the full `Shift+<key>` completion list. (Manual check.)