### PR TITLE
feat(skill): @humanjs/skill — install the HumanJS coding-agent skill

### DIFF
--- a/.changeset/skill-package.md
+++ b/.changeset/skill-package.md
@@ -1,0 +1,9 @@
+---
+"@humanjs/skill": minor
+---
+
+Initial release of `@humanjs/skill` — a one-command installer that teaches AI coding assistants to write humanized HumanJS automation.
+
+`npx @humanjs/skill` drops the HumanJS skill into your project for **Claude Code** (`.claude/skills/humanjs/SKILL.md`), **Cursor** (`.cursor/rules/humanjs.mdc`), and/or **Codex** (root `AGENTS.md`, merged in place via markers — never clobbered). With no flags it prompts which tools to set up; `--claude` / `--cursor` / `--codex` / `--all` pick non-interactively (and CI / non-TTY use requires flags rather than hanging on a prompt).
+
+Distinct from `@humanjs/mcp`: the MCP server lets an agent *drive* a humanized browser; this skill teaches a coding agent to *write* HumanJS code.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ ghost-cursor pioneered humanized mouse paths and is excellent at what it does. H
 - [x] Session recorder → mp4 / GIF / JSON timeline
 - [x] MCP server (`@humanjs/mcp`) for AI agents
 - [x] Recorder code export (Playwright / HumanJS)
-- [ ] AI coding-agent skill (`@humanjs/skill`)
+- [x] AI coding-agent skill (`@humanjs/skill`)
 - [ ] Visual generator (`@humanjs/generator`)
 - [ ] Plugin system + community personalities (`@humanjs-community/personality-*`)
 - [ ] Recipes (`@humanjs/recipes`) for common flows

--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ claude mcp add humanjs -- npx -y @humanjs/mcp
 
 Every action the agent takes goes through HumanJS without changing your agent code. See [`@humanjs/mcp`](./packages/mcp/README.md) for the full tool catalog and per-client config.
 
+**Writing HumanJS by hand with an AI coding assistant?** Install the skill so Claude Code, Cursor, and Codex know the API:
+
+```bash
+npx @humanjs/skill
+```
+
+Drops the HumanJS skill into your project (`.claude/skills/`, `.cursor/rules/`, or `AGENTS.md`). See [`@humanjs/skill`](./packages/skill/README.md). (The MCP server *runs* a humanized browser; the skill teaches an agent to *write* HumanJS.)
+
 ## Recorder
 
 ```ts

--- a/packages/skill/README.md
+++ b/packages/skill/README.md
@@ -1,0 +1,67 @@
+# @humanjs/skill
+
+<p>
+  <a href="https://www.npmjs.com/package/@humanjs/skill"><img alt="npm" src="https://img.shields.io/npm/v/@humanjs/skill"></a>
+  <a href="https://www.npmjs.com/package/@humanjs/skill"><img alt="downloads" src="https://img.shields.io/npm/dt/@humanjs/skill"></a>
+  <a href="https://github.com/totigm/humanjs"><img alt="GitHub" src="https://img.shields.io/badge/GitHub-totigm%2Fhumanjs-181717?logo=github"></a>
+  <a href="https://github.com/totigm/humanjs/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/totigm/humanjs/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="https://github.com/totigm/humanjs/blob/main/LICENSE"><img alt="license" src="https://img.shields.io/npm/l/@humanjs/skill"></a>
+  <a href="https://humanjs.dev"><img alt="docs" src="https://img.shields.io/badge/docs-humanjs.dev-emerald"></a>
+</p>
+
+Teach your AI **coding** assistant to write correct [HumanJS](https://humanjs.dev) — humanized Playwright automation. One command drops the skill into your project for Claude Code, Cursor, and/or Codex.
+
+> Different from [`@humanjs/mcp`](../mcp): the **MCP server** lets an agent *drive* a humanized browser at runtime; this **skill** teaches a coding agent to *write* HumanJS code.
+
+## Usage
+
+Run it in your project root:
+
+```bash
+npx @humanjs/skill
+```
+
+With no flags it asks which tools to set up. Or name them directly:
+
+```bash
+npx @humanjs/skill --all                  # all three
+npx @humanjs/skill --claude --cursor       # pick some
+```
+
+| Flag | Writes |
+|---|---|
+| `--claude` | `.claude/skills/humanjs/SKILL.md` |
+| `--cursor` | `.cursor/rules/humanjs.mdc` |
+| `--codex` | `AGENTS.md` (merged in place — see below) |
+| `--all` | all of the above |
+| `-h`, `--help` | usage |
+
+The same instructions go to every target; only the wrapper format and location differ. Re-running is safe — files are overwritten with the latest skill, and `AGENTS.md` is updated in place.
+
+### AGENTS.md is never clobbered
+
+For Codex, the skill is written into your root `AGENTS.md` between markers:
+
+```md
+<!-- humanjs:start -->
+… HumanJS skill …
+<!-- humanjs:end -->
+```
+
+If `AGENTS.md` doesn't exist it's created; if it exists, the block is appended (your content untouched); if the markers are already there, the block is replaced in place. Idempotent.
+
+### Non-interactive use
+
+In CI or any non-TTY context the prompt is skipped — pass explicit flags (`--all`, etc.). Running with no flags and no TTY prints usage and exits non-zero instead of hanging.
+
+## Copy-paste instead
+
+Don't want the installer? Grab [`templates/skill-body.md`](./templates/skill-body.md) from this package and drop it where your tool looks:
+
+- **Claude Code** → `.claude/skills/humanjs/SKILL.md` (add `name` + `description` frontmatter)
+- **Cursor** → `.cursor/rules/humanjs.mdc` (add `description`, `globs`, `alwaysApply` frontmatter)
+- **Codex / any tool** → paste into your root `AGENTS.md`
+
+## License
+
+MIT

--- a/packages/skill/package.json
+++ b/packages/skill/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@humanjs/skill",
+  "version": "0.0.0",
+  "description": "Install the HumanJS coding-agent skill — teaches Claude Code, Cursor, and Codex to write humanized Playwright automation. Run: npx @humanjs/skill",
+  "keywords": [
+    "humanjs",
+    "playwright",
+    "skill",
+    "agent-skill",
+    "claude",
+    "claude-code",
+    "cursor",
+    "codex",
+    "agents-md",
+    "browser-automation"
+  ],
+  "author": "Gonzalo Muñoz <toti@eventurex.com.ar>",
+  "license": "MIT",
+  "homepage": "https://humanjs.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/totigm/humanjs.git",
+    "directory": "packages/skill"
+  },
+  "bugs": "https://github.com/totigm/humanjs/issues",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "humanjs-skill": "./dist/index.js"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "templates",
+    "README.md",
+    "LICENSE"
+  ],
+  "sideEffects": false,
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "clean": "rm -rf dist .turbo"
+  },
+  "devDependencies": {
+    "@clack/prompts": "^1.4.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/skill/src/compose.test.ts
+++ b/packages/skill/src/compose.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AGENTS_END,
+  AGENTS_START,
+  composeAgentsBlock,
+  composeClaude,
+  composeCursor,
+  mergeAgentsMd,
+  SKILL_DESCRIPTION,
+} from './compose';
+
+const BODY = '# HumanJS\n\nSome guidance.\n';
+
+describe('composeClaude', () => {
+  it('prepends name + description frontmatter', () => {
+    const out = composeClaude(BODY);
+    expect(out.startsWith('---\n')).toBe(true);
+    expect(out).toContain('name: humanjs');
+    expect(out).toContain(`description: ${SKILL_DESCRIPTION}`);
+    expect(out).toContain('# HumanJS');
+    // exactly one frontmatter fence pair (opening + closing)
+    expect(out.match(/^---$/gm)?.length).toBe(2);
+  });
+});
+
+describe('composeCursor', () => {
+  it('emits .mdc frontmatter with description, globs, alwaysApply', () => {
+    const out = composeCursor(BODY);
+    expect(out).toContain(`description: ${SKILL_DESCRIPTION}`);
+    expect(out).toContain('globs: []');
+    expect(out).toContain('alwaysApply: false');
+    expect(out).toContain('# HumanJS');
+  });
+});
+
+describe('mergeAgentsMd', () => {
+  it('creates the file from just the block when none exists', () => {
+    const out = mergeAgentsMd(null, BODY);
+    expect(out).toContain(AGENTS_START);
+    expect(out).toContain(AGENTS_END);
+    expect(out).toContain('# HumanJS');
+  });
+
+  it('treats whitespace-only existing content as empty', () => {
+    expect(mergeAgentsMd('   \n\n', BODY)).toBe(mergeAgentsMd(null, BODY));
+  });
+
+  it('appends the block, preserving existing content, when no markers present', () => {
+    const existing = '# My project\n\nExisting agent instructions.\n';
+    const out = mergeAgentsMd(existing, BODY);
+    expect(out).toContain('# My project');
+    expect(out).toContain('Existing agent instructions.');
+    expect(out).toContain(AGENTS_START);
+    expect(out.indexOf('Existing agent instructions.')).toBeLessThan(out.indexOf(AGENTS_START));
+  });
+
+  it('replaces the block in place when markers already exist', () => {
+    const first = mergeAgentsMd('# Project\n\nKeep me.\n', BODY);
+    const updated = mergeAgentsMd(first, '# HumanJS\n\nUPDATED guidance.\n');
+    expect(updated).toContain('Keep me.');
+    expect(updated).toContain('UPDATED guidance.');
+    expect(updated).not.toContain('Some guidance.');
+    // still exactly one marker pair — no duplication
+    expect(updated.match(new RegExp(AGENTS_START, 'g'))?.length).toBe(1);
+    expect(updated.match(new RegExp(AGENTS_END, 'g'))?.length).toBe(1);
+  });
+
+  it('is idempotent — re-merging the same body changes nothing', () => {
+    const once = mergeAgentsMd('# Project\n\nKeep me.\n', BODY);
+    const twice = mergeAgentsMd(once, BODY);
+    expect(twice).toBe(once);
+    // and again from the no-existing path
+    const a = mergeAgentsMd(null, BODY);
+    expect(mergeAgentsMd(a, BODY)).toBe(a);
+  });
+});
+
+describe('composeAgentsBlock', () => {
+  it('wraps the body in the marker pair', () => {
+    const block = composeAgentsBlock(BODY);
+    expect(block.startsWith(AGENTS_START)).toBe(true);
+    expect(block.trimEnd().endsWith(AGENTS_END)).toBe(true);
+  });
+});

--- a/packages/skill/src/compose.ts
+++ b/packages/skill/src/compose.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure composition: given the shared skill body (markdown), produce the file
+ * content for each target tool. No filesystem access — see `install.ts` for
+ * the I/O side. Keeping this pure makes the frontmatter and the (fiddly)
+ * AGENTS.md merge unit-testable.
+ */
+
+/** A short, single-line summary used in the Claude/Cursor frontmatter. */
+export const SKILL_DESCRIPTION =
+  'Write humanized Playwright automation with HumanJS — use when creating or editing browser automation, QA tests, or demo scripts that should move, type, scroll, and read like a real user (createHuman, personalities, recorder, code export).';
+
+/** Markers delimiting the HumanJS block inside a shared `AGENTS.md`. */
+export const AGENTS_START = '<!-- humanjs:start -->';
+export const AGENTS_END = '<!-- humanjs:end -->';
+
+/** Claude Code skill: YAML frontmatter (`name`, `description`) + body. */
+export function composeClaude(body: string): string {
+  return `---\nname: humanjs\ndescription: ${SKILL_DESCRIPTION}\n---\n\n${body.trimEnd()}\n`;
+}
+
+/** Cursor project rule (`.mdc`): frontmatter + body. Not auto-applied; the
+ * agent attaches it by relevance via the description. */
+export function composeCursor(body: string): string {
+  return `---\ndescription: ${SKILL_DESCRIPTION}\nglobs: []\nalwaysApply: false\n---\n\n${body.trimEnd()}\n`;
+}
+
+/** The body wrapped in the marker block, for embedding in `AGENTS.md`. */
+export function composeAgentsBlock(body: string): string {
+  return `${AGENTS_START}\n\n${body.trimEnd()}\n\n${AGENTS_END}`;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Merge the HumanJS block into an existing `AGENTS.md` without clobbering the
+ * user's content. Idempotent:
+ * - no existing file (null/empty) → the block becomes the file
+ * - markers already present → replace the block in place
+ * - file exists without markers → append the block
+ *
+ * Running it twice with the same body yields identical output.
+ */
+export function mergeAgentsMd(existing: string | null, body: string): string {
+  const block = composeAgentsBlock(body);
+  if (existing === null || existing.trim() === '') {
+    return `${block}\n`;
+  }
+  const markerRe = new RegExp(`${escapeRegExp(AGENTS_START)}[\\s\\S]*?${escapeRegExp(AGENTS_END)}`);
+  if (markerRe.test(existing)) {
+    return existing.replace(markerRe, block);
+  }
+  return `${existing.trimEnd()}\n\n${block}\n`;
+}

--- a/packages/skill/src/index.ts
+++ b/packages/skill/src/index.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from 'node:fs';
+import { relative } from 'node:path';
+import { cancel, intro, isCancel, multiselect, outro } from '@clack/prompts';
+import { installTarget } from './install';
+import { ALL_TARGETS, parseArgs, TARGET_LABELS, type Target } from './targets';
+
+const HELP = `humanjs-skill — install the HumanJS coding-agent skill
+
+Teaches Claude Code, Cursor, and Codex to write humanized Playwright
+automation with HumanJS. Run it in your project root.
+
+Usage:
+  npx @humanjs/skill [targets]
+
+Targets (omit to choose interactively):
+  --claude     .claude/skills/humanjs/SKILL.md
+  --cursor     .cursor/rules/humanjs.mdc
+  --codex      AGENTS.md (merged in place — never clobbered)
+  --all        all of the above
+  -h, --help   show this help
+`;
+
+/** The shared skill body, shipped alongside the bundle in `templates/`. */
+function readBody(): string {
+  return readFileSync(new URL('../templates/skill-body.md', import.meta.url), 'utf8');
+}
+
+/** Interactive multiselect of targets. Returns `null` if the user cancels. */
+async function promptTargets(): Promise<Target[] | null> {
+  intro('HumanJS skill installer');
+  const selected = await multiselect<Target>({
+    message: 'Which tools should get the HumanJS skill?',
+    options: ALL_TARGETS.map((value) => ({ value, label: TARGET_LABELS[value] })),
+    required: true,
+  });
+  if (isCancel(selected)) {
+    cancel('Cancelled — nothing was written.');
+    return null;
+  }
+  return selected;
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const { targets: flagged, help } = parseArgs(argv);
+
+  if (help) {
+    process.stdout.write(HELP);
+    return;
+  }
+
+  let targets = flagged;
+  if (targets === null) {
+    if (!process.stdin.isTTY) {
+      // Non-interactive (piped / CI) with no flags: don't hang on a prompt.
+      process.stderr.write(HELP);
+      process.stderr.write(
+        '\nNo targets given and not running interactively. Pass --claude / --cursor / --codex / --all.\n',
+      );
+      process.exitCode = 1;
+      return;
+    }
+    targets = await promptTargets();
+    if (targets === null) return;
+  }
+
+  const body = readBody();
+  const cwd = process.cwd();
+  const written: string[] = [];
+  for (const target of targets) {
+    written.push(await installTarget(target, body, cwd));
+  }
+
+  const list = written.map((p) => `  ${relative(cwd, p) || p}`).join('\n');
+  outro(`Installed the HumanJS skill:\n${list}`);
+}
+
+main().catch((error) => {
+  console.error('[humanjs-skill] failed:', error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/packages/skill/src/install.ts
+++ b/packages/skill/src/install.ts
@@ -1,0 +1,45 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { composeClaude, composeCursor, mergeAgentsMd } from './compose';
+import type { Target } from './targets';
+
+async function writeFileMkdir(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content, 'utf8');
+}
+
+/** Read a file, returning `null` if it doesn't exist (rethrows other errors). */
+async function readIfExists(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+/**
+ * Write the skill file for one target under `cwd`, returning the path written.
+ * `codex` merges into an existing `AGENTS.md` (idempotent, never clobbers);
+ * the others write self-contained files in their own locations.
+ */
+export async function installTarget(target: Target, body: string, cwd: string): Promise<string> {
+  switch (target) {
+    case 'claude': {
+      const path = join(cwd, '.claude', 'skills', 'humanjs', 'SKILL.md');
+      await writeFileMkdir(path, composeClaude(body));
+      return path;
+    }
+    case 'cursor': {
+      const path = join(cwd, '.cursor', 'rules', 'humanjs.mdc');
+      await writeFileMkdir(path, composeCursor(body));
+      return path;
+    }
+    case 'codex': {
+      const path = join(cwd, 'AGENTS.md');
+      const existing = await readIfExists(path);
+      await writeFile(path, mergeAgentsMd(existing, body), 'utf8');
+      return path;
+    }
+  }
+}

--- a/packages/skill/src/targets.test.ts
+++ b/packages/skill/src/targets.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { ALL_TARGETS, parseArgs } from './targets';
+
+describe('parseArgs', () => {
+  it('returns null targets when no target flag is given', () => {
+    expect(parseArgs([]).targets).toBeNull();
+  });
+
+  it('--all selects every target', () => {
+    expect(parseArgs(['--all']).targets).toEqual([...ALL_TARGETS]);
+  });
+
+  it('individual flags combine, in canonical order', () => {
+    expect(parseArgs(['--codex', '--claude']).targets).toEqual(['claude', 'codex']);
+  });
+
+  it('detects --help / -h', () => {
+    expect(parseArgs(['--help']).help).toBe(true);
+    expect(parseArgs(['-h']).help).toBe(true);
+    expect(parseArgs(['--claude']).help).toBe(false);
+  });
+
+  it('--all wins over individual flags', () => {
+    expect(parseArgs(['--claude', '--all']).targets).toEqual([...ALL_TARGETS]);
+  });
+});

--- a/packages/skill/src/targets.ts
+++ b/packages/skill/src/targets.ts
@@ -1,0 +1,33 @@
+/** The tools the installer can write skill files for. */
+export type Target = 'claude' | 'cursor' | 'codex';
+
+export const ALL_TARGETS: readonly Target[] = ['claude', 'cursor', 'codex'];
+
+/** Human-readable label per target, for prompts and output. */
+export const TARGET_LABELS: Record<Target, string> = {
+  claude: 'Claude Code (.claude/skills/humanjs/SKILL.md)',
+  cursor: 'Cursor (.cursor/rules/humanjs.mdc)',
+  codex: 'Codex (AGENTS.md)',
+};
+
+export interface ParsedArgs {
+  /** Targets named via flags, or `null` if none were given (→ prompt). */
+  readonly targets: Target[] | null;
+  /** `-h` / `--help` was passed. */
+  readonly help: boolean;
+}
+
+/**
+ * Parse CLI flags into explicit targets. `--all` selects every target;
+ * `--claude` / `--cursor` / `--codex` select individually (combinable).
+ * Returns `targets: null` when no target flag is present, so the caller can
+ * fall back to an interactive prompt (or the non-TTY guard).
+ */
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  const help = argv.includes('-h') || argv.includes('--help');
+  if (argv.includes('--all')) {
+    return { targets: [...ALL_TARGETS], help };
+  }
+  const picked = ALL_TARGETS.filter((t) => argv.includes(`--${t}`));
+  return { targets: picked.length > 0 ? picked : null, help };
+}

--- a/packages/skill/templates/skill-body.md
+++ b/packages/skill/templates/skill-body.md
@@ -1,0 +1,134 @@
+# HumanJS — humanized Playwright automation
+
+HumanJS wraps a Playwright `Page` so clicks, typing, scrolling, and reading happen at realistic human pace (curved mouse paths, typing rhythm, reading dwell). Use it for **AI agents**, **QA tests** where real-pace timing exposes bugs, and **demo/tutorial recordings**.
+
+**Use this skill when** writing or editing browser automation, Playwright tests, or demo scripts that should behave like a real user — or when the user mentions HumanJS, `createHuman`, humanized clicks/typing, or recording a flow.
+
+## Setup
+
+`@humanjs/playwright` wraps an existing Playwright `Page` — it does not replace Playwright.
+
+```ts
+import { chromium, createHuman } from '@humanjs/playwright';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+
+const human = await createHuman(page, {
+  personality: 'careful', // 'careful' | 'fast' | 'distracted' | 'precise'
+  seed: 'session-42',     // optional — deterministic trajectories when set
+  speed: 'human',         // 'human' (default) | 'fast' | 'instant'
+});
+
+await human.goto('https://example.com');
+await human.click('Sign in');
+await human.type('Email', 'user@example.com');
+```
+
+`page` stays fully usable for assertions and anything HumanJS doesn't cover (`expect(page)…`, `page.locator(…)`).
+
+## Selector strategy — prefer accessible names
+
+Pass Playwright selectors as strings. **Prefer accessible names and roles** (`getByRole`, `getByLabel`, `getByText`) over brittle CSS/XPath — it's both more robust and a humanization signal (real users navigate by what they see). HumanJS forwards the string to `page.locator()`, so any Playwright selector works, but reach for CSS only when there's no accessible handle.
+
+```ts
+await human.click('Buy now');                 // resolved by accessible name
+await human.type('Card number', '4242…');      // by label
+await human.click('button.checkout');          // CSS fallback when needed
+```
+
+## Personalities
+
+```ts
+createHuman(page, { personality: 'careful' });    // slow, precise, few mistakes
+createHuman(page, { personality: 'fast' });       // quick but still natural
+createHuman(page, { personality: 'distracted' }); // scrolls back, retypes, hovers
+createHuman(page, { personality: 'precise' });    // minimal noise, smooth motion
+```
+
+Extend, override, or blend (the `Personality` type is exported and stable):
+
+```ts
+import { blend } from '@humanjs/playwright';
+
+createHuman(page, { personality: { extends: 'careful', typing: { typoProbability: 0.1 } } });
+createHuman(page, { personality: blend('careful', 'distracted', 0.3) });
+```
+
+## Determinism and CI
+
+Set `seed` for reproducible runs (required for snapshot tests). Use `speed: 'instant'` in CI to bypass humanization and keep the suite fast — the documented test pattern:
+
+```ts
+import { test, expect } from '@playwright/test';
+import { createHuman } from '@humanjs/playwright';
+
+test('checkout flow', async ({ page }) => {
+  const human = await createHuman(page, {
+    seed: test.info().title,
+    speed: process.env.CI ? 'instant' : 'human',
+  });
+
+  await human.goto('/');
+  await human.click('Buy now');
+  await expect(page).toHaveURL(/checkout/);
+});
+```
+
+`'instant'` uses Playwright's native methods (no curved paths or per-key timing) so tests stay quick; local runs get the full human treatment for catching real-pace bugs.
+
+## Primitives
+
+All await; selectors are strings or Playwright `Locator`s (`move`/`drag` also accept a `{ x, y }` Point).
+
+| Call | Behavior |
+|---|---|
+| `human.goto(url)` | Navigate. |
+| `human.click(target)` | Hover → micro-move → click. Occasional near-miss + recovery. |
+| `human.rightClick(target)` | Context-menu click. |
+| `human.hover(target)` | Hover and settle (no click). |
+| `human.move(target)` | Positional move, no dwell. |
+| `human.drag(from, to)` | Humanized drag; endpoints are selector / Locator / Point. |
+| `human.type(target, value)` | Click to focus, then realistic typing rhythm (+ optional typos/backspace). |
+| `human.paste(target, value)` | Cmd-V style insert — no per-char timing. |
+| `human.press(key)` | Single key (`'Tab'`) or chord (`'Mod+S'` — `Mod` = Meta on macOS, Control elsewhere). |
+| `human.read(target)` | Dwell based on word count. |
+| `human.scroll('natural')` | Humanized scroll; also `{ by }` / `{ to }` / a selector. |
+| `human.sleep(ms)` | Pause (also exported standalone as `sleep`). |
+
+## Recording and code export
+
+Record a session and export it several ways:
+
+```ts
+const rec = await human.record(async () => {
+  await human.goto('/checkout');
+  await human.click('Buy now');
+  await human.type('Email', 'user@example.com');
+});
+
+await rec.toVideo('checkout.mp4');          // mp4 / webm
+await rec.toGif('checkout.gif');            // animated gif
+await rec.toTimeline('checkout.json');      // structured JSON timeline
+await rec.toHumanJS('checkout.ts');         // runnable HumanJS script
+await rec.toPlaywright('checkout.spec.ts'); // @playwright/test spec (humanized)
+```
+
+Or one call that owns the browser lifecycle (`@humanjs/recorder`):
+
+```ts
+import { record } from '@humanjs/recorder';
+
+await record({ output: 'demo.mp4', name: 'checkout flow' }, async (human) => {
+  await human.goto('/checkout');
+  await human.click('Buy now');
+});
+```
+
+`toPlaywright()` generates a real test: it runs `speed: process.env.CI ? 'instant' : …`, drops recorded `sleep()` pauses by default (`{ keepSleeps: true }` to keep them), and derives safe assertions (`toBeVisible` from reads, `toHaveValue` from captured inputs).
+
+**Captured inputs / passwords:** typed values are recorded into the timeline and code exports by default so generated scripts are runnable, **except `input[type="password"]` values, which are always masked**. Don't hand-edit a real secret back into an exported file — read it from an env var (`process.env.APP_PASSWORD`) instead. Set `captureInputs: false` on `record()` to capture no input values at all.
+
+## Not in scope — do not frame HumanJS this way
+
+HumanJS is for legitimate automation, QA, and demos. It is **not** a stealth tool and will not defeat sophisticated bot detection. Never write code, comments, or copy that positions it for: captcha solving/bypass, fingerprint masking, proxy rotation, or "undetectable" automation. If asked for those, decline — they are explicit non-goals.

--- a/packages/skill/tsconfig.json
+++ b/packages/skill/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/skill/tsup.config.ts
+++ b/packages/skill/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  treeshake: true,
+  splitting: false,
+  // `@clack/prompts` is ESM-only, so leaving it external would break the CJS
+  // build's `require()`. Bundle it into both outputs instead — the installer
+  // is self-contained and ships no runtime dependencies.
+  noExternal: ['@clack/prompts'],
+  // The bin entry (`humanjs-skill`) needs a shebang so `npx @humanjs/skill`
+  // can execute it directly.
+  banner: { js: '#!/usr/bin/env node' },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,12 @@ importers:
         specifier: ^1.60.0
         version: 1.60.0
 
+  packages/skill:
+    devDependencies:
+      '@clack/prompts':
+        specifier: ^1.4.0
+        version: 1.4.0
+
 packages:
 
   '@alloc/quick-lru@5.2.0':
@@ -280,6 +286,14 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@clack/core@1.3.1':
+    resolution: {integrity: sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.4.0':
+    resolution: {integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==}
+    engines: {node: '>= 20.12.0'}
 
   '@commitlint/cli@21.0.1':
     resolution: {integrity: sha512-8vq10krmbJwBkvzXKhbs4o4JQEVscd3pqOlWuDUaDBwbeL694/P33UC29tZQFTAgPU9fVJ2+f2m3zw16yKWxHg==}
@@ -1765,8 +1779,17 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2534,6 +2557,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -3030,6 +3056,18 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.3
       prettier: 2.8.8
+
+  '@clack/core@1.3.1':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.4.0':
+    dependencies:
+      '@clack/core': 1.3.1
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
 
   '@commitlint/cli@21.0.1(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@6.0.3)':
     dependencies:
@@ -4221,7 +4259,17 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.2: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fastq@1.20.1:
     dependencies:
@@ -4979,6 +5027,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
 


### PR DESCRIPTION
## Summary

New package: **`@humanjs/skill`** — a one-command installer that teaches AI *coding* assistants to write correct HumanJS.

```bash
npx @humanjs/skill
```

Drops the HumanJS skill into a project for **Claude Code** (`.claude/skills/humanjs/SKILL.md`), **Cursor** (`.cursor/rules/humanjs.mdc`), and/or **Codex** (root `AGENTS.md`). With no flags it prompts which tools; `--claude` / `--cursor` / `--codex` / `--all` pick non-interactively, and non-TTY use requires flags rather than hanging on a prompt.

> Distinct from `@humanjs/mcp`: the MCP server lets an agent *drive* a humanized browser at runtime; this skill teaches a coding agent to *write* HumanJS code.

## Design

- **One source of truth:** the skill content is authored once in `templates/skill-body.md` (real markdown — keeps code fences readable) and composed per target. Shipped via the `files` array and read at runtime relative to the bundle.
- **Pure, tested composition layer** (`src/compose.ts`): Claude/Cursor frontmatter + the idempotent `AGENTS.md` merge. The merge **never clobbers** — creates if absent, appends if present, replaces in place between `<!-- humanjs:start/end -->` markers if already there. Re-running is a no-op.
- **Self-contained bin:** `@clack/prompts` (ESM-only) is bundled (`noExternal`), so the published package has zero runtime dependencies.
- Mirrors the `@humanjs/mcp` bin-package scaffold (shebang banner, `version: 0.0.0`, `publishConfig`).

## Out of scope (deliberate)

- **Landing page** — covered by the upcoming landing redesign.
- **No MCP tool for the skill** — different audience/layer (coding agents consume skills via files, not MCP resources); the "consider the MCP surface" rule doesn't apply to a CLI installer.

## Test plan

- [x] `pnpm --filter @humanjs/skill test` — 13 unit tests (compose incl. AGENTS-merge idempotency, flag parsing)
- [x] `pnpm -w typecheck` 9/9 · biome clean · build (shebang present)
- [x] `npm pack --dry-run` — confirms `templates/skill-body.md` ships
- [x] Live smoke test: `--all` writes all 3 files; existing `AGENTS.md` content preserved; re-run byte-identical (idempotent); non-TTY with no flags exits 1 (no hang); `--help` exits 0

## Changeset

`@humanjs/skill` minor → publishes `0.1.0`.