### PR TITLE
feat(recorder): persistent profile + CDP attach for record()

### DIFF
--- a/.changeset/recorder-browser-modes.md
+++ b/.changeset/recorder-browser-modes.md
@@ -1,0 +1,18 @@
+---
+"@humanjs/recorder": minor
+---
+
+`record()` can now record in a persistent profile or attach to a browser you already launched — completing the browser-mode story alongside `@humanjs/mcp` (env/tools) and `@humanjs/playwright` (bring-your-own-page).
+
+- **`userDataDir`** — record in a persistent profile so logins/cookies survive across runs (sign in once in a headed run, reuse it). Uses `launchPersistentContext`; `headless` / `launch` / `channel` / `viewport` still apply.
+- **`cdpUrl`** — attach to a running browser over CDP (start it with `--remote-debugging-port`) and record its existing context — real logins, tabs, extensions. HumanJS **never closes** a browser it attached to; it only borrows it. Takes precedence over `userDataDir`.
+- **`channel`** — launch an installed browser (`'chrome'`, `'msedge'`) instead of bundled Chromium (default + persistent modes). A channel alone does NOT reuse your profile — pair it with `userDataDir` or `cdpUrl` for logins.
+
+```ts
+// Stay signed in across runs
+await record({ output: 'dashboard.mp4', userDataDir: './.humanjs-profile' }, async (human) => {
+  await human.goto('https://app.example.com/dashboard');
+});
+```
+
+Default behavior is unchanged — omit the new options and you get a fresh ephemeral browser as before.

--- a/packages/recorder/README.md
+++ b/packages/recorder/README.md
@@ -87,6 +87,9 @@ await record(
     viewport: { width: 1920, height: 1080 },
     headless: false,             // defaults false so you can watch the recording
     cursor: true,                // auto-install visible cursor overlay (default true)
+    userDataDir: './.profile',   // persistent profile — stay logged in across runs
+    cdpUrl: 'http://localhost:9222', // OR attach to a browser you launched (precedence)
+    channel: 'chrome',           // launch installed Chrome instead of bundled Chromium
     launch: { args: ['--no-sandbox'] },  // forwarded to chromium.launch()
     context: { locale: 'en-US' },         // forwarded to browser.newContext()
   },
@@ -101,6 +104,29 @@ await record(
 ```
 
 **No-video mode**: omit `output` entirely (or call `record(fn)` with no options). No screenshot polling, no temp files, no encoding overhead. The structured timeline is still captured.
+
+## Recording a logged-in flow
+
+By default each `record()` call uses a fresh, signed-out browser. Two ways to record something behind a login:
+
+```ts
+// Persistent profile — sign in once (in a headed run), reuse it forever
+await record({ output: 'dashboard.mp4', userDataDir: './.humanjs-profile' }, async (human) => {
+  await human.goto('https://app.example.com/dashboard');
+});
+
+// Or attach to a browser you already launched (real logins/tabs)
+//   chrome --remote-debugging-port=9222 --user-data-dir="$HOME/.humanjs-chrome"
+await record({ output: 'flow.mp4', cdpUrl: 'http://localhost:9222' }, async (human) => {
+  await human.goto('https://app.example.com/dashboard');
+});
+```
+
+- **`userDataDir`** keeps cookies/logins across runs (a dedicated profile, starts empty).
+- **`cdpUrl`** records a browser you launched yourself — its existing session. HumanJS **never closes** a browser it attached to; it only borrows it. Takes precedence over `userDataDir`.
+- **`channel`** (`'chrome'` / `'msedge'`) swaps the binary but, on its own, still uses a fresh profile — pair it with `userDataDir` or `cdpUrl` for real logins.
+
+> You can't attach to your everyday Chrome — it only exposes a CDP port when launched with `--remote-debugging-port`, and Chrome refuses that on the default profile. Use a dedicated `--user-data-dir` (you sign in once there), or `userDataDir` to let HumanJS manage one.
 
 ## Quality presets
 

--- a/packages/recorder/README.md
+++ b/packages/recorder/README.md
@@ -84,7 +84,7 @@ await record(
     url: 'https://example.com',  // optional — navigate before the callback
     personality: 'careful',      // any PersonalityConfig
     seed: 'session-42',          // deterministic when set
-    viewport: { width: 1920, height: 1080 },
+    viewport: { width: 1920, height: 1080 }, // ephemeral/persistent only — CDP uses the real window
     headless: false,             // defaults false so you can watch the recording
     cursor: true,                // auto-install visible cursor overlay (default true)
     userDataDir: './.profile',   // persistent profile — stay logged in across runs
@@ -127,6 +127,8 @@ await record({ output: 'flow.mp4', cdpUrl: 'http://localhost:9222' }, async (hum
 - **`channel`** (`'chrome'` / `'msedge'`) swaps the binary but, on its own, still uses a fresh profile — pair it with `userDataDir` or `cdpUrl` for real logins.
 
 > You can't attach to your everyday Chrome — it only exposes a CDP port when launched with `--remote-debugging-port`, and Chrome refuses that on the default profile. Use a dedicated `--user-data-dir` (you sign in once there), or `userDataDir` to let HumanJS manage one.
+
+> **Recording resolution in CDP mode:** the attached browser's real window size wins — `viewport` is intentionally not applied. HumanJS is borrowing a window it doesn't own, and forcing a size would only *emulate* one (letterboxing the capture so the frames don't match what you see). Need a specific resolution? Launch the browser with `--window-size=1920,1080` to size the real window, or use the default/persistent modes where HumanJS owns the window and `viewport` applies directly.
 
 ## Quality presets
 

--- a/packages/recorder/src/record/index.ts
+++ b/packages/recorder/src/record/index.ts
@@ -1,5 +1,6 @@
 import { extname } from 'node:path';
 import {
+  type BrowserContext,
   type BrowserContextOptions,
   type CreateHumanOptions,
   chromium,
@@ -63,6 +64,31 @@ export interface RecordOptions extends CreateHumanOptions {
   /** Forwarded to `browser.newContext()` (alongside `viewport`). */
   readonly context?: BrowserContextOptions;
   /**
+   * Record in a **persistent profile** at this directory so logins and
+   * cookies survive across runs — sign in once (in a headed run), and later
+   * recordings start authenticated. Uses `launchPersistentContext` under the
+   * hood (a single context); `headless`, `launch`, `channel`, and `viewport`
+   * still apply. Starts empty the first time.
+   */
+  readonly userDataDir?: string;
+  /**
+   * Record by **attaching to a browser you already launched** over CDP (e.g.
+   * `"http://localhost:9222"`). Reuses that browser's existing context — your
+   * real logins, tabs, extensions. Start the browser yourself with
+   * `--remote-debugging-port`. HumanJS never closes a browser it attached to;
+   * it only borrows it. Takes precedence over `userDataDir`; `launch` /
+   * `headless` / `channel` / `viewport` are ignored in this mode.
+   */
+  readonly cdpUrl?: string;
+  /**
+   * Playwright browser channel — e.g. `'chrome'`, `'msedge'`. Launches that
+   * installed browser's binary instead of bundled Chromium (applies to the
+   * default and `userDataDir` modes). NOTE: a channel alone does NOT reuse
+   * your existing profile — pair it with `userDataDir` (persistent) or
+   * `cdpUrl` (attach) for real logins.
+   */
+  readonly channel?: string;
+  /**
    * Install the HumanJS visible cursor overlay so recorded videos show
    * mouse motion — Playwright's synthetic mouse doesn't render a cursor
    * by itself, so without this the recording would look like text and
@@ -85,9 +111,14 @@ export interface RecordOptions extends CreateHumanOptions {
 export type RecordCallback = (human: Human, page: Page) => Promise<void>;
 
 /**
- * One-call session recording. Launches a browser, opens a page, creates a
- * humanized session, runs `fn`, and returns a {@link Recording} you can
- * export to video, JSON timeline, or read in-memory.
+ * One-call session recording. Launches (or attaches to) a browser, opens a
+ * page, creates a humanized session, runs `fn`, and returns a
+ * {@link Recording} you can export to video, JSON timeline, or read in-memory.
+ *
+ * Browser source (default → ephemeral fresh profile):
+ * - `userDataDir` — a persistent profile that keeps logins across runs.
+ * - `cdpUrl` — attach to a browser you launched yourself (real logins/tabs);
+ *   never closed on finish, only released.
  *
  * If `options.output` is set, the output file is written to that path before
  * `record()` resolves — extension dispatches to `toVideo` (`.mp4` / `.webm`)
@@ -108,11 +139,10 @@ export type RecordCallback = (human: Human, page: Page) => Promise<void>;
  *
  * @example
  * ```ts
- * // Timeline only, no video overhead
- * const rec = await record(async (human) => {
- *   await human.click('#login');
+ * // Stay signed in across runs (persistent profile)
+ * await record({ output: 'dashboard.mp4', userDataDir: './.humanjs-profile' }, async (human) => {
+ *   await human.goto('https://app.example.com/dashboard');
  * });
- * await rec.toTimeline('demo.json');
  * ```
  *
  * For multi-page flows or recording a slice of a larger session, use
@@ -136,62 +166,130 @@ export async function record(
     viewport,
     headless,
     launch,
-    context,
+    context: contextOptions,
+    userDataDir,
+    cdpUrl,
+    channel,
     cursor,
     ...createHumanOptions
   } = options;
 
   const resolvedQuality: RecordingQuality = quality ?? 'high';
   const browserPreset = QUALITY_BROWSER_PRESETS[resolvedQuality];
-  const resolvedViewport = viewport ?? context?.viewport ?? browserPreset.viewport;
+  const resolvedViewport = viewport ?? contextOptions?.viewport ?? browserPreset.viewport;
   const wantsCapture = output !== undefined;
 
-  const browser = await chromium.launch({
-    ...launch,
+  const { page, dispose } = await acquireRecordingContext({
+    cdpUrl,
+    userDataDir,
+    channel,
     headless: headless ?? false,
+    viewport: resolvedViewport,
+    launch,
+    context: contextOptions,
+    cursor,
   });
+
   try {
-    const browserContext = await browser.newContext({
-      ...context,
-      viewport: resolvedViewport,
-    });
-    try {
-      // Install the visible-cursor overlay before any page is created so
-      // the addInitScript runs on the initial page render — and on any
-      // page.setContent() inside the callback too.
-      if (cursor !== false) {
-        const cursorOptions = typeof cursor === 'object' ? cursor : undefined;
-        await installMouseHelper(browserContext, cursorOptions);
+    if (url) await page.goto(url);
+
+    const human = await createHuman(page, createHumanOptions);
+
+    // Capture runs only when the caller asked for an output file — saves
+    // the screenshot + disk-write overhead for timeline-only recordings.
+    const recording = await human.record({ video: wantsCapture, quality: resolvedQuality }, () =>
+      fn(human, page),
+    );
+
+    if (wantsCapture && output) {
+      // Dispatch by extension: .gif goes through the GIF exporter (which
+      // ignores `quality` — GIF doesn't have a CRF concept), everything
+      // else flows into the mp4/webm encoder with the chosen preset.
+      const ext = extname(output).toLowerCase();
+      if (ext === '.gif') {
+        await recording.toGif(output);
+      } else {
+        await recording.toVideo(output, { quality: resolvedQuality });
       }
-
-      const page = await browserContext.newPage();
-      if (url) await page.goto(url);
-
-      const human = await createHuman(page, createHumanOptions);
-
-      // Capture runs only when the caller asked for an output file — saves
-      // the screenshot + disk-write overhead for timeline-only recordings.
-      const recording = await human.record({ video: wantsCapture, quality: resolvedQuality }, () =>
-        fn(human, page),
-      );
-
-      if (wantsCapture && output) {
-        // Dispatch by extension: .gif goes through the GIF exporter (which
-        // ignores `quality` — GIF doesn't have a CRF concept), everything
-        // else flows into the mp4/webm encoder with the chosen preset.
-        const ext = extname(output).toLowerCase();
-        if (ext === '.gif') {
-          await recording.toGif(output);
-        } else {
-          await recording.toVideo(output, { quality: resolvedQuality });
-        }
-      }
-
-      return recording;
-    } finally {
-      await browserContext.close().catch(() => undefined);
     }
+
+    return recording;
   } finally {
-    await browser.close();
+    await dispose();
   }
+}
+
+/** Internal options for {@link acquireRecordingContext}. */
+interface AcquireOptions {
+  readonly cdpUrl?: string;
+  readonly userDataDir?: string;
+  readonly channel?: string;
+  readonly headless: boolean;
+  readonly viewport: { readonly width: number; readonly height: number };
+  readonly launch?: LaunchOptions;
+  readonly context?: BrowserContextOptions;
+  readonly cursor?: boolean | InstallMouseHelperOptions;
+}
+
+/**
+ * Resolves the browser source — CDP attach > persistent profile > ephemeral
+ * — and returns the page to drive plus a `dispose` that tears down only what
+ * we created. A CDP-attached browser is borrowed: `dispose` leaves it (and
+ * its context) untouched so we never close the caller's real browser.
+ */
+async function acquireRecordingContext(
+  opts: AcquireOptions,
+): Promise<{ page: Page; dispose: () => Promise<void> }> {
+  const cursorOptions = typeof opts.cursor === 'object' ? opts.cursor : undefined;
+  const installCursor = async (ctx: BrowserContext): Promise<void> => {
+    if (opts.cursor !== false) await installMouseHelper(ctx, cursorOptions);
+  };
+
+  // Attach to a browser the caller launched. Reuse its existing context so we
+  // record their real session; only make a fresh one if there's none. Never
+  // close it on dispose — it's borrowed.
+  if (opts.cdpUrl) {
+    const browser = await chromium.connectOverCDP(opts.cdpUrl);
+    const context = browser.contexts()[0] ?? (await browser.newContext({ ...opts.context }));
+    await installCursor(context);
+    const page = context.pages()[0] ?? (await context.newPage());
+    return { page, dispose: async () => undefined };
+  }
+
+  // Persistent profile — the context owns its browser, so closing it on
+  // dispose tears everything down.
+  if (opts.userDataDir) {
+    const context = await chromium.launchPersistentContext(opts.userDataDir, {
+      ...opts.launch,
+      ...opts.context,
+      channel: opts.channel ?? opts.launch?.channel,
+      headless: opts.headless,
+      viewport: opts.viewport,
+    });
+    await installCursor(context);
+    const page = context.pages()[0] ?? (await context.newPage());
+    return {
+      page,
+      dispose: async () => {
+        await context.close().catch(() => undefined);
+      },
+    };
+  }
+
+  // Ephemeral (default) — a fresh throwaway browser + context.
+  const browser = await chromium.launch({
+    ...opts.launch,
+    channel: opts.channel ?? opts.launch?.channel,
+    headless: opts.headless,
+  });
+  const context = await browser.newContext({ ...opts.context, viewport: opts.viewport });
+  await installCursor(context);
+  const page = await context.newPage();
+  return {
+    page,
+    dispose: async () => {
+      await context.close().catch(() => undefined);
+      await browser.close().catch(() => undefined);
+    },
+  };
 }

--- a/packages/recorder/src/record/index.ts
+++ b/packages/recorder/src/record/index.ts
@@ -55,7 +55,11 @@ export interface RecordOptions extends CreateHumanOptions {
   readonly quality?: RecordingQuality;
   /** Optional URL to navigate to before the callback runs. */
   readonly url?: string;
-  /** Viewport dimensions. Overrides the quality preset's viewport. */
+  /**
+   * Viewport dimensions. Overrides the quality preset's viewport. Applies to
+   * the default and persistent (`userDataDir`) modes; ignored when attaching
+   * over `cdpUrl`, where the real browser window's size wins (see `cdpUrl`).
+   */
   readonly viewport?: { readonly width: number; readonly height: number };
   /** Run headless. Defaults to `false` so users can watch the recording happen. */
   readonly headless?: boolean;
@@ -76,8 +80,13 @@ export interface RecordOptions extends CreateHumanOptions {
    * `"http://localhost:9222"`). Reuses that browser's existing context — your
    * real logins, tabs, extensions. Start the browser yourself with
    * `--remote-debugging-port`. HumanJS never closes a browser it attached to;
-   * it only borrows it. Takes precedence over `userDataDir`; `launch` /
-   * `headless` / `channel` / `viewport` are ignored in this mode.
+   * it only borrows it. Takes precedence over `userDataDir`.
+   *
+   * `launch` / `headless` / `channel` / `viewport` don't apply here — you're
+   * borrowing a window HumanJS doesn't own, so the browser's real window size
+   * wins. Forcing a `viewport` would only *emulate* one and letterbox the
+   * capture. For a fixed recording resolution, launch the browser yourself
+   * with `--window-size=1920,1080`, or use the default / persistent modes.
    */
   readonly cdpUrl?: string;
   /**

--- a/packages/recorder/src/record/record.test.ts
+++ b/packages/recorder/src/record/record.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Fakes + mock fns, hoisted so the vi.mock factory below can use them.
+const m = vi.hoisted(() => {
+  const fakePage = { goto: vi.fn() };
+  const fakeContext = { newPage: vi.fn(), pages: vi.fn(), close: vi.fn() };
+  const fakeBrowser = { newContext: vi.fn(), contexts: vi.fn(), close: vi.fn() };
+  const fakeRecording = { toVideo: vi.fn(), toGif: vi.fn(), toTimeline: vi.fn() };
+  const fakeHuman = { record: vi.fn() };
+  return {
+    fakePage,
+    fakeContext,
+    fakeBrowser,
+    fakeRecording,
+    fakeHuman,
+    launch: vi.fn(),
+    launchPersistentContext: vi.fn(),
+    connectOverCDP: vi.fn(),
+    createHuman: vi.fn(),
+    installMouseHelper: vi.fn(),
+  };
+});
+
+vi.mock('@humanjs/playwright', () => ({
+  chromium: {
+    launch: m.launch,
+    launchPersistentContext: m.launchPersistentContext,
+    connectOverCDP: m.connectOverCDP,
+  },
+  createHuman: m.createHuman,
+  installMouseHelper: m.installMouseHelper,
+}));
+
+import { record } from './index';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  m.fakePage.goto.mockResolvedValue(undefined);
+  m.fakeContext.newPage.mockResolvedValue(m.fakePage);
+  m.fakeContext.pages.mockReturnValue([m.fakePage]);
+  m.fakeContext.close.mockResolvedValue(undefined);
+  m.fakeBrowser.newContext.mockResolvedValue(m.fakeContext);
+  m.fakeBrowser.contexts.mockReturnValue([m.fakeContext]);
+  m.fakeBrowser.close.mockResolvedValue(undefined);
+  m.launch.mockResolvedValue(m.fakeBrowser);
+  m.launchPersistentContext.mockResolvedValue(m.fakeContext);
+  m.connectOverCDP.mockResolvedValue(m.fakeBrowser);
+  m.installMouseHelper.mockResolvedValue(undefined);
+  // human.record runs the callback (so the user's fn is exercised) and
+  // resolves with the fake Recording.
+  m.fakeHuman.record.mockImplementation(async (_opts: unknown, cb: () => Promise<void>) => {
+    await cb();
+    return m.fakeRecording;
+  });
+  m.createHuman.mockResolvedValue(m.fakeHuman);
+});
+
+describe('record — ephemeral (default)', () => {
+  it('launches a fresh browser + context and closes both on finish', async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    const rec = await record(fn);
+    expect(rec).toBe(m.fakeRecording);
+    expect(fn).toHaveBeenCalledWith(m.fakeHuman, m.fakePage);
+    expect(m.launch).toHaveBeenCalledTimes(1);
+    expect(m.fakeBrowser.newContext).toHaveBeenCalledTimes(1);
+    expect(m.installMouseHelper).toHaveBeenCalledWith(m.fakeContext, undefined);
+    expect(m.fakeContext.close).toHaveBeenCalled();
+    expect(m.fakeBrowser.close).toHaveBeenCalled();
+    expect(m.launchPersistentContext).not.toHaveBeenCalled();
+    expect(m.connectOverCDP).not.toHaveBeenCalled();
+  });
+
+  it('forwards the channel to launch', async () => {
+    await record({ channel: 'chrome' }, vi.fn().mockResolvedValue(undefined));
+    expect(m.launch).toHaveBeenCalledWith(expect.objectContaining({ channel: 'chrome' }));
+  });
+
+  it('skips the cursor overlay when cursor:false', async () => {
+    await record({ cursor: false }, vi.fn().mockResolvedValue(undefined));
+    expect(m.installMouseHelper).not.toHaveBeenCalled();
+  });
+
+  it('exports to the output path (video vs gif by extension)', async () => {
+    await record({ output: 'demo.mp4' }, vi.fn().mockResolvedValue(undefined));
+    expect(m.fakeRecording.toVideo).toHaveBeenCalledWith('demo.mp4', { quality: 'high' });
+
+    vi.clearAllMocks();
+    m.fakeHuman.record.mockImplementation(async (_o: unknown, cb: () => Promise<void>) => {
+      await cb();
+      return m.fakeRecording;
+    });
+    m.createHuman.mockResolvedValue(m.fakeHuman);
+    m.launch.mockResolvedValue(m.fakeBrowser);
+    m.fakeBrowser.newContext.mockResolvedValue(m.fakeContext);
+    m.fakeContext.newPage.mockResolvedValue(m.fakePage);
+    await record({ output: 'demo.gif' }, vi.fn().mockResolvedValue(undefined));
+    expect(m.fakeRecording.toGif).toHaveBeenCalledWith('demo.gif');
+  });
+});
+
+describe('record — persistent profile (userDataDir)', () => {
+  it('uses launchPersistentContext and closes that context (no separate browser)', async () => {
+    await record({ userDataDir: '/profile' }, vi.fn().mockResolvedValue(undefined));
+    expect(m.launchPersistentContext).toHaveBeenCalledWith('/profile', expect.any(Object));
+    expect(m.launch).not.toHaveBeenCalled();
+    expect(m.fakeContext.close).toHaveBeenCalled();
+    expect(m.fakeBrowser.close).not.toHaveBeenCalled();
+  });
+});
+
+describe('record — CDP attach (cdpUrl)', () => {
+  it('connects over CDP, reuses the existing context, and NEVER closes it', async () => {
+    await record({ cdpUrl: 'http://localhost:9222' }, vi.fn().mockResolvedValue(undefined));
+    expect(m.connectOverCDP).toHaveBeenCalledWith('http://localhost:9222');
+    expect(m.fakeBrowser.newContext).not.toHaveBeenCalled(); // reused contexts()[0]
+    // Borrowed browser — leave it and its context untouched.
+    expect(m.fakeContext.close).not.toHaveBeenCalled();
+    expect(m.fakeBrowser.close).not.toHaveBeenCalled();
+  });
+
+  it('takes precedence over userDataDir', async () => {
+    await record(
+      { cdpUrl: 'http://localhost:9222', userDataDir: '/profile' },
+      vi.fn().mockResolvedValue(undefined),
+    );
+    expect(m.connectOverCDP).toHaveBeenCalled();
+    expect(m.launchPersistentContext).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the browser-mode options to `@humanjs/recorder`'s `record()`, completing the "browser modes everywhere" story (now consistent with `@humanjs/mcp` env/tools and `@humanjs/playwright`'s bring-your-own-page). Lets you record a logged-in flow without re-authenticating each run.

## New `record()` options

- **`userDataDir`** — record in a persistent profile so logins/cookies survive across runs. Uses `launchPersistentContext`; `headless` / `launch` / `channel` / `viewport` still apply.
- **`cdpUrl`** — attach to a browser you launched yourself (`--remote-debugging-port`) and record its existing context (real logins/tabs/extensions). **Never closes** the borrowed browser. Takes precedence over `userDataDir`.
- **`channel`** — launch installed Chrome/Edge instead of bundled Chromium (default + persistent modes). Alone it doesn't reuse your profile — pair with `userDataDir`/`cdpUrl`.

```ts
await record({ output: 'dashboard.mp4', userDataDir: './.humanjs-profile' }, async (human) => {
  await human.goto('https://app.example.com/dashboard');
});
```

## Implementation

Browser acquisition + teardown factored into `acquireRecordingContext` with **mode-aware dispose**: ephemeral closes browser + context, persistent closes its context (owns the browser), CDP leaves the borrowed browser untouched. Default ephemeral behavior is unchanged.

## Versioning

`@humanjs/recorder` flips from a patch (internal dep bump) to a **minor** in the open "chore: version packages" PR (#28) once this merges — recorder ships this feature in the same release wave as `@humanjs/mcp` 0.1.0 / playwright + core 0.6.0.

## Test plan

- [x] `pnpm -w typecheck` — 8/8
- [x] `@humanjs/recorder` unit tests — 7 (mode dispatch + the CDP-never-closed guarantee), mocked, fast
- [x] biome clean
- [ ] After merge: confirm #28 shows `@humanjs/recorder` as minor, then merge #28 to release