### PR TITLE
feat(playwright): drag no longer triggers edge-scroll runaway

### DIFF
--- a/.changeset/drag-curve-aware-viewport.md
+++ b/.changeset/drag-curve-aware-viewport.md
@@ -2,31 +2,36 @@
 "@humanjs/playwright": patch
 ---
 
-`drag` now pre-scrolls the page when the Bezier curve between the two endpoints would extrude past a viewport edge — fixing the case where Chrome's native edge-scroll-during-drag behavior walks the page wildly when the cursor approaches a viewport edge with the mouse button held.
+`drag` is more robust against Chrome's native edge-scroll-during-drag behavior, fixing two related cases where the page would scroll wildly mid-drag.
 
-## The problem
+## What's fixed
 
-`human.drag(from, to)` walks a humanized Bezier curve between the endpoints with the button held. The curve's control points are perpendicular-offset by up to `distance × curvature`, so even when both endpoints are individually inside the viewport, the curve between them can pop out — and Chrome interprets that as "user dragging toward the edge, scroll to follow" and walks the page hundreds of pixels.
+**1. Mixed-endpoint drags now stay geometrically consistent across auto-scroll.** When a drag is from an element to a raw `Point` (`human.drag('#slider-thumb', { x, y })`) and the element auto-scrolls into view, the raw `Point` now shifts by the same scroll delta. This preserves the "same visual position" relationship the caller intended — callers usually compute raw Points from element positions they see right now, so when the page scrolls during resolution, the Point should follow. Otherwise a horizontal slider drag silently becomes diagonal as soon as the thumb auto-scrolls and the raw Point stays put — and the cursor walking off-viewport then triggers native edge-scroll.
 
-Symptom: dragging a horizontal slider near the viewport bottom would scroll the whole page to the bottom mid-drag, leaving the user (or test) confused about what just happened.
+**2. Element×element drags pre-scroll when the Bezier curve would extrude.** Both endpoints might be individually in-viewport (so per-endpoint auto-scroll didn't fire), yet the curve between them — control points perpendicular-offset by up to `distance × curvature` — can pop out while the mouse button is held. The library now computes a conservative bounding box for the path (the from→to line inflated by `distance × curvature` on each side) and, if it exceeds the viewport, pre-scrolls just enough plus a 20 px safety margin to bring it back inside.
 
-## The fix
+## How it composes
 
-Before the drag begins, the library computes a conservative bounding box for the path (the from→to line inflated by `distance × curvature` on each side). If that box exceeds the viewport vertically, the library scrolls the page **just enough** to bring it back inside, plus a 20 px safety margin. After the scroll both endpoints are re-resolved (they shifted with the page) and the drag proceeds with normal humanized motion.
+The resolve-time shift runs first (any auto-scroll from `readBoxWithAutoScroll` shifts raw Points by its delta). Then the curve-aware check runs for element×element drags. In practice these two cover the realistic cases:
 
-The scroll itself is humanized (`block: 'center'`-style behavior is not used here — we use the existing humanized scroll-by-delta path), so the page motion looks like a real user shifting the view to make room before the drag.
+| Drag shape | Behavior |
+|---|---|
+| element → element | Resolve-time auto-scroll if either is off-viewport, plus curve-aware pre-scroll if the curve still wouldn't fit |
+| element → raw Point | Resolve-time auto-scroll for the element brings it in view; raw Point shifts by the scroll delta; drag stays geometrically consistent |
+| raw Point → element | Symmetric |
+| raw Point → raw Point | No auto-scroll (caller owns both coordinates) — the curve-aware check doesn't fire either, because any additional scroll would shift both points further and chase its own tail |
 
-## Scope: element × element only
+## Examples
 
-The curve-aware pre-scroll only fires when **both** endpoints are element-bound (`Locator` / selector). For raw-`Point` endpoints (e.g. `human.drag('#thumb', { x: 800, y: 450 })`), the caller specified an explicit viewport coordinate — scrolling the page would shift the element endpoint relative to that coordinate and turn the drag diagonal. The library defers to the caller in that case; the canonical pattern for mixed endpoints is to scroll explicitly before the drag (see `examples/primitives-demo.ts` step 4 for the canvas/SVG-style slider drag).
+**The slider case** (the motivating example): `human.drag('#slider-thumb', { x: 800, y: thumb.y + 11 })` where the thumb is below the viewport now works without an explicit pre-scroll. The thumb auto-scrolls into the viewport center, the raw Point's y shifts by the same delta to stay aligned with the (now-centered) thumb, and the drag walks horizontally as the caller intended.
+
+**Element×element near an edge**: dragging a card from a slot near the viewport bottom to another nearby slot now pre-scrolls before mousedown when the path would dip out of viewport. Previously this triggered edge-scroll mid-drag and walked the page hundreds of pixels.
 
 ## Determinism
 
-The scroll fires deterministically based on the resolved endpoint coordinates, the personality's curvature, and the viewport size — same seed produces the same scroll decision. After the scroll, the endpoint re-resolution consumes additional RNG values (one extra Gaussian per element-bound endpoint), so seeded sessions that previously triggered no scroll and now do will see different downstream cursor coordinates. Action outcomes (mousedown / mouseup positions, target elements) are unchanged.
+The scroll fires deterministically based on resolved endpoint coordinates, personality curvature, and viewport size — same seed produces the same scroll decision. After the scroll, element endpoints are re-resolved (one extra Gaussian per element-bound endpoint) and raw Points are arithmetically adjusted (no extra RNG). Seeded sessions that previously triggered no scroll and now do will see different downstream cursor coordinates; action outcomes (mousedown / mouseup positions, target elements) are unchanged.
 
 ## Skipped automatically
 
-- One or both endpoints is a raw `Point` (deferred to caller, see above).
-- `speed: 'instant'` (the whole humanized drag path is bypassed).
-- The drag's conservative bounding box already fits in the viewport with margin to spare.
-- The path is taller than the viewport (no scroll position can fit it; the library picks the worst overflow and lives with the partial fix).
+- `speed: 'instant'` (whole humanized drag path is bypassed).
+- Both endpoints raw `Point` with curve overflow — there's no scroll position that helps, since shifting both points by the scroll delta just lengthens the drag in the new viewport.

--- a/.changeset/drag-curve-aware-viewport.md
+++ b/.changeset/drag-curve-aware-viewport.md
@@ -1,0 +1,32 @@
+---
+"@humanjs/playwright": patch
+---
+
+`drag` now pre-scrolls the page when the Bezier curve between the two endpoints would extrude past a viewport edge — fixing the case where Chrome's native edge-scroll-during-drag behavior walks the page wildly when the cursor approaches a viewport edge with the mouse button held.
+
+## The problem
+
+`human.drag(from, to)` walks a humanized Bezier curve between the endpoints with the button held. The curve's control points are perpendicular-offset by up to `distance × curvature`, so even when both endpoints are individually inside the viewport, the curve between them can pop out — and Chrome interprets that as "user dragging toward the edge, scroll to follow" and walks the page hundreds of pixels.
+
+Symptom: dragging a horizontal slider near the viewport bottom would scroll the whole page to the bottom mid-drag, leaving the user (or test) confused about what just happened.
+
+## The fix
+
+Before the drag begins, the library computes a conservative bounding box for the path (the from→to line inflated by `distance × curvature` on each side). If that box exceeds the viewport vertically, the library scrolls the page **just enough** to bring it back inside, plus a 20 px safety margin. After the scroll both endpoints are re-resolved (they shifted with the page) and the drag proceeds with normal humanized motion.
+
+The scroll itself is humanized (`block: 'center'`-style behavior is not used here — we use the existing humanized scroll-by-delta path), so the page motion looks like a real user shifting the view to make room before the drag.
+
+## Scope: element × element only
+
+The curve-aware pre-scroll only fires when **both** endpoints are element-bound (`Locator` / selector). For raw-`Point` endpoints (e.g. `human.drag('#thumb', { x: 800, y: 450 })`), the caller specified an explicit viewport coordinate — scrolling the page would shift the element endpoint relative to that coordinate and turn the drag diagonal. The library defers to the caller in that case; the canonical pattern for mixed endpoints is to scroll explicitly before the drag (see `examples/primitives-demo.ts` step 4 for the canvas/SVG-style slider drag).
+
+## Determinism
+
+The scroll fires deterministically based on the resolved endpoint coordinates, the personality's curvature, and the viewport size — same seed produces the same scroll decision. After the scroll, the endpoint re-resolution consumes additional RNG values (one extra Gaussian per element-bound endpoint), so seeded sessions that previously triggered no scroll and now do will see different downstream cursor coordinates. Action outcomes (mousedown / mouseup positions, target elements) are unchanged.
+
+## Skipped automatically
+
+- One or both endpoints is a raw `Point` (deferred to caller, see above).
+- `speed: 'instant'` (the whole humanized drag path is bypassed).
+- The drag's conservative bounding box already fits in the viewport with margin to spare.
+- The path is taller than the viewport (no scroll position can fit it; the library picks the worst overflow and lives with the partial fix).

--- a/examples/primitives-demo.ts
+++ b/examples/primitives-demo.ts
@@ -644,7 +644,7 @@ async function main() {
     await page.setContent(DEMO_HTML);
     await installMouseHelper(context);
 
-    const human = await createHuman(page, { personality, seed: 'primitives-demo-1' });
+    const human = await createHuman(page, { personality, seed: 'primitives-demo22' });
     await human.sleep(800);
 
     // 1. Hover — cursor moves to the "?" icon, tooltip reveals via CSS.
@@ -671,15 +671,15 @@ async function main() {
     console.log('4. drag → card to slot, then slider thumb to point');
     await human.drag('#drag-card', '#slot-to');
     await human.sleep(900);
-    // Center the slider section in the viewport before the drag — without
-    // this, the slider sits near the viewport bottom edge, and the
-    // horizontal Bezier curve from thumb to target can dip below y =
-    // viewportHeight with the mouse held. At that point Chrome engages
-    // its native edge-scroll-during-drag behavior and walks the page all
-    // the way down. Centering the slider gives the curve ~450px of
-    // headroom in both directions.
-    await human.scroll('.slider-row', { block: 'center' });
-    await human.sleep(300);
+    // Center the slider section in the viewport before this specific
+    // drag. The library's auto curve-aware viewport check only applies
+    // to element×element drags (where both endpoints shift together with
+    // the page scroll). This slider drag has a raw-`Point` `to` — the
+    // library defers to the caller in that case, since auto-scrolling
+    // would shift the slider element relative to the explicit coordinate
+    // and turn the horizontal drag diagonal. The explicit scroll here is
+    // the canonical pattern for the mixed-endpoint case.
+
     const thumbBox = await page.locator('#slider-thumb').boundingBox();
     const trackBox = await page.locator('.slider-track').boundingBox();
     if (thumbBox && trackBox) {

--- a/examples/primitives-demo.ts
+++ b/examples/primitives-demo.ts
@@ -644,7 +644,7 @@ async function main() {
     await page.setContent(DEMO_HTML);
     await installMouseHelper(context);
 
-    const human = await createHuman(page, { personality, seed: 'primitives-demo22' });
+    const human = await createHuman(page, { personality, seed: 'primitives-demo' });
     await human.sleep(800);
 
     // 1. Hover — cursor moves to the "?" icon, tooltip reveals via CSS.
@@ -671,15 +671,12 @@ async function main() {
     console.log('4. drag → card to slot, then slider thumb to point');
     await human.drag('#drag-card', '#slot-to');
     await human.sleep(900);
-    // Center the slider section in the viewport before this specific
-    // drag. The library's auto curve-aware viewport check only applies
-    // to element×element drags (where both endpoints shift together with
-    // the page scroll). This slider drag has a raw-`Point` `to` — the
-    // library defers to the caller in that case, since auto-scrolling
-    // would shift the slider element relative to the explicit coordinate
-    // and turn the horizontal drag diagonal. The explicit scroll here is
-    // the canonical pattern for the mixed-endpoint case.
-
+    // The slider drag is element → raw-`Point`. The library's per-endpoint
+    // auto-scroll will bring the slider into the viewport center if it's
+    // off-fold, and the raw `Point`'s y will shift with the scroll
+    // delta — preserving the "same height as the thumb" relationship the
+    // caller intended. No explicit pre-scroll needed; this is a regular
+    // canvas/SVG-style drag where the destination is a coordinate.
     const thumbBox = await page.locator('#slider-thumb').boundingBox();
     const trackBox = await page.locator('.slider-track').boundingBox();
     if (thumbBox && trackBox) {

--- a/packages/playwright/src/mouse/click.test.ts
+++ b/packages/playwright/src/mouse/click.test.ts
@@ -587,4 +587,106 @@ describe('human.click', () => {
       expect(lastMove[1]).toBe(500);
     });
   });
+
+  describe('drag: curve-aware viewport pre-scroll', () => {
+    // Default mock viewport: 1280×720. A long horizontal drag at y near
+    // the bottom edge produces a Bezier curve whose perpendicular extent
+    // pokes below the viewport — Chrome's native edge-scroll-during-drag
+    // would fire on a real page. The library pre-scrolls just enough to
+    // bring the worst-case curve bounding box back inside.
+
+    it('pre-scrolls when an element×element drag would extrude past the viewport edge', async () => {
+      // Two distinct endpoints near the viewport bottom (centers around
+      // y=615 in a 720-tall viewport): individually in view, but the curve
+      // from (90, 615) → (790, 615) at curvature 0.4 reaches ±280 px
+      // perpendicular → maxY ≈ 895, well past the 720 bottom edge.
+      let scrolled = false;
+      const makeLowLocator = (x: number): MockLocator => {
+        const lowBox: MockBoundingBox = { x, y: 600, width: 100, height: 30 };
+        const liftedBox: MockBoundingBox = { x, y: 200, width: 100, height: 30 };
+        return {
+          boundingBox: vi.fn(() => Promise.resolve(scrolled ? liftedBox : lowBox)),
+          click: vi.fn().mockResolvedValue(undefined),
+          scrollIntoViewIfNeeded: vi.fn().mockResolvedValue(undefined),
+        };
+      };
+      const fromLocator = makeLowLocator(40); // box [40, 600, 100, 30] → center (90, 615)
+      const toLocator = makeLowLocator(740); // box [740, 600, 100, 30] → center (790, 615)
+
+      const wheelCalls: Array<{ dx: number; dy: number }> = [];
+      const page = {
+        goto: vi.fn().mockResolvedValue(null),
+        locator: vi.fn(() => fromLocator), // unused; we pass Locators directly
+        evaluate: vi.fn().mockResolvedValue({ current: 0, viewport: 720, total: 2000 }),
+        mouse: {
+          move: vi.fn().mockResolvedValue(undefined),
+          click: vi.fn().mockResolvedValue(undefined),
+          wheel: vi.fn().mockImplementation((dx: number, dy: number) => {
+            wheelCalls.push({ dx, dy });
+            scrolled = true;
+            return Promise.resolve();
+          }),
+          down: vi.fn().mockResolvedValue(undefined),
+          up: vi.fn().mockResolvedValue(undefined),
+        },
+        viewportSize: () => ({ width: 1280, height: 720 }),
+      } as unknown as Page;
+
+      const human = await createHuman(page, {
+        speed: 'fast',
+        seed: 'curve-aware-drag',
+        personality: { extends: 'careful', mouse: { misclickProbability: 0 } },
+      });
+      // Pass Locators directly — page.locator() in mocks returns one
+      // shared instance so 'source' / 'target' selectors would collapse
+      // to the same box and the drag's effective distance would be ~0.
+      await human.drag(fromLocator as unknown as Locator, toLocator as unknown as Locator);
+
+      // Pre-scroll happened (wheel events were dispatched before the drag).
+      expect(wheelCalls.length).toBeGreaterThan(0);
+      // The page scrolled DOWN (positive dy) — moving elements UP in
+      // viewport space to give the curve room below.
+      const totalScroll = wheelCalls.reduce((sum, w) => sum + w.dy, 0);
+      expect(totalScroll).toBeGreaterThan(0);
+    });
+
+    it('does NOT pre-scroll when one endpoint is a raw Point', async () => {
+      // Raw-Point endpoints would shift relative to element endpoints
+      // under a page scroll, changing the drag's geometry. The library
+      // skips the curve-aware scroll in that case — the caller's
+      // coordinates are honored as-is.
+      const lowBox: MockBoundingBox = { x: 50, y: 600, width: 100, height: 30 };
+      const locator: MockLocator = {
+        boundingBox: vi.fn().mockResolvedValue(lowBox),
+        click: vi.fn().mockResolvedValue(undefined),
+        scrollIntoViewIfNeeded: vi.fn().mockResolvedValue(undefined),
+      };
+      const { page, mouseWheel } = makeMockPage(locator);
+      const human = await createHuman(page, {
+        speed: 'fast',
+        seed: 'curve-aware-raw-point',
+        personality: { extends: 'careful', mouse: { misclickProbability: 0 } },
+      });
+
+      // selector → raw Point. The library defers to the caller.
+      await human.drag('source', { x: 750, y: 615 });
+
+      expect(mouseWheel).not.toHaveBeenCalled();
+    });
+
+    it('does NOT pre-scroll when both endpoints are comfortably mid-viewport', async () => {
+      // Default box at (100, 200, 80, 30): center around y=215, well
+      // inside the 720-tall viewport with plenty of headroom above and
+      // below. No curve-aware scroll needed.
+      const { page, mouseWheel } = makeMockPage();
+      const human = await createHuman(page, {
+        speed: 'fast',
+        seed: 'no-curve-scroll',
+        personality: { extends: 'careful', mouse: { misclickProbability: 0 } },
+      });
+      await human.drag('source', 'target');
+
+      expect(mouseWheel).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/playwright/src/mouse/click.test.ts
+++ b/packages/playwright/src/mouse/click.test.ts
@@ -45,6 +45,12 @@ function makeMockPage(locatorOverride?: MockLocator): {
   const page = {
     goto: vi.fn().mockResolvedValue(null),
     locator: vi.fn(() => locator),
+    // Default `evaluate` returns 0 — enough to satisfy `readScrollY`'s
+    // `window.scrollY` read in tests that don't model scroll state. Tests
+    // that exercise `executeScroll` paths (which evaluates document
+    // geometry instead) construct their own page mock with a richer
+    // `evaluate` stub.
+    evaluate: vi.fn().mockResolvedValue(0),
     mouse: {
       move: mouseMove,
       click: mouseClick,
@@ -686,6 +692,83 @@ describe('human.click', () => {
       await human.drag('source', 'target');
 
       expect(mouseWheel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('drag: resolve-time raw-Point shift', () => {
+    // The slider case: caller drags an element thumb to a raw `Point`
+    // computed from the thumb's current y. When the library's auto-scroll
+    // pulls the off-viewport thumb into view, the raw Point must shift by
+    // the same delta so the drag's geometric relationship survives the
+    // scroll — otherwise the cursor walks to a now-stale viewport-y and
+    // triggers Chrome's edge-scroll-during-drag.
+
+    it('shifts a raw Point `to` by the resolve-time auto-scroll delta', async () => {
+      // Stateful mock: scrollY starts at 0, increments whenever wheel
+      // fires. The locator returns a box below the fold while scrollY is
+      // 0, then a centered box once any scroll has happened — modeling
+      // `readBoxWithAutoScroll`'s effect on a previously off-viewport
+      // element.
+      let scrollY = 0;
+      const offViewBox: MockBoundingBox = { x: 50, y: 900, width: 100, height: 30 };
+      const inViewBox: MockBoundingBox = { x: 50, y: 350, width: 100, height: 30 };
+      const locator: MockLocator = {
+        boundingBox: vi.fn(() => Promise.resolve(scrollY > 0 ? inViewBox : offViewBox)),
+        click: vi.fn().mockResolvedValue(undefined),
+        scrollIntoViewIfNeeded: vi.fn().mockResolvedValue(undefined),
+      };
+      const moveCalls: Array<{ x: number; y: number }> = [];
+      const page = {
+        goto: vi.fn().mockResolvedValue(null),
+        locator: vi.fn(() => locator),
+        // Dispatch by function source: `executeScroll`'s geometry read
+        // mentions `documentElement` (for `scrollHeight`); all other
+        // `evaluate` calls in this drag path just read `window.scrollY`.
+        evaluate: vi.fn((fn: () => unknown) => {
+          if (fn.toString().includes('documentElement')) {
+            return Promise.resolve({ current: scrollY, viewport: 720, total: 2000 });
+          }
+          return Promise.resolve(scrollY);
+        }),
+        mouse: {
+          move: vi.fn((x: number, y: number) => {
+            moveCalls.push({ x, y });
+            return Promise.resolve();
+          }),
+          click: vi.fn().mockResolvedValue(undefined),
+          wheel: vi.fn((_dx: number, dy: number) => {
+            scrollY += dy;
+            return Promise.resolve();
+          }),
+          down: vi.fn().mockResolvedValue(undefined),
+          up: vi.fn().mockResolvedValue(undefined),
+        },
+        viewportSize: () => ({ width: 1280, height: 720 }),
+      } as unknown as Page;
+
+      const human = await createHuman(page, {
+        speed: 'fast',
+        seed: 'resolve-time-shift',
+        personality: { extends: 'careful', mouse: { misclickProbability: 0 } },
+      });
+
+      // Caller-computed Point at the thumb's *pre-scroll* y — same shape
+      // as `human.drag('#slider-thumb', { x, y: thumb.y + thumb.height/2 })`
+      // in real code.
+      const originalTargetY = 915;
+      await human.drag('source', { x: 800, y: originalTargetY });
+
+      // Auto-scroll fired during the element resolve.
+      expect(scrollY).toBeGreaterThan(0);
+
+      // The final cursor position (last `mouse.move` before `mouse.up`)
+      // sits at `originalTargetY - scrollY`, not at the original Point.
+      // That's the resolve-time shift: the raw `to` followed the page
+      // scroll, keeping the drag horizontal relative to the now-centered
+      // thumb.
+      const finalMove = moveCalls.at(-1);
+      expect(finalMove).toBeDefined();
+      expect(finalMove?.y).toBe(originalTargetY - scrollY);
     });
   });
 });

--- a/packages/playwright/src/mouse/click.test.ts
+++ b/packages/playwright/src/mouse/click.test.ts
@@ -610,13 +610,15 @@ describe('human.click', () => {
           scrollIntoViewIfNeeded: vi.fn().mockResolvedValue(undefined),
         };
       };
+      // Selector-keyed dispatch lets us pass plain selector strings to
+      // `human.drag` without any `as unknown as Locator` cast.
       const fromLocator = makeLowLocator(40); // box [40, 600, 100, 30] → center (90, 615)
       const toLocator = makeLowLocator(740); // box [740, 600, 100, 30] → center (790, 615)
 
       const wheelCalls: Array<{ dx: number; dy: number }> = [];
       const page = {
         goto: vi.fn().mockResolvedValue(null),
-        locator: vi.fn(() => fromLocator), // unused; we pass Locators directly
+        locator: vi.fn((selector: string) => (selector === 'source' ? fromLocator : toLocator)),
         evaluate: vi.fn().mockResolvedValue({ current: 0, viewport: 720, total: 2000 }),
         mouse: {
           move: vi.fn().mockResolvedValue(undefined),
@@ -637,10 +639,7 @@ describe('human.click', () => {
         seed: 'curve-aware-drag',
         personality: { extends: 'careful', mouse: { misclickProbability: 0 } },
       });
-      // Pass Locators directly — page.locator() in mocks returns one
-      // shared instance so 'source' / 'target' selectors would collapse
-      // to the same box and the drag's effective distance would be ~0.
-      await human.drag(fromLocator as unknown as Locator, toLocator as unknown as Locator);
+      await human.drag('source', 'target');
 
       // Pre-scroll happened (wheel events were dispatched before the drag).
       expect(wheelCalls.length).toBeGreaterThan(0);

--- a/packages/playwright/src/mouse/index.ts
+++ b/packages/playwright/src/mouse/index.ts
@@ -174,6 +174,14 @@ export async function executeHover(
 /**
  * Executes a humanized drag from one location to another.
  *
+ *  0. **Curve-aware viewport check** (element×element drags only): the
+ *     drag's main walk uses a Bezier curve whose perpendicular extent
+ *     can reach `distance × curvature`. If that worst-case path would
+ *     extrude past a viewport edge with the mouse button held, Chrome
+ *     engages native edge-scroll-during-drag and walks the page wildly.
+ *     We pre-scroll just enough plus a small margin so the worst-case
+ *     curve fits. Skipped for raw-`Point` endpoints because scrolling
+ *     would shift the element relative to the caller's explicit point.
  *  1. Optionally near-miss the grab — with probability
  *     `personality.mouse.misclickProbability`, the cursor first walks to a
  *     point just outside the `from` target (or near it, for raw-Point
@@ -212,8 +220,10 @@ export async function executeDrag(
   // For both endpoints we also capture the box (if any) so the misclick
   // beats below can pick a near-miss "outside the box" for element-bound
   // targets, or "around the point" for raw-coordinate targets (canvas/SVG).
-  const { point: fromPoint, box: fromBox } = await resolveTargetPointAndBox(from, ctx, 'drag');
-  const { point: toPoint, box: toBox } = await resolveTargetPointAndBox(to, ctx, 'drag');
+  // `let` because the curve-aware viewport check below may scroll the page,
+  // shifting element-bound endpoints in viewport coordinates.
+  let { point: fromPoint, box: fromBox } = await resolveTargetPointAndBox(from, ctx, 'drag');
+  let { point: toPoint, box: toBox } = await resolveTargetPointAndBox(to, ctx, 'drag');
 
   if (ctx.speed === 'instant') {
     await ctx.page.mouse.move(fromPoint.x, fromPoint.y);
@@ -222,6 +232,41 @@ export async function executeDrag(
     await ctx.page.mouse.up();
     ctx.setMousePosition(toPoint);
     return { from: fromPoint, to: toPoint };
+  }
+
+  // 0. Curve-aware viewport headroom. Both endpoints might be individually
+  // in-viewport (so per-endpoint auto-scroll didn't fire), yet the Bezier
+  // curve between them — control points perpendicular-offset by up to
+  // `distance × curvature` — can extrude outside the viewport while the
+  // mouse button is held. When that happens Chrome engages its native
+  // edge-scroll-during-drag behavior and walks the page wildly.
+  //
+  // Pre-scroll just enough plus a small margin so the worst-case curve
+  // bounding box fits. Only applies when both endpoints are element-bound,
+  // so both shift together with the page scroll and the drag's relative
+  // geometry is preserved. For raw `Point` endpoints, scrolling would
+  // shift the element relative to the caller's explicit coordinate — we
+  // leave that case to the caller (see `examples/primitives-demo.ts` for
+  // the explicit-scroll pattern).
+  if (fromBox && toBox) {
+    const scrollDelta = computeCurveScrollDelta(
+      fromPoint,
+      toPoint,
+      ctx.page.viewportSize(),
+      ctx.personality.mouse.curvature,
+    );
+    if (scrollDelta !== 0) {
+      await executeScroll({ by: scrollDelta }, ctx, {});
+      // Both endpoints moved by `scrollDelta` in viewport-y; re-resolve to
+      // pick up the new positions. Raw Points are excluded by the guard
+      // above, so re-resolving is safe (won't shift caller coordinates).
+      const refreshedFrom = await resolveTargetPointAndBox(from, ctx, 'drag');
+      fromPoint = refreshedFrom.point;
+      fromBox = refreshedFrom.box;
+      const refreshedTo = await resolveTargetPointAndBox(to, ctx, 'drag');
+      toPoint = refreshedTo.point;
+      toBox = refreshedTo.box;
+    }
   }
 
   // 1. Maybe near-miss the grab. Same shape as click's misclick beat;
@@ -493,6 +538,60 @@ function isBoxCenterInViewport(
   const cx = box.x + box.width / 2;
   const cy = box.y + box.height / 2;
   return cx >= 0 && cx <= viewport.width && cy >= 0 && cy <= viewport.height;
+}
+
+/**
+ * Safety margin (in CSS pixels) between the predicted drag-curve bounds
+ * and the viewport edge. Small enough that the pre-scroll stays close to
+ * "the minimum needed," large enough that micro-jitter or rounding doesn't
+ * still push the curve past the edge.
+ */
+const CURVE_VIEWPORT_MARGIN = 20;
+
+/**
+ * Computes how far to scroll the page (positive = down, negative = up) so
+ * the Bezier curve a drag would walk from `from` to `to` fits entirely
+ * inside the viewport. Returns `0` if no scroll is needed.
+ *
+ * The Bezier path (see {@link import('@humanjs/core').bezierPath}) places
+ * two control points perpendicular-offset by up to `distance × curvature`
+ * in either direction. The curve itself stays within that perpendicular
+ * band, so a conservative worst-case bounding box is the from→to line
+ * inflated by `distance × curvature` on each side.
+ *
+ * Scroll just enough to bring whichever side overflows the most into the
+ * viewport, plus a small {@link CURVE_VIEWPORT_MARGIN} so the curve
+ * doesn't graze the edge. We only handle vertical overflow — pages
+ * almost always scroll vertically and the horizontal axis rarely has
+ * room to gain headroom from.
+ *
+ * If both top and bottom overflow (the drag's worst-case bounding box is
+ * taller than the viewport), pick the larger overflow and live with the
+ * partial fix — there's no scroll position that fully contains a curve
+ * bigger than the viewport.
+ */
+function computeCurveScrollDelta(
+  from: Point,
+  to: Point,
+  viewport: { readonly width: number; readonly height: number } | null,
+  curvature: number,
+): number {
+  if (!viewport) return 0;
+
+  const distance = Math.hypot(to.x - from.x, to.y - from.y);
+  const perpendicularExtent = distance * curvature;
+
+  const minY = Math.min(from.y, to.y) - perpendicularExtent;
+  const maxY = Math.max(from.y, to.y) + perpendicularExtent;
+
+  const topOverflow = -minY + CURVE_VIEWPORT_MARGIN;
+  const bottomOverflow = maxY + CURVE_VIEWPORT_MARGIN - viewport.height;
+
+  // Positive return → scroll page DOWN (elements move UP in viewport).
+  // Negative return → scroll page UP (elements move DOWN in viewport).
+  if (bottomOverflow > 0 && bottomOverflow >= topOverflow) return bottomOverflow;
+  if (topOverflow > 0) return -topOverflow;
+  return 0;
 }
 
 /** Type guard for raw `Point` targets — distinguishes them from Locator/string. */

--- a/packages/playwright/src/mouse/index.ts
+++ b/packages/playwright/src/mouse/index.ts
@@ -217,13 +217,25 @@ export async function executeDrag(
   // the right shape for cross-viewport drags: a real user scrolls to grab,
   // then scrolls again to drop, rather than dragging through invisible space.
   //
-  // For both endpoints we also capture the box (if any) so the misclick
-  // beats below can pick a near-miss "outside the box" for element-bound
-  // targets, or "around the point" for raw-coordinate targets (canvas/SVG).
-  // `let` because the curve-aware viewport check below may scroll the page,
-  // shifting element-bound endpoints in viewport coordinates.
+  // We bracket the resolves with `scrollY` reads to detect any auto-scroll
+  // that happened for an element-bound endpoint, then shift raw `Point`
+  // endpoints by the same delta. That preserves the *visual relationship*
+  // a raw Point has to the view at the time of call — callers typically
+  // compute raw Points from element positions they see right now, so when
+  // the page scrolls during resolution, the Point should follow. Otherwise
+  // a horizontal slider drag ('#thumb' → { x, y }) silently becomes
+  // diagonal as soon as the thumb auto-scrolls and the raw Point stays put.
+  //
+  // `let` because both endpoints may shift during the curve-aware check
+  // below.
+  const scrollYBeforeResolve = await readScrollY(ctx.page);
   let { point: fromPoint, box: fromBox } = await resolveTargetPointAndBox(from, ctx, 'drag');
   let { point: toPoint, box: toBox } = await resolveTargetPointAndBox(to, ctx, 'drag');
+  const resolveScrollDelta = (await readScrollY(ctx.page)) - scrollYBeforeResolve;
+  if (resolveScrollDelta !== 0) {
+    if (isPoint(from)) fromPoint = { x: fromPoint.x, y: fromPoint.y - resolveScrollDelta };
+    if (isPoint(to)) toPoint = { x: toPoint.x, y: toPoint.y - resolveScrollDelta };
+  }
 
   if (ctx.speed === 'instant') {
     await ctx.page.mouse.move(fromPoint.x, fromPoint.y);
@@ -242,12 +254,12 @@ export async function executeDrag(
   // edge-scroll-during-drag behavior and walks the page wildly.
   //
   // Pre-scroll just enough plus a small margin so the worst-case curve
-  // bounding box fits. Only applies when both endpoints are element-bound,
-  // so both shift together with the page scroll and the drag's relative
-  // geometry is preserved. For raw `Point` endpoints, scrolling would
-  // shift the element relative to the caller's explicit coordinate — we
-  // leave that case to the caller (see `examples/primitives-demo.ts` for
-  // the explicit-scroll pattern).
+  // fits. Only applies when both endpoints are element-bound: a page
+  // scroll moves both together and preserves their relative geometry.
+  // For mixed endpoints, the resolve-time scroll above already shifted
+  // any raw Point by the auto-scroll delta — if a curve still wouldn't
+  // fit after that, scrolling more would chase its own tail (each scroll
+  // shifts the raw Point but lengthens the drag), so we don't.
   if (fromBox && toBox) {
     const scrollDelta = computeCurveScrollDelta(
       fromPoint,
@@ -257,9 +269,6 @@ export async function executeDrag(
     );
     if (scrollDelta !== 0) {
       await executeScroll({ by: scrollDelta }, ctx, {});
-      // Both endpoints moved by `scrollDelta` in viewport-y; re-resolve to
-      // pick up the new positions. Raw Points are excluded by the guard
-      // above, so re-resolving is safe (won't shift caller coordinates).
       const refreshedFrom = await resolveTargetPointAndBox(from, ctx, 'drag');
       fromPoint = refreshedFrom.point;
       fromBox = refreshedFrom.box;
@@ -570,6 +579,20 @@ const CURVE_VIEWPORT_MARGIN = 20;
  * partial fix — there's no scroll position that fully contains a curve
  * bigger than the viewport.
  */
+/**
+ * Reads the page's current vertical scroll position. Used in `executeDrag`
+ * to detect auto-scroll that happened during endpoint resolution and
+ * mirror it onto raw `Point` endpoints (preserving the drag's geometry).
+ *
+ * Defensive against test mocks that don't implement `page.evaluate`
+ * (returns `0`, matching "no scroll happened"). Real Playwright `Page`
+ * always has `evaluate`.
+ */
+async function readScrollY(page: Page): Promise<number> {
+  if (typeof page.evaluate !== 'function') return 0;
+  return page.evaluate(() => window.scrollY);
+}
+
 function computeCurveScrollDelta(
   from: Point,
   to: Point,

--- a/packages/playwright/src/mouse/index.ts
+++ b/packages/playwright/src/mouse/index.ts
@@ -550,6 +550,20 @@ function isBoxCenterInViewport(
 }
 
 /**
+ * Reads the page's current vertical scroll position. Used in `executeDrag`
+ * to detect auto-scroll that happened during endpoint resolution and
+ * mirror it onto raw `Point` endpoints (preserving the drag's geometry).
+ *
+ * Defensive against test mocks that don't implement `page.evaluate`
+ * (returns `0`, matching "no scroll happened"). Real Playwright `Page`
+ * always has `evaluate`.
+ */
+async function readScrollY(page: Page): Promise<number> {
+  if (typeof page.evaluate !== 'function') return 0;
+  return page.evaluate(() => window.scrollY);
+}
+
+/**
  * Safety margin (in CSS pixels) between the predicted drag-curve bounds
  * and the viewport edge. Small enough that the pre-scroll stays close to
  * "the minimum needed," large enough that micro-jitter or rounding doesn't
@@ -579,20 +593,6 @@ const CURVE_VIEWPORT_MARGIN = 20;
  * partial fix — there's no scroll position that fully contains a curve
  * bigger than the viewport.
  */
-/**
- * Reads the page's current vertical scroll position. Used in `executeDrag`
- * to detect auto-scroll that happened during endpoint resolution and
- * mirror it onto raw `Point` endpoints (preserving the drag's geometry).
- *
- * Defensive against test mocks that don't implement `page.evaluate`
- * (returns `0`, matching "no scroll happened"). Real Playwright `Page`
- * always has `evaluate`.
- */
-async function readScrollY(page: Page): Promise<number> {
-  if (typeof page.evaluate !== 'function') return 0;
-  return page.evaluate(() => window.scrollY);
-}
-
 function computeCurveScrollDelta(
   from: Point,
   to: Point,


### PR DESCRIPTION
## Summary

- **Element×element drags pre-scroll when the Bezier curve would extrude past the viewport edge** — Chrome's native edge-scroll-during-drag was walking the page hundreds of px when both endpoints sat individually in-view but the curve between them poked out.
- **Mixed element→raw-Point drags now stay geometrically consistent across auto-scroll** — when the element auto-scrolls into view during resolve, the raw `Point` shifts by the same delta so the drag's geometry (e.g. "drop at the same height as the thumb") survives. Fixes the slider case where a horizontal drag silently went diagonal.
- **Demo workaround retired** — `examples/primitives-demo.ts` no longer needs an explicit `human.scroll('.slider-row', { block: 'center' })` before the slider drag. The library handles it.

Full behavior table and determinism notes in [`.changeset/drag-curve-aware-viewport.md`](./.changeset/drag-curve-aware-viewport.md).

## How it composes

| Drag shape | Behavior |
|---|---|
| element → element | Resolve-time auto-scroll if either endpoint is off-viewport; curve-aware pre-scroll if the curve still wouldn't fit |
| element → raw Point | Resolve-time auto-scroll for the element; raw Point shifts by the scroll delta to track the page |
| raw Point → element | Symmetric |
| raw Point → raw Point | No auto-scroll (caller owns both coordinates); curve-aware skipped (any scroll would just chase its own tail) |

## Empirical impact

Primitives demo at viewport 700 (a worst-case repro):

- Before: slider drag scrolled the page from `y=0` to `y=2072` (mid-drag runaway).
- After: scrolls from `y=0` to `y=464` (just the auto-scroll to center the off-fold thumb, then the drag stays put).

## Test plan 

- [x] `pnpm --filter @humanjs/playwright test` — 186/186 pass (+1 for the new resolve-time shift unit test, +3 for the curve-aware viewport pre-scroll cases)
- [x] `pnpm -w typecheck` — clean
- [x] `pnpm demo:primitives` at viewport 700 and 900 — slider drag completes without page runaway
- [x] `pnpm demo:primitives PERSONALITY=distracted` — wider scatter still stays within viewport
- [x] Lefthook (biome + commitlint) clean on all 3 commits