### PR TITLE
feat(playwright): visible near-miss for click / rightClick / drag

### DIFF
--- a/.changeset/misclick-recovery.md
+++ b/.changeset/misclick-recovery.md
@@ -51,8 +51,9 @@ Or set it higher than the preset for stronger humanization signal in demos. The 
 
 ## Edge cases
 
-- Targets at the viewport edge: if the candidate misclick point would land off-screen, the misclick is skipped for that action (rather than producing a "near-miss" that gets clamped back onto the target).
-- Determinism: same seed produces the same misclick decisions and same misclick coordinates. Misclick fires/skips deterministically per seed, like every other humanization knob.
+- **Cursor already on the target.** When the action starts with the cursor already inside the target's bounding box (or within a few pixels of a raw-Point target), the near-miss beat is suppressed. A real user doesn't aim away from a button they're already hovering — the misclick is fundamentally an approach pattern, so no approach means no overshoot. The probability roll still happens (so RNG state stays seed-deterministic), but the beat itself is skipped. This catches the case where the user scrolled into the element, where the previous action left the cursor on the target, or any other "already there" scenario.
+- **Targets at the viewport edge:** if the candidate misclick point would land off-screen, the misclick is skipped for that action (rather than producing a "near-miss" that gets clamped back onto the target).
+- **Determinism:** same seed produces the same misclick decisions and same misclick coordinates. Misclick fires/skips deterministically per seed, like every other humanization knob.
 
 ## Note for snapshot-style tests
 

--- a/.changeset/misclick-recovery.md
+++ b/.changeset/misclick-recovery.md
@@ -24,7 +24,8 @@ Drag-over events (`dragover`, `dragenter`, `dragleave`) fire on whatever the cur
 - `human.drag('#card', '#slot')` may near-miss the grab, the drop, both, or neither — each endpoint rolls independently. `mousedown` still fires at the resolved `from`; `mouseup` still fires at the resolved `to`.
 - Raw-`Point` drag endpoints (`human.drag({ x, y }, ...)`) also misclick — the near-miss is picked 5–15 px from the coordinate in a random direction.
 - Action duration is slightly longer when the misclick fires (one extra Bezier walk + a short dwell per fired endpoint).
-- `hover`, `move`, `type`, `paste`, `read`, `scroll`, `press` are unchanged.
+- `hover`, `move`, `read`, `scroll`, `press` are unchanged.
+- `type` and `paste` keep their typing / insertion behavior exactly. Their implicit focus-acquiring click goes through the normal `click` path, so it can now occasionally near-miss like a bare `human.click` does — but the keystrokes themselves and the resolved focus target are unaffected.
 
 This is process humanization: how the click / grab / drop happened differs, not what got clicked or where it landed. Personality controls the *rate* of near-misses (precise: 0.001, careful: 0.01, fast: 0.005, distracted: 0.05); the per-action behavior is the same shape across all personalities. Drag's effective miss rate is ~2× the per-roll value because both endpoints roll independently — realistic, since drag is two cognitive moments (grab and drop).
 

--- a/.changeset/misclick-recovery.md
+++ b/.changeset/misclick-recovery.md
@@ -1,8 +1,11 @@
 ---
 "@humanjs/playwright": minor
+"@humanjs/core": patch
 ---
 
 Wires up the long-declared `personality.mouse.misclickProbability` knob: actions that commit on a mouse press now occasionally produce a visible "near-miss" wobble before landing on the target.
+
+The behavior change is in `@humanjs/playwright`. The `@humanjs/core` patch is a JSDoc update on `MouseProfile.misclickProbability` reflecting the now-wired semantics — no API or runtime changes in core.
 
 When the probability fires for `click`, `rightClick`, or the `from` endpoint of `drag`:
 

--- a/.changeset/misclick-recovery.md
+++ b/.changeset/misclick-recovery.md
@@ -2,24 +2,25 @@
 "@humanjs/playwright": minor
 ---
 
-Wires up the long-declared `personality.mouse.misclickProbability` knob: clicks now occasionally produce a visible "near-miss" wobble before landing on the target.
+Wires up the long-declared `personality.mouse.misclickProbability` knob: actions that commit on a mouse press now occasionally produce a visible "near-miss" wobble before landing on the target.
 
-When the probability fires for a `click` / `rightClick` action:
+When the probability fires for `click`, `rightClick`, or the `from` endpoint of `drag`:
 
-1. Cursor walks via Bezier path to a point 5–15 px outside an edge of the target's bounding box.
+1. Cursor walks via Bezier path to a near-miss point — 5–15 px outside an edge of the bounding box (element-bound targets) or 5–15 px from the target coordinate in a random direction (raw-`Point` targets, for canvas/SVG drags).
 2. Brief "oh, I missed" dwell (scaled by personality — same shape as the pre-click settle beat).
-3. Cursor walks the small distance to the real click point inside the box.
-4. Click fires once, on the target.
+3. Cursor walks the small distance to the real click point.
+4. Click / mousedown fires once, on the target.
 
-**The misclick is visible cursor motion only — no `mouse.click` event fires at the off-target coordinates.** That's deliberate: dispatching real clicks just outside the target risks hitting ancestor / sibling elements with their own handlers (a destructive button, a modal trigger, a navigation link). Since we can't reliably detect "does this element have an `addEventListener`-attached handler?" from outside the page, the safe-by-construction design is to never fire a click anywhere we didn't mean to.
+**The misclick is visible cursor motion only — no `mouse.click` or `mouse.down` event fires at the off-target coordinates.** That's deliberate: dispatching real clicks just outside the target risks hitting ancestor / sibling elements with their own handlers (a destructive button, a modal trigger, a navigation link). Since we can't reliably detect "does this element have an `addEventListener`-attached handler?" from outside the page, the safe-by-construction design is to never fire an event anywhere we didn't mean to.
 
 ## What changes for callers
 
-- `human.click('#target')` and `human.rightClick('#target')` may now show a small cursor detour before clicking. The click itself still lands on `#target` with the same button and same assertions.
+- `human.click('#target')`, `human.rightClick('#target')`, and `human.drag('#card', '#slot')` may now show a small cursor detour on the way to the click / grab. The action itself still commits at the resolved coordinates with the same button and same assertions.
+- `human.drag({ x, y }, ...)` (raw-Point `from`) also misclicks — the near-miss point is picked 5–15 px from the coordinate in a random direction.
 - Action duration is slightly longer when the misclick fires (one extra Bezier walk + a short dwell).
-- `hover` / `move` / `drag` / `type` / `paste` are unchanged — only the click-shaped actions misclick.
+- `hover`, `move`, `type`, `paste`, `read`, `scroll`, `press` are unchanged. Drag's `to` endpoint is also unchanged: mouseup is the single commit moment, with no "almost dropped" pattern to model.
 
-This is process humanization: how the click happened differs, not what got clicked. Personality controls the *rate* of near-misses (precise: 0.001, careful: 0.01, fast: 0.005, distracted: 0.05); the per-click behavior is the same shape across all personalities.
+This is process humanization: how the click / grab happened differs, not what got clicked. Personality controls the *rate* of near-misses (precise: 0.001, careful: 0.01, fast: 0.005, distracted: 0.05); the per-action behavior is the same shape across all personalities.
 
 ## What stayed the same
 

--- a/.changeset/misclick-recovery.md
+++ b/.changeset/misclick-recovery.md
@@ -7,23 +7,26 @@ Wires up the long-declared `personality.mouse.misclickProbability` knob: actions
 
 The behavior change is in `@humanjs/playwright`. The `@humanjs/core` patch is a JSDoc update on `MouseProfile.misclickProbability` reflecting the now-wired semantics — no API or runtime changes in core.
 
-When the probability fires for `click`, `rightClick`, or the `from` endpoint of `drag`:
+When the probability fires for `click`, `rightClick`, or either endpoint of `drag` (grab and drop roll independently):
 
 1. Cursor walks via Bezier path to a near-miss point — 5–15 px outside an edge of the bounding box (element-bound targets) or 5–15 px from the target coordinate in a random direction (raw-`Point` targets, for canvas/SVG drags).
 2. Brief "oh, I missed" dwell (scaled by personality — same shape as the pre-click settle beat).
-3. Cursor walks the small distance to the real click point.
-4. Click / mousedown fires once, on the target.
+3. Cursor walks the small distance to the real commit point.
+4. Click / mousedown / mouseup fires once, on the target.
 
-**The misclick is visible cursor motion only — no `mouse.click` or `mouse.down` event fires at the off-target coordinates.** That's deliberate: dispatching real clicks just outside the target risks hitting ancestor / sibling elements with their own handlers (a destructive button, a modal trigger, a navigation link). Since we can't reliably detect "does this element have an `addEventListener`-attached handler?" from outside the page, the safe-by-construction design is to never fire an event anywhere we didn't mean to.
+**The misclick is visible cursor motion only — no `mouse.click`, `mouse.down`, or `mouse.up` event fires at the off-target coordinates.** That's deliberate: dispatching real clicks just outside the target risks hitting ancestor / sibling elements with their own handlers (a destructive button, a modal trigger, a navigation link). Since we can't reliably detect "does this element have an `addEventListener`-attached handler?" from outside the page, the safe-by-construction design is to never fire an event anywhere we didn't mean to.
+
+Drag-over events (`dragover`, `dragenter`, `dragleave`) fire on whatever the cursor passes during a drop-side misclick detour, but those events already fire throughout normal drag motion — the misclick just adds a small extra loop, which reads as exploratory cursor behavior.
 
 ## What changes for callers
 
-- `human.click('#target')`, `human.rightClick('#target')`, and `human.drag('#card', '#slot')` may now show a small cursor detour on the way to the click / grab. The action itself still commits at the resolved coordinates with the same button and same assertions.
-- `human.drag({ x, y }, ...)` (raw-Point `from`) also misclicks — the near-miss point is picked 5–15 px from the coordinate in a random direction.
-- Action duration is slightly longer when the misclick fires (one extra Bezier walk + a short dwell).
-- `hover`, `move`, `type`, `paste`, `read`, `scroll`, `press` are unchanged. Drag's `to` endpoint is also unchanged: mouseup is the single commit moment, with no "almost dropped" pattern to model.
+- `human.click('#target')` and `human.rightClick('#target')` may now show a small cursor detour on the way to the click. The action itself still commits at the resolved coordinates with the same button and same assertions.
+- `human.drag('#card', '#slot')` may near-miss the grab, the drop, both, or neither — each endpoint rolls independently. `mousedown` still fires at the resolved `from`; `mouseup` still fires at the resolved `to`.
+- Raw-`Point` drag endpoints (`human.drag({ x, y }, ...)`) also misclick — the near-miss is picked 5–15 px from the coordinate in a random direction.
+- Action duration is slightly longer when the misclick fires (one extra Bezier walk + a short dwell per fired endpoint).
+- `hover`, `move`, `type`, `paste`, `read`, `scroll`, `press` are unchanged.
 
-This is process humanization: how the click / grab happened differs, not what got clicked. Personality controls the *rate* of near-misses (precise: 0.001, careful: 0.01, fast: 0.005, distracted: 0.05); the per-action behavior is the same shape across all personalities.
+This is process humanization: how the click / grab / drop happened differs, not what got clicked or where it landed. Personality controls the *rate* of near-misses (precise: 0.001, careful: 0.01, fast: 0.005, distracted: 0.05); the per-action behavior is the same shape across all personalities. Drag's effective miss rate is ~2× the per-roll value because both endpoints roll independently — realistic, since drag is two cognitive moments (grab and drop).
 
 ## What stayed the same
 
@@ -53,6 +56,6 @@ Or set it higher than the preset for stronger humanization signal in demos. The 
 
 ## Note for snapshot-style tests
 
-Wiring `misclickProbability` into the mouse path consumes one RNG value per click / rightClick / drag-from action, regardless of whether the misclick fires that round. Existing seeded sessions will produce **different intermediate cursor coordinates** after upgrade — even when the misclick doesn't fire — because downstream RNG state is shifted by one consumer.
+Wiring `misclickProbability` into the mouse path consumes one RNG value per misclick decision — once per `click` / `rightClick` action, and twice per `drag` (one per endpoint). Existing seeded sessions will produce **different intermediate cursor coordinates** after upgrade — even when no misclick fires — because downstream RNG state is shifted by those consumers.
 
 Action outcomes (click coordinates, mousedown / mouseup positions, the resolved button, the target element) are unchanged. Only tests snapshotting the exact mouse-move sequence against a seed will need to refresh their snapshots. Tests asserting page state, form values, or action results (the typical kind) are unaffected.

--- a/.changeset/misclick-recovery.md
+++ b/.changeset/misclick-recovery.md
@@ -1,0 +1,48 @@
+---
+"@humanjs/playwright": minor
+---
+
+Wires up the long-declared `personality.mouse.misclickProbability` knob: clicks now occasionally produce a visible "near-miss" wobble before landing on the target.
+
+When the probability fires for a `click` / `rightClick` action:
+
+1. Cursor walks via Bezier path to a point 5–15 px outside an edge of the target's bounding box.
+2. Brief "oh, I missed" dwell (scaled by personality — same shape as the pre-click settle beat).
+3. Cursor walks the small distance to the real click point inside the box.
+4. Click fires once, on the target.
+
+**The misclick is visible cursor motion only — no `mouse.click` event fires at the off-target coordinates.** That's deliberate: dispatching real clicks just outside the target risks hitting ancestor / sibling elements with their own handlers (a destructive button, a modal trigger, a navigation link). Since we can't reliably detect "does this element have an `addEventListener`-attached handler?" from outside the page, the safe-by-construction design is to never fire a click anywhere we didn't mean to.
+
+## What changes for callers
+
+- `human.click('#target')` and `human.rightClick('#target')` may now show a small cursor detour before clicking. The click itself still lands on `#target` with the same button and same assertions.
+- Action duration is slightly longer when the misclick fires (one extra Bezier walk + a short dwell).
+- `hover` / `move` / `drag` / `type` / `paste` are unchanged — only the click-shaped actions misclick.
+
+This is process humanization: how the click happened differs, not what got clicked. Personality controls the *rate* of near-misses (precise: 0.001, careful: 0.01, fast: 0.005, distracted: 0.05); the per-click behavior is the same shape across all personalities.
+
+## What stayed the same
+
+- The `misclickProbability` field was already declared on `MouseProfile` and set on all four presets — it just never fired. This release wires it up.
+- The preset values are unchanged.
+- All other behavior (auto-scroll, hover dwell, action timeline, plugin events) is unchanged. The misclick is a sub-step of the `'click'` action — it doesn't emit its own timeline event.
+
+## Override
+
+If you specifically want to disable the near-miss (e.g. for tightly-timed assertions where the extra detour matters):
+
+```ts
+const human = await createHuman(page, {
+  personality: {
+    extends: 'careful',
+    mouse: { misclickProbability: 0 },
+  },
+});
+```
+
+Or set it higher than the preset for stronger humanization signal in demos. The field is part of the public `MouseProfile` type.
+
+## Edge cases
+
+- Targets at the viewport edge: if the candidate misclick point would land off-screen, the misclick is skipped for that action (rather than producing a "near-miss" that gets clamped back onto the target).
+- Determinism: same seed produces the same misclick decisions and same misclick coordinates. Misclick fires/skips deterministically per seed, like every other humanization knob.

--- a/.changeset/misclick-recovery.md
+++ b/.changeset/misclick-recovery.md
@@ -47,3 +47,9 @@ Or set it higher than the preset for stronger humanization signal in demos. The 
 
 - Targets at the viewport edge: if the candidate misclick point would land off-screen, the misclick is skipped for that action (rather than producing a "near-miss" that gets clamped back onto the target).
 - Determinism: same seed produces the same misclick decisions and same misclick coordinates. Misclick fires/skips deterministically per seed, like every other humanization knob.
+
+## Note for snapshot-style tests
+
+Wiring `misclickProbability` into the mouse path consumes one RNG value per click / rightClick / drag-from action, regardless of whether the misclick fires that round. Existing seeded sessions will produce **different intermediate cursor coordinates** after upgrade — even when the misclick doesn't fire — because downstream RNG state is shifted by one consumer.
+
+Action outcomes (click coordinates, mousedown / mouseup positions, the resolved button, the target element) are unchanged. Only tests snapshotting the exact mouse-move sequence against a seed will need to refresh their snapshots. Tests asserting page state, form values, or action results (the typical kind) are unaffected.

--- a/examples/primitives-demo.ts
+++ b/examples/primitives-demo.ts
@@ -583,14 +583,19 @@ const DEMO_HTML = /* html */ `
       });
       window.addEventListener('mouseup', () => { sliderDragging = false; });
 
-      // --- 6. press --- Mod+S handler flashes the save indicator
+      // --- 6. press --- Mod+S handler flashes the save indicator AND
+      // surfaces the exact chord that fired so a viewer watching the demo
+      // sees "saved ✓ via ⌘S" (Mac) or "saved ✓ via Ctrl+S" (other) —
+      // makes it visually obvious that the cross-platform Mod token
+      // resolved to the right keycode for the platform.
       const saveIndicator = document.getElementById('save-indicator');
       window.addEventListener('keydown', (e) => {
         const isSaveCombo = (e.metaKey || e.ctrlKey) && (e.key === 's' || e.key === 'S');
         if (isSaveCombo) {
           e.preventDefault();
+          const chord = e.metaKey ? '⌘S' : 'Ctrl+S';
           saveIndicator.classList.add('saved');
-          saveIndicator.textContent = 'saved ✓';
+          saveIndicator.textContent = 'saved ✓  via ' + chord;
           setTimeout(() => {
             saveIndicator.classList.remove('saved');
             saveIndicator.textContent = 'unsaved';
@@ -659,11 +664,29 @@ async function main() {
     await human.sleep(1500);
 
     // 4. Drag — card from one slot to another, then a slider drag using a
-    // Point coordinate to demo the Point variant.
+    // Point coordinate to demo the Point variant. The slider's target Y
+    // tracks the thumb's actual position (not a hardcoded coordinate) so
+    // the drag lands on the track instead of floating above it across
+    // different viewport sizes.
     console.log('4. drag → card to slot, then slider thumb to point');
     await human.drag('#drag-card', '#slot-to');
     await human.sleep(900);
-    await human.drag('#slider-thumb', { x: 800, y: 685 });
+    // Center the slider section in the viewport before the drag — without
+    // this, the slider sits near the viewport bottom edge, and the
+    // horizontal Bezier curve from thumb to target can dip below y =
+    // viewportHeight with the mouse held. At that point Chrome engages
+    // its native edge-scroll-during-drag behavior and walks the page all
+    // the way down. Centering the slider gives the curve ~450px of
+    // headroom in both directions.
+    await human.scroll('.slider-row', { block: 'center' });
+    await human.sleep(300);
+    const thumbBox = await page.locator('#slider-thumb').boundingBox();
+    const trackBox = await page.locator('.slider-track').boundingBox();
+    if (thumbBox && trackBox) {
+      const targetX = trackBox.x + trackBox.width * 0.85;
+      const targetY = thumbBox.y + thumbBox.height / 2;
+      await human.drag('#slider-thumb', { x: targetX, y: targetY });
+    }
     await human.sleep(900);
 
     // 5. Type — realistic per-key rhythm into the input. `human.type()` also

--- a/packages/core/src/personality.ts
+++ b/packages/core/src/personality.ts
@@ -64,8 +64,16 @@ export interface MouseProfile {
    * Does NOT apply to: `hover` (positional, doesn't commit) or `move`
    * (explicit-coordinate positioning).
    *
-   * Skipped automatically when the target sits at the viewport edge and
-   * the candidate near-miss point would have to land off-screen.
+   * Skipped automatically in two cases:
+   *
+   *  1. **Cursor already on the target.** A real user doesn't aim away
+   *     from a button they're already hovering. If the cursor sits inside
+   *     the target's bounding box (or within a few pixels of a raw-Point
+   *     target) when the action starts, the near-miss beat is suppressed
+   *     — there's no approach to overshoot.
+   *  2. **Target at the viewport edge** with no room for the candidate
+   *     near-miss off-screen — better to commit cleanly than fake a
+   *     "miss" that clamps back onto the target.
    */
   readonly misclickProbability: number;
   /**

--- a/packages/core/src/personality.ts
+++ b/packages/core/src/personality.ts
@@ -40,16 +40,20 @@ export interface MouseProfile {
   readonly overshootProbability: number;
   /**
    * Probability per click-shaped action of producing the visible "near-miss"
-   * cursor wobble (0..1). Applies to `click`, `rightClick`, and the `from`
-   * endpoint of `drag` (where mousedown commits the grab). When it fires,
+   * cursor wobble (0..1). Applies to `click`, `rightClick`, and both
+   * endpoints of `drag` (grab and drop — each rolls independently, so a
+   * single drag may near-miss either, both, or neither). When it fires,
    * the cursor walks to a point just outside the target — outside its
    * bounding box for element-bound targets, or 5–15 px away in a random
    * direction for raw-`Point` targets (canvas/SVG drags) — dwells briefly
    * (the "oh, I missed" beat), then walks to the real point.
    *
-   * **No click or mousedown is dispatched at the off-target coordinates** —
-   * the misclick is purely visual cursor motion, so it never triggers
-   * handlers on ancestors or siblings.
+   * **No click, mousedown, or mouseup is dispatched at the off-target
+   * coordinates** — the misclick is purely visual cursor motion, so it
+   * never triggers handlers on ancestors or siblings. Drag-over events do
+   * fire on whatever the cursor passes during the detour, but `dragover`
+   * is already part of normal drag motion — the misclick just adds a
+   * small extra loop, which reads as exploratory cursor behavior.
    *
    * This is process humanization, not outcome change. `human.click(target)`
    * still lands its click on `target`; `human.drag(from, to)` still
@@ -57,9 +61,8 @@ export interface MouseProfile {
    * the cursor's path (it makes a brief detour) and the action's total
    * duration (slightly longer).
    *
-   * Does NOT apply to: `hover` (positional, doesn't commit), `move`
-   * (explicit-coordinate positioning), or `drag`'s `to` endpoint (mouseup
-   * is the single commit moment — no "almost dropped" pattern to model).
+   * Does NOT apply to: `hover` (positional, doesn't commit) or `move`
+   * (explicit-coordinate positioning).
    *
    * Skipped automatically when the target sits at the viewport edge and
    * the candidate near-miss point would have to land off-screen.

--- a/packages/core/src/personality.ts
+++ b/packages/core/src/personality.ts
@@ -39,20 +39,30 @@ export interface MouseProfile {
   /** Probability of overshooting a target and correcting (0..1). */
   readonly overshootProbability: number;
   /**
-   * Probability per click action of producing the visible "near-miss"
-   * cursor wobble (0..1). When it fires, the cursor walks to a point just
-   * outside the target's bounding box, dwells briefly (the "oh, I missed"
-   * beat), then walks to the real click point. **No click is dispatched
-   * at the off-target coordinates** — the misclick is purely visual cursor
-   * motion, so it never triggers handlers on ancestors or siblings.
+   * Probability per click-shaped action of producing the visible "near-miss"
+   * cursor wobble (0..1). Applies to `click`, `rightClick`, and the `from`
+   * endpoint of `drag` (where mousedown commits the grab). When it fires,
+   * the cursor walks to a point just outside the target — outside its
+   * bounding box for element-bound targets, or 5–15 px away in a random
+   * direction for raw-`Point` targets (canvas/SVG drags) — dwells briefly
+   * (the "oh, I missed" beat), then walks to the real point.
    *
-   * This is process humanization, not outcome change: `human.click(target)`
-   * still lands its click on `target`, with `button` and assertions
-   * unchanged. The only differences are the cursor's path (it makes a
-   * brief detour) and the action's total duration (slightly longer).
+   * **No click or mousedown is dispatched at the off-target coordinates** —
+   * the misclick is purely visual cursor motion, so it never triggers
+   * handlers on ancestors or siblings.
+   *
+   * This is process humanization, not outcome change. `human.click(target)`
+   * still lands its click on `target`; `human.drag(from, to)` still
+   * mousedowns at `from` and mouseups at `to`. The only differences are
+   * the cursor's path (it makes a brief detour) and the action's total
+   * duration (slightly longer).
+   *
+   * Does NOT apply to: `hover` (positional, doesn't commit), `move`
+   * (explicit-coordinate positioning), or `drag`'s `to` endpoint (mouseup
+   * is the single commit moment — no "almost dropped" pattern to model).
    *
    * Skipped automatically when the target sits at the viewport edge and
-   * the candidate misclick point would have to land off-screen.
+   * the candidate near-miss point would have to land off-screen.
    */
   readonly misclickProbability: number;
   /**

--- a/packages/core/src/personality.ts
+++ b/packages/core/src/personality.ts
@@ -38,7 +38,22 @@ export interface MouseProfile {
   readonly travelTimeJitter: number;
   /** Probability of overshooting a target and correcting (0..1). */
   readonly overshootProbability: number;
-  /** Probability of clicking slightly off-target and correcting (0..1). */
+  /**
+   * Probability per click action of producing the visible "near-miss"
+   * cursor wobble (0..1). When it fires, the cursor walks to a point just
+   * outside the target's bounding box, dwells briefly (the "oh, I missed"
+   * beat), then walks to the real click point. **No click is dispatched
+   * at the off-target coordinates** — the misclick is purely visual cursor
+   * motion, so it never triggers handlers on ancestors or siblings.
+   *
+   * This is process humanization, not outcome change: `human.click(target)`
+   * still lands its click on `target`, with `button` and assertions
+   * unchanged. The only differences are the cursor's path (it makes a
+   * brief detour) and the action's total duration (slightly longer).
+   *
+   * Skipped automatically when the target sits at the viewport edge and
+   * the candidate misclick point would have to land off-screen.
+   */
   readonly misclickProbability: number;
   /**
    * Click-point spread inside the target's bounding box, as a fraction of

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -52,8 +52,8 @@ The full `Human` surface, at a glance. Each one fires real DOM events through Pl
 | Primitive | Purpose |
 |---|---|
 | `goto(url)` | Navigate the page. |
-| `click(target)` | Bezier path → pre-click hover dwell → click. |
-| `rightClick(target)` | Same as `click` but with `button: 'right'`. Fires `contextmenu`. |
+| `click(target)` | Bezier path → pre-click hover dwell → click. Occasionally near-misses (cursor wobble outside the target, then corrects) per `personality.mouse.misclickProbability`. |
+| `rightClick(target)` | Same as `click` but with `button: 'right'`. Fires `contextmenu`. Same near-miss behavior. |
 | `hover(target)` | Walk to the element and settle. No click. Hover-state UI (tooltips, dropdowns) fires. |
 | `move(target)` | Walk to a `Locator \| string \| Point`. Pure positional motion. No dwell, no element interaction — use this when you want the cursor parked somewhere with no implied click. |
 | `drag(from, to)` | Two-phase Bezier (to start → mouse down → curve to end → mouse up). Both endpoints accept `Locator \| string \| Point` — `Point` is essential for canvas / SVG / slider drags. |

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -54,7 +54,7 @@ The full `Human` surface, at a glance. Each one fires real DOM events through Pl
 | `goto(url)` | Navigate the page. |
 | `click(target)` | Bezier path → pre-click hover dwell → click. Occasionally near-misses (cursor wobble outside the target, then corrects) per `personality.mouse.misclickProbability`. |
 | `rightClick(target)` | Same as `click` but with `button: 'right'`. Fires `contextmenu`. Same near-miss behavior. |
-| `drag(from, to)` | Two-phase Bezier (to start → mouse down → curve to end → mouse up). Both endpoints accept `Locator \| string \| Point` — `Point` is essential for canvas / SVG / slider drags. Occasionally near-misses the **grab** (same shape as `click` — no near-miss on the drop). |
+| `drag(from, to)` | Two-phase Bezier (to start → mouse down → curve to end → mouse up). Both endpoints accept `Locator \| string \| Point` — `Point` is essential for canvas / SVG / slider drags. Both endpoints independently near-miss per `misclickProbability` — a drag may wobble on the grab, the drop, both, or neither. |
 | `hover(target)` | Walk to the element and settle. No click. Hover-state UI (tooltips, dropdowns) fires. |
 | `move(target)` | Walk to a `Locator \| string \| Point`. Pure positional motion. No dwell, no element interaction — use this when you want the cursor parked somewhere with no implied click. |
 | `type(target, value)` | Clicks the field for focus, then per-key rhythm with optional typos + Backspace recovery. |

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -54,9 +54,9 @@ The full `Human` surface, at a glance. Each one fires real DOM events through Pl
 | `goto(url)` | Navigate the page. |
 | `click(target)` | Bezier path → pre-click hover dwell → click. Occasionally near-misses (cursor wobble outside the target, then corrects) per `personality.mouse.misclickProbability`. |
 | `rightClick(target)` | Same as `click` but with `button: 'right'`. Fires `contextmenu`. Same near-miss behavior. |
+| `drag(from, to)` | Two-phase Bezier (to start → mouse down → curve to end → mouse up). Both endpoints accept `Locator \| string \| Point` — `Point` is essential for canvas / SVG / slider drags. Occasionally near-misses the **grab** (same shape as `click` — no near-miss on the drop). |
 | `hover(target)` | Walk to the element and settle. No click. Hover-state UI (tooltips, dropdowns) fires. |
 | `move(target)` | Walk to a `Locator \| string \| Point`. Pure positional motion. No dwell, no element interaction — use this when you want the cursor parked somewhere with no implied click. |
-| `drag(from, to)` | Two-phase Bezier (to start → mouse down → curve to end → mouse up). Both endpoints accept `Locator \| string \| Point` — `Point` is essential for canvas / SVG / slider drags. |
 | `type(target, value)` | Clicks the field for focus, then per-key rhythm with optional typos + Backspace recovery. |
 | `paste(target, value)` | Clicks the field for focus, then `insertText` — instant insertion, no per-character timing. Cmd-V semantic. |
 | `press(key)` | Single key (`'Tab'`) or chord (`'Mod+S'`). See [Keyboard](#keyboard) below. |

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -67,7 +67,7 @@ The full `Human` surface, at a glance. Each one fires real DOM events through Pl
 
 Targets accept a CSS selector string or a Playwright `Locator`. `move` and `drag` additionally accept raw `Point` coordinates. Auto-scroll fires for any element-bound primitive when the target is outside the viewport — humanized scroll in normal speed modes, `scrollIntoViewIfNeeded` in `'instant'`.
 
-Near-miss (cursor wobble before committing — see `personality.mouse.misclickProbability`) applies only to the primitives that commit a button event at the resolved coordinates: `click`, `rightClick`, and both `drag` endpoints. `hover`, `move`, `type`, `paste`, `press`, `read`, and `scroll` never misclick, by design — a wobble would trigger handlers on the wrong element for `hover`, and would contradict the explicit-coordinate contract for `move`. The misclick is also skipped when the cursor is already on the target (no approach means no overshoot).
+Near-miss (cursor wobble before committing — see `personality.mouse.misclickProbability`) applies to the primitives that commit a button event at the resolved coordinates: `click`, `rightClick`, both `drag` endpoints, and the implicit focus-acquiring click inside `type` / `paste` (the keystrokes themselves are unaffected). `hover`, `move`, `press`, `read`, and `scroll` never misclick, by design — a wobble would trigger handlers on the wrong element for `hover`, and would contradict the explicit-coordinate contract for `move`. The misclick is also skipped when the cursor is already on the target (no approach means no overshoot).
 
 ### Keyboard
 

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -67,6 +67,8 @@ The full `Human` surface, at a glance. Each one fires real DOM events through Pl
 
 Targets accept a CSS selector string or a Playwright `Locator`. `move` and `drag` additionally accept raw `Point` coordinates. Auto-scroll fires for any element-bound primitive when the target is outside the viewport — humanized scroll in normal speed modes, `scrollIntoViewIfNeeded` in `'instant'`.
 
+Near-miss (cursor wobble before committing — see `personality.mouse.misclickProbability`) applies only to the primitives that commit a button event at the resolved coordinates: `click`, `rightClick`, and both `drag` endpoints. `hover`, `move`, `type`, `paste`, `press`, `read`, and `scroll` never misclick, by design — a wobble would trigger handlers on the wrong element for `hover`, and would contradict the explicit-coordinate contract for `move`. The misclick is also skipped when the cursor is already on the target (no approach means no overshoot).
+
 ### Keyboard
 
 ```ts

--- a/packages/playwright/src/mouse/click.test.ts
+++ b/packages/playwright/src/mouse/click.test.ts
@@ -537,5 +537,31 @@ describe('human.click', () => {
       expect(mouseDown).toHaveBeenCalledTimes(1);
       expect(mouseUp).toHaveBeenCalledTimes(1);
     });
+
+    it("drag's `to` misclick keeps the drop coordinates exact", async () => {
+      // With both endpoints rolling for misclick (prob 1 here), the drop
+      // misclick wanders the cursor near `to` and dwells, then walks back
+      // to the real drop coordinates. The contract that mouseup fires at
+      // exactly `to` must still hold — visual-only safety, like the grab
+      // side. Using raw Points so we know the exact resolved drop coords.
+      const { page, mouseMove } = makeMockPage();
+      const mouseUp = page.mouse.up as ReturnType<typeof vi.fn>;
+      const human = await createHuman(page, {
+        personality: { extends: 'careful', mouse: { misclickProbability: 1 } },
+        speed: 'fast',
+        seed: 'drag-to-misclick',
+      });
+      await human.drag({ x: 100, y: 100 }, { x: 500, y: 500 });
+
+      // mouseup called exactly once — the misclick is visual-only.
+      expect(mouseUp).toHaveBeenCalledTimes(1);
+
+      // The last mouse.move before mouseup lands at the exact drop point.
+      // If the to-endpoint misclick leaked into the actual drop coords, the
+      // cursor would end somewhere 5–15 px off and this would fail.
+      const lastMove = mouseMove.mock.calls.at(-1) as [number, number];
+      expect(lastMove[0]).toBe(500);
+      expect(lastMove[1]).toBe(500);
+    });
   });
 });

--- a/packages/playwright/src/mouse/click.test.ts
+++ b/packages/playwright/src/mouse/click.test.ts
@@ -538,6 +538,29 @@ describe('human.click', () => {
       expect(mouseUp).toHaveBeenCalledTimes(1);
     });
 
+    it('skips the misclick beat when the cursor is already on the target', async () => {
+      // Cursor starts inside the target box (default box is at 100,200,80,30
+      // → center 140,215, well inside). A real user doesn't aim away from
+      // a button they're already hovering, so the misclick beat should be
+      // suppressed in this case — even at probability 1.
+      async function clickMoves(misclickProbability: number) {
+        const { page, mouseMove } = makeMockPage();
+        const human = await createHuman(page, {
+          personality: { extends: 'careful', mouse: { misclickProbability } },
+          speed: 'fast',
+          seed: 'cursor-already-on-target',
+          initialMousePosition: { x: 140, y: 215 },
+        });
+        await human.click('button');
+        return mouseMove.mock.calls.length;
+      }
+
+      const off = await clickMoves(0);
+      const on = await clickMoves(1);
+      // With cursor already inside, prob 1 must NOT add a detour.
+      expect(on).toBe(off);
+    });
+
     it("drag's `to` misclick keeps the drop coordinates exact", async () => {
       // With both endpoints rolling for misclick (prob 1 here), the drop
       // misclick wanders the cursor near `to` and dwells, then walks back

--- a/packages/playwright/src/mouse/click.test.ts
+++ b/packages/playwright/src/mouse/click.test.ts
@@ -480,5 +480,62 @@ describe('human.click', () => {
       const on = await hoverMoves(1);
       expect(off).toBe(on);
     });
+
+    it('drag with element-bound `from` fires the misclick beat before grabbing', async () => {
+      // Element-bound `from` (selector / Locator) routes through
+      // `pickMisclickOutsideBox` for the near-miss point. With prob 1, the
+      // detour should produce substantially more moves than the baseline.
+      async function dragMoves(misclickProbability: number) {
+        const { page, mouseMove } = makeMockPage();
+        const human = await createHuman(page, {
+          personality: { extends: 'careful', mouse: { misclickProbability } },
+          speed: 'fast',
+          seed: 'drag-element-misclick',
+        });
+        await human.drag('source', 'target');
+        return mouseMove.mock.calls.length;
+      }
+
+      const off = await dragMoves(0);
+      const on = await dragMoves(1);
+      expect(on).toBeGreaterThan(off * 1.3);
+    });
+
+    it('drag with raw-Point `from` fires the misclick beat around the point', async () => {
+      // Raw-Point `from` (no element) routes through `pickMisclickAroundPoint`.
+      // Same expected outcome: prob 1 produces more moves than prob 0.
+      async function dragMoves(misclickProbability: number) {
+        const { page, mouseMove } = makeMockPage();
+        const human = await createHuman(page, {
+          personality: { extends: 'careful', mouse: { misclickProbability } },
+          speed: 'fast',
+          seed: 'drag-point-misclick',
+        });
+        await human.drag({ x: 400, y: 300 }, { x: 800, y: 500 });
+        return mouseMove.mock.calls.length;
+      }
+
+      const off = await dragMoves(0);
+      const on = await dragMoves(1);
+      expect(on).toBeGreaterThan(off * 1.3);
+    });
+
+    it('drag fires exactly one mousedown and one mouseup at the resolved endpoints', async () => {
+      // No matter whether misclick fires, the drag boundaries (mousedown
+      // at `from`, mouseup at `to`) commit exactly once at the resolved
+      // coordinates — the misclick is visual cursor motion only.
+      const { page } = makeMockPage();
+      const mouseDown = page.mouse.down as ReturnType<typeof vi.fn>;
+      const mouseUp = page.mouse.up as ReturnType<typeof vi.fn>;
+      const human = await createHuman(page, {
+        personality: { extends: 'careful', mouse: { misclickProbability: 1 } },
+        speed: 'fast',
+        seed: 'drag-commits-cleanly',
+      });
+      await human.drag('source', 'target');
+
+      expect(mouseDown).toHaveBeenCalledTimes(1);
+      expect(mouseUp).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/playwright/src/mouse/click.test.ts
+++ b/packages/playwright/src/mouse/click.test.ts
@@ -379,4 +379,106 @@ describe('human.click', () => {
       expect(page.mouse.move).toHaveBeenCalledWith(140, 315);
     });
   });
+
+  describe('misclick + recovery', () => {
+    // Default target box: (100, 200, 80, 30). The misclick beat detours via
+    // a point 5-15px outside the box, then back to a Gaussian point inside.
+    // We can't reliably assert "all moves inside box" — the Bezier path
+    // naturally traverses outside-the-box space on the way in from (0, 0).
+    // Instead, compare move counts between misclick-off and misclick-on runs:
+    // the misclick path adds a whole extra Bezier walk, so move count
+    // roughly doubles. That's the robust signal.
+    const insideBox = (x: number, y: number) => x >= 100 && x <= 180 && y >= 200 && y <= 230;
+
+    async function clickAndCountMoves(misclickProbability: number, seed: string) {
+      const { page, mouseMove, mouseClick } = makeMockPage();
+      const human = await createHuman(page, {
+        personality: { extends: 'careful', mouse: { misclickProbability } },
+        speed: 'fast',
+        seed,
+      });
+      await human.click('button');
+      return {
+        moveCount: mouseMove.mock.calls.length,
+        clickCalls: mouseClick.mock.calls as Array<[number, number, { button?: string }?]>,
+      };
+    }
+
+    it('click lands inside the target whether or not misclick fires', async () => {
+      // Same seed, two settings: prob 0 and prob 1. In both cases the click
+      // must land inside the target — the misclick is visual cursor motion
+      // only, never a real click at off-target coordinates.
+      const off = await clickAndCountMoves(0, 'same-seed');
+      const on = await clickAndCountMoves(1, 'same-seed');
+
+      for (const result of [off, on]) {
+        expect(result.clickCalls).toHaveLength(1);
+        const [x, y] = result.clickCalls[0] as [number, number];
+        expect(insideBox(x, y)).toBe(true);
+      }
+    });
+
+    it('misclick path adds a Bezier detour — more mouse.move calls vs no-misclick', async () => {
+      // Robust signal: misclick on adds a whole extra walk-to-then-back leg,
+      // which produces substantially more mouse.move events than the
+      // straight walk. Avoids brittle assertions on specific coordinates.
+      const off = await clickAndCountMoves(0, 'compare-seed');
+      const on = await clickAndCountMoves(1, 'compare-seed');
+
+      // The detour adds roughly a second Bezier path of moves. Conservative
+      // assertion: at least 50% more moves with misclick enabled.
+      expect(on.moveCount).toBeGreaterThan(off.moveCount * 1.5);
+    });
+
+    it('rightClick triggers misclick the same way (still a click action)', async () => {
+      // Helper local to this test so we capture both the move count and
+      // the right-button click args from each run.
+      async function rightClick(misclickProbability: number, seed: string) {
+        const { page, mouseMove, mouseClick } = makeMockPage();
+        const human = await createHuman(page, {
+          personality: { extends: 'careful', mouse: { misclickProbability } },
+          speed: 'fast',
+          seed,
+        });
+        await human.rightClick('button');
+        return {
+          moveCount: mouseMove.mock.calls.length,
+          clickCalls: mouseClick.mock.calls as Array<[number, number, { button?: string }?]>,
+        };
+      }
+
+      const off = await rightClick(0, 'right-misclick');
+      const on = await rightClick(1, 'right-misclick');
+
+      // Click fires once with button: 'right' inside the target box, regardless of misclick.
+      for (const result of [off, on]) {
+        expect(result.clickCalls).toHaveLength(1);
+        const [x, y, opts] = result.clickCalls[0] as [number, number, { button?: string }];
+        expect(opts?.button).toBe('right');
+        expect(insideBox(x, y)).toBe(true);
+      }
+
+      // Misclick on adds a Bezier detour → substantially more mouse.move events.
+      expect(on.moveCount).toBeGreaterThan(off.moveCount * 1.5);
+    });
+
+    it('hover does NOT misclick — same move count at probability 0 or 1', async () => {
+      // Hover takes a non-misclick code path inside moveToTarget, so the
+      // move count must be identical regardless of misclickProbability.
+      async function hoverMoves(misclickProbability: number) {
+        const { page, mouseMove } = makeMockPage();
+        const human = await createHuman(page, {
+          personality: { extends: 'careful', mouse: { misclickProbability } },
+          speed: 'fast',
+          seed: 'hover-seed',
+        });
+        await human.hover('button');
+        return mouseMove.mock.calls.length;
+      }
+
+      const off = await hoverMoves(0);
+      const on = await hoverMoves(1);
+      expect(off).toBe(on);
+    });
+  });
 });

--- a/packages/playwright/src/mouse/index.ts
+++ b/packages/playwright/src/mouse/index.ts
@@ -519,14 +519,14 @@ const MISCLICK_OFFSET_MIN = 5;
 const MISCLICK_OFFSET_MAX = 15;
 
 /**
- * Performs the "near-miss" beat shared by `click` and `drag`'s `from`
- * endpoint: with probability `personality.mouse.misclickProbability`, walks
+ * Performs the "near-miss" beat shared by `click` and both endpoints of
+ * `drag`: with probability `personality.mouse.misclickProbability`, walks
  * the cursor to a point just outside (or near, for raw-Point targets) the
  * commit point, dwells briefly, then returns. The caller continues from
  * wherever the cursor lands — usually with its own walk to the real point.
  *
- * No click is dispatched at the off-target coordinates. The misclick is
- * visible cursor motion only.
+ * No click / mousedown / mouseup is dispatched at the off-target
+ * coordinates. The misclick is visible cursor motion only.
  *
  * Two flavors:
  *  - `box` non-null: pick a point just outside one of the four edges.
@@ -536,9 +536,17 @@ const MISCLICK_OFFSET_MAX = 15;
  *    direction. Used for raw-Point targets (canvas/SVG drags), where there
  *    is no box but the action still commits at a specific coordinate.
  *
- * Skipped (no beat) when the resulting near-miss would have to be clamped
- * back onto the target — better to commit cleanly than fake a degenerate
- * "miss" that lands on the target anyway.
+ * Skipped (no beat) in three cases:
+ *  1. The probability roll comes up under the threshold.
+ *  2. The cursor is already on the target — there's no approach to miss
+ *     when you're already hovering the element. A real user doesn't aim
+ *     away from a button they're already on. The probability roll still
+ *     consumes one RNG value in this case (kept *before* the cursor-on-
+ *     target check) so seeded runs stay deterministic regardless of
+ *     where the cursor happened to start.
+ *  3. The candidate near-miss would have to be clamped back onto the
+ *     target (target pinned at the viewport edge). Better to commit
+ *     cleanly than fake a degenerate "miss" that lands on the target.
  */
 async function maybeMisclickBeat(
   ctx: MouseContext,
@@ -546,6 +554,12 @@ async function maybeMisclickBeat(
   targetPoint: Point,
 ): Promise<void> {
   if (!ctx.rng.chance(ctx.personality.mouse.misclickProbability)) return;
+
+  // Skip when cursor is already on/near the target — no approach to miss.
+  // Important: this check runs AFTER the chance() roll above so the RNG
+  // sequence stays identical regardless of where the cursor happened to
+  // start, preserving seed-level determinism across runs.
+  if (cursorAlreadyOnTarget(ctx.getMousePosition(), box, targetPoint)) return;
 
   const viewport = ctx.page.viewportSize();
   const misclickPoint = box
@@ -565,6 +579,34 @@ async function maybeMisclickBeat(
     ctx.rng,
   );
   if (realizeMs > 0) await sleep(realizeMs);
+}
+
+/**
+ * True when the cursor is already on (or close enough to) the target.
+ * Used by {@link maybeMisclickBeat} to skip the near-miss beat when
+ * there's no approach to overshoot.
+ *
+ * For element-bound targets (`box` non-null): inside the bounding box.
+ * For raw-Point targets (`box` null): within `MISCLICK_OFFSET_MIN` px
+ * of the target coordinate — at that distance any "outside" near-miss
+ * would be barely-outside, defeating the visual signal anyway.
+ */
+function cursorAlreadyOnTarget(
+  current: Point,
+  box: BoundingBox | null,
+  targetPoint: Point,
+): boolean {
+  if (box) {
+    return (
+      current.x >= box.x &&
+      current.x <= box.x + box.width &&
+      current.y >= box.y &&
+      current.y <= box.y + box.height
+    );
+  }
+  const dx = current.x - targetPoint.x;
+  const dy = current.y - targetPoint.y;
+  return Math.hypot(dx, dy) < MISCLICK_OFFSET_MIN;
 }
 
 /**

--- a/packages/playwright/src/mouse/index.ts
+++ b/packages/playwright/src/mouse/index.ts
@@ -174,15 +174,21 @@ export async function executeHover(
 /**
  * Executes a humanized drag from one location to another.
  *
- *  1. Move the cursor to the `from` target along a Bezier path.
- *  2. Press the left mouse button down.
- *  3. Walk a fresh Bezier path from `from` to `to`, with the button still
+ *  1. Optionally near-miss the grab — with probability
+ *     `personality.mouse.misclickProbability`, the cursor first walks to a
+ *     point just outside the `from` target (or near it, for raw-Point
+ *     `from`), dwells briefly, then approaches the real grab point. No
+ *     mousedown fires at the off-target coordinates.
+ *  2. Move the cursor to the `from` target along a Bezier path.
+ *  3. Press the left mouse button down.
+ *  4. Walk a fresh Bezier path from `from` to `to`, with the button still
  *     held. This is the actual drag motion the page sees.
- *  4. Release the button at `to`.
+ *  5. Release the button at `to`.
  *
  * Both endpoints accept a CSS selector, a Locator, or a literal `Point` —
  * the last form is essential for canvas/SVG drags where the destination
- * isn't a DOM element.
+ * isn't a DOM element. The `to` endpoint does NOT misclick — mouseup is
+ * the single commit moment, with no "almost dropped" pattern to model.
  *
  * In `speed: 'instant'`, dispatches a single `mouse.down → move → up`
  * sequence at the resolved endpoints without humanized motion.

--- a/packages/playwright/src/mouse/index.ts
+++ b/packages/playwright/src/mouse/index.ts
@@ -292,13 +292,48 @@ export async function executeMove(target: MouseTarget, ctx: MouseContext): Promi
  * `executeDrag` and `executeMove` accept raw `Point` inputs too, so they
  * reach the same Bezier walk through `resolveTargetPoint` + `walkBezierTo`
  * instead of going through here.
+ *
+ * For `'click'` actions, this is also where the misclick beat fires: with
+ * probability `personality.mouse.misclickProbability`, the cursor first
+ * walks to a point just outside the target's bounding box, dwells briefly
+ * (the "oh, I missed" beat), then walks to the real click point. No click
+ * is dispatched at the off-target coordinates — the misclick is purely
+ * cursor motion, so we never trigger handlers on ancestors or siblings.
+ * That keeps the visible humanization signal while making the behavior
+ * safe by construction. Hover never misclicks; hovers are about settling
+ * on an element, not committing an action.
  */
 async function moveToTarget(
   target: Locator | string,
   ctx: MouseContext,
   action: 'click' | 'hover',
 ): Promise<Point> {
-  const targetPoint = await resolveLocatorPoint(target, ctx, action);
+  const box = await readBoxWithAutoScroll(target, ctx, action);
+  const targetPoint = pickClickPoint(box, ctx.rng, ctx.personality.mouse.clickSpread);
+
+  if (action === 'click' && ctx.rng.chance(ctx.personality.mouse.misclickProbability)) {
+    const misclickPoint = pickMisclickPoint(box, ctx.rng, ctx.page.viewportSize());
+    // `null` means clamping pulled the candidate back onto the target (target
+    // is at the viewport edge) — skip the misclick this round rather than
+    // produce a meaningless "near-miss" that lands on the target anyway.
+    if (misclickPoint !== null) {
+      await walkBezierTo(misclickPoint, ctx);
+      ctx.setMousePosition(misclickPoint);
+
+      // "Realize the miss" dwell — same shape as the pre-click settle beat.
+      // A real user notices the cursor is wrong before committing the click;
+      // this is the moment between near-miss and correction.
+      const realizeMs = computeDwellTime(
+        ctx.personality.dwell.preClickMs,
+        ctx.personality.dwell.preClickJitter,
+        ctx.personality,
+        ctx.speed,
+        ctx.rng,
+      );
+      if (realizeMs > 0) await sleep(realizeMs);
+    }
+  }
+
   await walkBezierTo(targetPoint, ctx);
   return targetPoint;
 }
@@ -452,6 +487,69 @@ interface BoundingBox {
   readonly y: number;
   readonly width: number;
   readonly height: number;
+}
+
+/** Range, in CSS pixels, that a misclick lands outside the target's bounding box. */
+const MISCLICK_OFFSET_MIN = 5;
+const MISCLICK_OFFSET_MAX = 15;
+
+/**
+ * Picks a point just outside the target's bounding box — the "near-miss"
+ * coordinates the cursor visits before correcting to the real click point.
+ *
+ * Process:
+ *
+ *  1. Pick one of the four edges to miss toward (top/right/bottom/left).
+ *  2. Pick an outward offset (5–15 px) — far enough to read as a miss,
+ *     close enough to read as a correctable wobble.
+ *  3. Pick a position along that edge (biased toward the middle 60%, so we
+ *     don't miss past a corner where the wobble reads as wild).
+ *  4. Clamp to the viewport, since the cursor can't legally land off-screen.
+ *  5. If clamping pulled the point back inside the target's box (target sits
+ *     at the viewport edge), return `null` — the caller skips the misclick
+ *     this round rather than produce a "near-miss" that lands on the target.
+ *
+ * Crucially, this function returns a *coordinate*; the caller never fires a
+ * click event there. The misclick is visible cursor motion only — no risk
+ * of triggering handlers on ancestors / siblings, which is why we don't
+ * need an `elementFromPoint` safety check.
+ */
+function pickMisclickPoint(
+  box: BoundingBox,
+  rng: Rng,
+  viewport: { readonly width: number; readonly height: number } | null,
+): Point | null {
+  const edge = rng.nextInt(0, 4); // 0=top, 1=right, 2=bottom, 3=left
+  const offset = rng.nextFloat(MISCLICK_OFFSET_MIN, MISCLICK_OFFSET_MAX);
+  const along = rng.nextFloat(0.2, 0.8);
+
+  let x: number;
+  let y: number;
+  if (edge === 0) {
+    x = box.x + box.width * along;
+    y = box.y - offset;
+  } else if (edge === 1) {
+    x = box.x + box.width + offset;
+    y = box.y + box.height * along;
+  } else if (edge === 2) {
+    x = box.x + box.width * along;
+    y = box.y + box.height + offset;
+  } else {
+    x = box.x - offset;
+    y = box.y + box.height * along;
+  }
+
+  if (viewport) {
+    x = clamp(x, 0, viewport.width - 1);
+    y = clamp(y, 0, viewport.height - 1);
+  }
+
+  // Clamping pulled the point back inside the box → the misclick is
+  // impossible at the viewport edge; skip it rather than fake one.
+  const insideBox = x >= box.x && x <= box.x + box.width && y >= box.y && y <= box.y + box.height;
+  if (insideBox) return null;
+
+  return { x, y };
 }
 
 /**

--- a/packages/playwright/src/mouse/index.ts
+++ b/packages/playwright/src/mouse/index.ts
@@ -196,7 +196,11 @@ export async function executeDrag(
   // destination is also off-viewport, this triggers a second scroll. That's
   // the right shape for cross-viewport drags: a real user scrolls to grab,
   // then scrolls again to drop, rather than dragging through invisible space.
-  const fromPoint = await resolveTargetPoint(from, ctx, 'drag');
+  //
+  // For `from` we also capture the box (if any) so the misclick beat below
+  // can pick a near-miss "outside the box" for element-bound grabs, or
+  // "around the point" for raw-coordinate grabs (canvas/SVG).
+  const { point: fromPoint, box: fromBox } = await resolveTargetPointAndBox(from, ctx, 'drag');
   const toPoint = await resolveTargetPoint(to, ctx, 'drag');
 
   if (ctx.speed === 'instant') {
@@ -208,11 +212,18 @@ export async function executeDrag(
     return { from: fromPoint, to: toPoint };
   }
 
-  // 1. Move to the start of the drag.
+  // 1. Maybe near-miss the grab — same shape as click's misclick beat.
+  // `from` commits an action (mousedown), so the misclick principle applies.
+  // The `to` endpoint does NOT misclick — there's no "almost commit then
+  // notice" moment for a drop; mouseup is the single commit, and any
+  // wobble before it just reads as drag-motion noise.
+  await maybeMisclickBeat(ctx, fromBox, fromPoint);
+
+  // 2. Move to the start of the drag.
   await walkBezierTo(fromPoint, ctx);
   ctx.setMousePosition(fromPoint);
 
-  // 2. Press down. Beat between settling on the source and starting to drag
+  // 3. Press down. Beat between settling on the source and starting to drag
   // — real users don't grab the same frame they arrive.
   const preDragMs = computeDwellTime(
     ctx.personality.dwell.preClickMs,
@@ -224,7 +235,7 @@ export async function executeDrag(
   if (preDragMs > 0) await sleep(preDragMs);
   await ctx.page.mouse.down();
 
-  // 3. Walk to the destination with the button still held. Generate a fresh
+  // 4. Walk to the destination with the button still held. Generate a fresh
   // humanized path so the drag motion has its own curve + jitter shape.
   const rawPath = bezierPath(fromPoint, toPoint, ctx.rng, {
     curvature: ctx.personality.mouse.curvature,
@@ -233,7 +244,7 @@ export async function executeDrag(
   const travelMs = computeTravelTime(path, ctx.personality, ctx.speed, ctx.rng);
   await walkMouseAlongPath(ctx.page, path, travelMs);
 
-  // 4. Release. Post-action dwell so the next action doesn't fire in the
+  // 5. Release. Post-action dwell so the next action doesn't fire in the
   // same frame as the drop.
   await ctx.page.mouse.up();
   ctx.setMousePosition(toPoint);
@@ -311,28 +322,8 @@ async function moveToTarget(
   const box = await readBoxWithAutoScroll(target, ctx, action);
   const targetPoint = pickClickPoint(box, ctx.rng, ctx.personality.mouse.clickSpread);
 
-  if (action === 'click' && ctx.rng.chance(ctx.personality.mouse.misclickProbability)) {
-    const misclickPoint = pickMisclickPoint(box, ctx.rng, ctx.page.viewportSize());
-    // `null` means clamping pulled the candidate back onto the target (target
-    // is at the viewport edge) — skip the misclick this round rather than
-    // produce a meaningless "near-miss" that lands on the target anyway.
-    if (misclickPoint !== null) {
-      await walkBezierTo(misclickPoint, ctx);
-      ctx.setMousePosition(misclickPoint);
-
-      // "Realize the miss" dwell — same shape as the pre-click settle beat.
-      // A real user notices the cursor is wrong before committing the click;
-      // this is the moment between near-miss and correction.
-      const realizeMs = computeDwellTime(
-        ctx.personality.dwell.preClickMs,
-        ctx.personality.dwell.preClickJitter,
-        ctx.personality,
-        ctx.speed,
-        ctx.rng,
-      );
-      if (realizeMs > 0) await sleep(realizeMs);
-    }
-  }
+  // Click commits an action; hover doesn't. Only click gets the misclick beat.
+  if (action === 'click') await maybeMisclickBeat(ctx, box, targetPoint);
 
   await walkBezierTo(targetPoint, ctx);
   return targetPoint;
@@ -368,6 +359,24 @@ async function resolveTargetPoint(
 ): Promise<Point> {
   if (isPoint(target)) return target;
   return resolveLocatorPoint(target, ctx, action);
+}
+
+/**
+ * Same as {@link resolveTargetPoint} but also returns the bounding box
+ * when the target is element-bound. Raw `Point` targets get `box: null` —
+ * there's no element, just a coordinate. Used by `executeDrag` so the
+ * misclick beat can pick a "near-miss outside the box" for element-bound
+ * grabs and a "near-miss around the point" for raw-coordinate grabs.
+ */
+async function resolveTargetPointAndBox(
+  target: MouseTarget,
+  ctx: MouseContext,
+  action: 'drag',
+): Promise<{ point: Point; box: BoundingBox | null }> {
+  if (isPoint(target)) return { point: target, box: null };
+  const box = await readBoxWithAutoScroll(target, ctx, action);
+  const point = pickClickPoint(box, ctx.rng, ctx.personality.mouse.clickSpread);
+  return { point, box };
 }
 
 /**
@@ -494,6 +503,55 @@ const MISCLICK_OFFSET_MIN = 5;
 const MISCLICK_OFFSET_MAX = 15;
 
 /**
+ * Performs the "near-miss" beat shared by `click` and `drag`'s `from`
+ * endpoint: with probability `personality.mouse.misclickProbability`, walks
+ * the cursor to a point just outside (or near, for raw-Point targets) the
+ * commit point, dwells briefly, then returns. The caller continues from
+ * wherever the cursor lands — usually with its own walk to the real point.
+ *
+ * No click is dispatched at the off-target coordinates. The misclick is
+ * visible cursor motion only.
+ *
+ * Two flavors:
+ *  - `box` non-null: pick a point just outside one of the four edges.
+ *    Used for element-bound targets where "outside the box" has obvious
+ *    geometry.
+ *  - `box` null: pick a point 5–15 px from the target Point in a random
+ *    direction. Used for raw-Point targets (canvas/SVG drags), where there
+ *    is no box but the action still commits at a specific coordinate.
+ *
+ * Skipped (no beat) when the resulting near-miss would have to be clamped
+ * back onto the target — better to commit cleanly than fake a degenerate
+ * "miss" that lands on the target anyway.
+ */
+async function maybeMisclickBeat(
+  ctx: MouseContext,
+  box: BoundingBox | null,
+  targetPoint: Point,
+): Promise<void> {
+  if (!ctx.rng.chance(ctx.personality.mouse.misclickProbability)) return;
+
+  const viewport = ctx.page.viewportSize();
+  const misclickPoint = box
+    ? pickMisclickOutsideBox(box, ctx.rng, viewport)
+    : pickMisclickAroundPoint(targetPoint, ctx.rng, viewport);
+
+  if (misclickPoint === null) return;
+
+  await walkBezierTo(misclickPoint, ctx);
+  ctx.setMousePosition(misclickPoint);
+
+  const realizeMs = computeDwellTime(
+    ctx.personality.dwell.preClickMs,
+    ctx.personality.dwell.preClickJitter,
+    ctx.personality,
+    ctx.speed,
+    ctx.rng,
+  );
+  if (realizeMs > 0) await sleep(realizeMs);
+}
+
+/**
  * Picks a point just outside the target's bounding box — the "near-miss"
  * coordinates the cursor visits before correcting to the real click point.
  *
@@ -508,13 +566,8 @@ const MISCLICK_OFFSET_MAX = 15;
  *  5. If clamping pulled the point back inside the target's box (target sits
  *     at the viewport edge), return `null` — the caller skips the misclick
  *     this round rather than produce a "near-miss" that lands on the target.
- *
- * Crucially, this function returns a *coordinate*; the caller never fires a
- * click event there. The misclick is visible cursor motion only — no risk
- * of triggering handlers on ancestors / siblings, which is why we don't
- * need an `elementFromPoint` safety check.
  */
-function pickMisclickPoint(
+function pickMisclickOutsideBox(
   box: BoundingBox,
   rng: Rng,
   viewport: { readonly width: number; readonly height: number } | null,
@@ -548,6 +601,44 @@ function pickMisclickPoint(
   // impossible at the viewport edge; skip it rather than fake one.
   const insideBox = x >= box.x && x <= box.x + box.width && y >= box.y && y <= box.y + box.height;
   if (insideBox) return null;
+
+  return { x, y };
+}
+
+/**
+ * Picks a point near (but not on) a raw target coordinate — the no-box
+ * analog of {@link pickMisclickOutsideBox}, used for `drag`'s raw-`Point`
+ * `from` endpoint (canvas / SVG / pixel-precise targets).
+ *
+ * Process:
+ *  1. Pick a random direction (angle in radians).
+ *  2. Pick a distance (5–15 px), same range as the box case.
+ *  3. Clamp to the viewport.
+ *  4. If clamping pulled the candidate exactly onto the target (target
+ *     pinned to the viewport corner with no usable direction), return
+ *     `null` so the caller skips the misclick rather than fake one.
+ *
+ * The target is treated as a zero-sized box: any non-zero offset puts the
+ * misclick "outside," which is the right semantic for a pixel-precise
+ * action committing at the exact coordinate.
+ */
+function pickMisclickAroundPoint(
+  target: Point,
+  rng: Rng,
+  viewport: { readonly width: number; readonly height: number } | null,
+): Point | null {
+  const angle = rng.nextFloat(0, Math.PI * 2);
+  const distance = rng.nextFloat(MISCLICK_OFFSET_MIN, MISCLICK_OFFSET_MAX);
+
+  let x = target.x + Math.cos(angle) * distance;
+  let y = target.y + Math.sin(angle) * distance;
+
+  if (viewport) {
+    x = clamp(x, 0, viewport.width - 1);
+    y = clamp(y, 0, viewport.height - 1);
+  }
+
+  if (x === target.x && y === target.y) return null;
 
   return { x, y };
 }

--- a/packages/playwright/src/mouse/index.ts
+++ b/packages/playwright/src/mouse/index.ts
@@ -181,14 +181,20 @@ export async function executeHover(
  *     mousedown fires at the off-target coordinates.
  *  2. Move the cursor to the `from` target along a Bezier path.
  *  3. Press the left mouse button down.
- *  4. Walk a fresh Bezier path from `from` to `to`, with the button still
- *     held. This is the actual drag motion the page sees.
- *  5. Release the button at `to`.
+ *  4. Optionally near-miss the drop — independent probability roll, same
+ *     visual-only shape: cursor walks to a near-miss point with the
+ *     button still held, dwells, then continues to the real drop point.
+ *     No mouseup fires at the off-target coordinates. The marginal cost
+ *     is a small extra detour through `dragover` events on neighbors,
+ *     which is already part of normal drag motion.
+ *  5. Walk a fresh Bezier path to `to`, with the button still held. This
+ *     is the actual drag motion the page sees.
+ *  6. Release the button at `to`.
  *
  * Both endpoints accept a CSS selector, a Locator, or a literal `Point` —
  * the last form is essential for canvas/SVG drags where the destination
- * isn't a DOM element. The `to` endpoint does NOT misclick — mouseup is
- * the single commit moment, with no "almost dropped" pattern to model.
+ * isn't a DOM element. The grab and drop endpoints roll for misclick
+ * independently, so a single drag may near-miss either, both, or neither.
  *
  * In `speed: 'instant'`, dispatches a single `mouse.down → move → up`
  * sequence at the resolved endpoints without humanized motion.
@@ -203,11 +209,11 @@ export async function executeDrag(
   // the right shape for cross-viewport drags: a real user scrolls to grab,
   // then scrolls again to drop, rather than dragging through invisible space.
   //
-  // For `from` we also capture the box (if any) so the misclick beat below
-  // can pick a near-miss "outside the box" for element-bound grabs, or
-  // "around the point" for raw-coordinate grabs (canvas/SVG).
+  // For both endpoints we also capture the box (if any) so the misclick
+  // beats below can pick a near-miss "outside the box" for element-bound
+  // targets, or "around the point" for raw-coordinate targets (canvas/SVG).
   const { point: fromPoint, box: fromBox } = await resolveTargetPointAndBox(from, ctx, 'drag');
-  const toPoint = await resolveTargetPoint(to, ctx, 'drag');
+  const { point: toPoint, box: toBox } = await resolveTargetPointAndBox(to, ctx, 'drag');
 
   if (ctx.speed === 'instant') {
     await ctx.page.mouse.move(fromPoint.x, fromPoint.y);
@@ -218,11 +224,8 @@ export async function executeDrag(
     return { from: fromPoint, to: toPoint };
   }
 
-  // 1. Maybe near-miss the grab — same shape as click's misclick beat.
+  // 1. Maybe near-miss the grab. Same shape as click's misclick beat;
   // `from` commits an action (mousedown), so the misclick principle applies.
-  // The `to` endpoint does NOT misclick — there's no "almost commit then
-  // notice" moment for a drop; mouseup is the single commit, and any
-  // wobble before it just reads as drag-motion noise.
   await maybeMisclickBeat(ctx, fromBox, fromPoint);
 
   // 2. Move to the start of the drag.
@@ -241,16 +244,23 @@ export async function executeDrag(
   if (preDragMs > 0) await sleep(preDragMs);
   await ctx.page.mouse.down();
 
-  // 4. Walk to the destination with the button still held. Generate a fresh
-  // humanized path so the drag motion has its own curve + jitter shape.
-  const rawPath = bezierPath(fromPoint, toPoint, ctx.rng, {
-    curvature: ctx.personality.mouse.curvature,
-  });
-  const path = humanizePath(rawPath, ctx.rng);
-  const travelMs = computeTravelTime(path, ctx.personality, ctx.speed, ctx.rng);
-  await walkMouseAlongPath(ctx.page, path, travelMs);
+  // 4. Maybe near-miss the drop. Independent roll from the grab — a drag
+  // may near-miss the grab, the drop, both, or neither. Same visual-only
+  // safety: the cursor wanders near `to` and dwells, but mouseup only
+  // fires once the cursor has walked to the real drop point in step 5.
+  // Dragover events fire on neighbors during the detour, but they were
+  // already firing along the natural drag path — the misclick adds a
+  // small extra loop, which is exactly what an exploratory drop attempt
+  // looks like in real human use.
+  await maybeMisclickBeat(ctx, toBox, toPoint);
 
-  // 5. Release. Post-action dwell so the next action doesn't fire in the
+  // 5. Walk to the destination with the button still held. `walkBezierTo`
+  // generates a fresh humanized path from the cursor's current position
+  // (which may be the misclick point from step 4, or `fromPoint` if no
+  // misclick fired) to `toPoint`.
+  await walkBezierTo(toPoint, ctx);
+
+  // 6. Release. Post-action dwell so the next action doesn't fire in the
   // same frame as the drop.
   await ctx.page.mouse.up();
   ctx.setMousePosition(toPoint);


### PR DESCRIPTION

## Summary

- Wires up the long-declared `personality.mouse.misclickProbability` knob: `click`, `rightClick`, and `drag`'s `from` endpoint now occasionally produce a visible "near-miss" cursor wobble before committing the action.
- The misclick is **visible cursor motion only** — no `mouse.click` or `mouse.down` event fires at the off-target coordinates, so handlers on ancestor / sibling / unrelated elements stay untouched. Safe by construction.
- Preset values unchanged (precise 0.001, careful 0.01, fast 0.005, distracted 0.05). The knob was already shipped — it just never fired.

## What happens when it fires

1. Cursor walks via Bezier path to a near-miss point — 5-15 px outside an edge of the bounding box (element-bound targets) or 5-15 px from the target coordinate in a random direction (raw-`Point` targets, for canvas/SVG drags).
2. Brief "oh, I missed" dwell, scaled by personality (same shape as the pre-click settle beat).
3. Cursor walks the small distance to the real commit point.
4. Click / mousedown fires once, on the target.

## Why visual-only (and not "fire a real off-target click then correct")

A real misclick fires a click event at the wrong coordinates, which can hit ancestor elements (parent containers with their own onClick), sibling elements (a destructive button next to the target), or invisible overlays (modal triggers). We can't reliably detect "does this element have an `addEventListener`-attached handler?" from outside the page — heuristics like tag name, `cursor: pointer`, or `onclick` attributes miss the React / Vue
/ Svelte case where everything uses `addEventListener` and styles are dynamic.

So the safe design is: never dispatch a click at the wrong coordinates. The misclick is the **cursor motion before committing** — the visible "I almost clicked the wrong thing, then noticed" signal — without the side effect of actually clicking the wrong thing.

This matches what sophisticated users do in real life: they notice their cursor is off and correct before letting up on the mouse button. It also makes the feature usable on production pages without worrying that an unlucky seed lands a destructive misclick.

## Scope — what does and doesn't misclick

| Primitive | Misclicks? | Why |
|---|---|---|
| `click` | ✓ | Commits an action; near-miss approach matches real human imprecision. |
| `rightClick` | ✓ | Same shape as `click`, just a different button. |
| `drag(from, to)` — the `from` endpoint | ✓ | `mousedown` commits the grab; the approach to it can miss the same way a click can. |
| `drag(from, to)` — the `to` endpoint | ✗ | `mouseup` is the single drop commit. There's no "almost dropped then noticed" pattern — any pre-drop wobble just reads as drag-motion noise. |
| `hover` | ✗ | Positional, not action-committing. A wrong-element hover would fire `mouseenter` on a neighbor and trigger its tooltip/dropdown briefly — exactly the "trigger wrong handlers" failure mode click misclick avoids. |
Drag's `from` works for both element-bound (selector / Locator) and raw-`Point` endpoints — the canvas / SVG / slider case is supported, with the near-miss picked 5-15 px from the coordinate in a random direction.

## Internal helpers

- `maybeMisclickBeat(ctx, box | null, targetPoint)` — shared between click and drag. Rolls probability, picks near-miss point, walks + dwells, or no-ops.
- `pickMisclickOutsideBox(box, rng, viewport)` — picks a point outside one of the four box edges. Skips and returns `null` when viewport clamping would pull the candidate back inside the box.
- `pickMisclickAroundPoint(target, rng, viewport)` — for raw-`Point` targets, picks a point at a random angle and distance. Same `null`-on-clamp escape.
- `resolveTargetPointAndBox(target, ctx, 'drag')` — drag-specific resolver returning both point and box (`box: null` for raw `Point` inputs).

## Override

Disable globally (or per-personality) by overriding the knob:

```ts
const human = await createHuman(page, {
  personality: {
    extends: 'careful',
    mouse: { misclickProbability: 0 },
  },
});
```

The `misclickProbability` field is part of the public `MouseProfile` type and is documented on `personality.mouse.misclickProbability` in `@humanjs/core`.

## Snapshot-test caveat

The misclick decision (`rng.chance(misclickProbability)`) consumes one RNG value per click-shaped action, regardless of whether the misclick fires. Existing seeded sessions will produce different **intermediate** cursor coordinates after upgrade — even when no misclick fires — because downstream RNG state is shifted by one consumer.

Action outcomes (click coordinates, mousedown / mouseup positions, button, target) are unchanged. Only tests that snapshot the exact mouse-move sequence against a seed will need to refresh snapshots. Tests asserting page state, form values, or action results (the typical kind) are unaffected.

## Test plan

- [x] `pnpm --filter @humanjs/playwright test` — 180 tests pass (7 new misclick-specific: click off/on, click coord-stays-inside, rightClick fires misclick, hover never misclicks, drag-element fires, drag-point fires, drag commits cleanly).
- [x] `pnpm --filter @humanjs/core test` — 143 tests pass (`MouseProfile` JSDoc only — no behavior change).
- [x] Strict `tsc --noEmit` clean on both packages.
- [x] Visual verification (headed): temporarily set `misclickProbability: 1` on `careful` in `packages/core/src/presets/careful.ts`, rebuild, run `pnpm demo:click` — every click should show a near-miss + recovery (cursor lands 5-15 px outside the button, dwells briefly, then commits).