### PR TITLE
docs(core): activate the plugin + community-personality ecosystem

### DIFF
--- a/.changeset/plugin-personality-authoring-docs.md
+++ b/.changeset/plugin-personality-authoring-docs.md
@@ -1,0 +1,5 @@
+---
+"@humanjs/core": patch
+---
+
+Document the personality + plugin authoring surface in the README — how to build a `Personality` (extend a preset or ship a full profile), publish it as a community `@yourname/personality-*` package, and write a `HumanPlugin`. No API changes; the contract was already exported and stable.

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ ghost-cursor pioneered humanized mouse paths and is excellent at what it does. H
 - [x] Recorder code export (Playwright / HumanJS)
 - [x] AI coding-agent skill (`@humanjs/skill`)
 - [ ] Visual generator (`@humanjs/generator`)
-- [ ] Plugin system + community personalities (`@humanjs-community/personality-*`)
+- [x] Plugin system + community personality authoring (`@yourname/personality-*`)
 - [ ] Recipes (`@humanjs/recipes`) for common flows
 - [ ] Touch / mobile humanization
 - [ ] Puppeteer adapter (`@humanjs/puppeteer`)

--- a/examples/package.json
+++ b/examples/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "click": "tsx click-demo.ts",
     "compare": "tsx compare-demo.ts",
+    "grandma": "tsx personality-grandma.ts",
+    "plugin": "tsx plugin-logger.ts",
     "primitives": "tsx primitives-demo.ts",
     "read": "tsx read-demo.ts",
     "record": "tsx record-demo.ts",

--- a/examples/personality-grandma.ts
+++ b/examples/personality-grandma.ts
@@ -1,0 +1,65 @@
+/**
+ * Authoring a community personality.
+ *
+ * A personality is plain data. To publish one, create a package named
+ * `@yourname/personality-<name>` whose entry exports an object exactly like
+ * `grandma` below — either a `PersonalityExtension` (a preset + overrides, as
+ * here) or a fully built `Personality`. Consumers then do:
+ *
+ *   import { grandma } from '@yourname/personality-grandma';
+ *   await createHuman(page, { personality: grandma });
+ *
+ * Run this demo:  pnpm --filter @humanjs/examples grandma
+ */
+
+import {
+  chromium,
+  createHuman,
+  installMouseHelper,
+  type PersonalityExtension,
+} from '@humanjs/playwright';
+
+/** Slow, deliberate, curvy — and a bit error-prone. The exact shape a
+ *  community `@yourname/personality-grandma` package would export. */
+export const grandma: PersonalityExtension = {
+  extends: 'careful',
+  name: 'grandma',
+  speed: 1.7, // everything ~70% slower
+  mouse: { curvature: 0.95, travelTimeMs: 1500, overshootProbability: 0.4 },
+  typing: {
+    baseDelayMs: 240,
+    typoProbability: 0.08,
+    thinkPauseProbability: 0.4,
+    thinkPauseMeanMs: 1000,
+  },
+  reading: { wpm: 130 },
+  dwell: { preClickMs: 650, postActionMs: 800 },
+};
+
+const PAGE =
+  '<!doctype html><meta charset="utf-8">' +
+  '<body style="margin:48px;font-family:sans-serif;font-size:16px">' +
+  '<button id="start" style="padding:10px 18px">Start</button>' +
+  '<input id="email" placeholder="email" style="display:block;margin-top:18px;padding:8px;width:260px">' +
+  '<p style="max-width:340px;margin-top:18px">HumanJS makes browser automation move, type, and read like a real person.</p>' +
+  '</body>';
+
+async function main() {
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext();
+  await installMouseHelper(context);
+  const page = await context.newPage();
+  await page.setContent(PAGE);
+
+  const human = await createHuman(page, { personality: grandma, seed: 'grandma-demo' });
+  await human.click('#start');
+  await human.type('#email', 'grandma@example.com');
+  await human.read('p');
+
+  await browser.close();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/plugin-logger.ts
+++ b/examples/plugin-logger.ts
@@ -1,0 +1,46 @@
+/**
+ * Writing a plugin.
+ *
+ * A plugin is a plain object with optional lifecycle hooks. The host calls
+ * them around every humanized action — observation only in v1 (hooks can't
+ * transform actions). Pass plugins when creating a session:
+ *
+ *   await createHuman(page, { plugins: [logger] });
+ *
+ * Run this demo:  pnpm --filter @humanjs/examples plugin
+ */
+
+import { chromium, createHuman, type HumanPlugin } from '@humanjs/playwright';
+
+/** A minimal observability plugin — logs every action and its duration. */
+const logger: HumanPlugin = {
+  name: 'logger',
+  install: (ctx) => console.log(`[logger] installed · personality=${ctx.personality.name}`),
+  beforeAction: (action) => console.log(`▶ ${action.type}`, action.params ?? {}),
+  afterAction: (action, result) => console.log(`✓ ${action.type} — ${result.durationMs}ms`),
+  onError: (action, error) => console.error(`✕ ${action.type}`, error),
+};
+
+const PAGE =
+  '<!doctype html><meta charset="utf-8">' +
+  '<body style="margin:40px;font-family:sans-serif">' +
+  '<button id="start">Start</button>' +
+  '<input id="email" placeholder="email" style="display:block;margin-top:16px">' +
+  '</body>';
+
+async function main() {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.setContent(PAGE);
+
+  const human = await createHuman(page, { plugins: [logger], speed: 'instant' });
+  await human.click('#start');
+  await human.type('#email', 'hi@example.com');
+
+  await browser.close();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -19,6 +19,76 @@ The core of [HumanJS](https://humanjs.dev): personality system, timing math, typ
 pnpm add @humanjs/core
 ```
 
+## Authoring a personality
+
+A `Personality` is plain, immutable data — it describes the *rhythm and shape*
+of humanization (mouse curvature, typing delays, reading speed, dwell) without
+owning any randomness. The `Personality` type is exported and stable, so anyone
+can build one and pass it to `createHuman({ personality })`.
+
+The simplest form extends a built-in preset and overrides only what you want:
+
+```ts
+import type { PersonalityExtension } from '@humanjs/core';
+
+export const grandma: PersonalityExtension = {
+  extends: 'careful',
+  name: 'grandma',
+  speed: 1.7, // ~70% slower overall
+  mouse: { curvature: 0.95, overshootProbability: 0.4 },
+  typing: { baseDelayMs: 240, thinkPauseProbability: 0.4, typoProbability: 0.08 },
+  reading: { wpm: 130 },
+};
+```
+
+You can also export a fully built `Personality` (every facet specified) — useful
+when you don't want to inherit from a preset. Compose presets with `blend()`,
+and resolve any config to a flat `Personality` with `resolvePersonality()`.
+
+### Publish it as a community package
+
+Personalities are a first-class extension point. To share one, publish a package
+named **`@yourname/personality-<name>`** whose entry exports the object:
+
+```ts
+// @yourname/personality-grandma
+export { grandma } from './grandma';
+```
+
+```ts
+// consumer
+import { grandma } from '@yourname/personality-grandma';
+import { createHuman } from '@humanjs/playwright';
+
+const human = await createHuman(page, { personality: grandma });
+```
+
+A runnable example lives in [`examples/personality-grandma.ts`](https://github.com/totigm/humanjs/blob/main/examples/personality-grandma.ts).
+
+## Writing a plugin
+
+A `HumanPlugin` is a plain object with optional lifecycle hooks the host calls
+around every action. Hooks are observation-only in v1 (they can't transform
+actions) and run in registration order; each may be sync or async.
+
+```ts
+import type { HumanPlugin } from '@humanjs/core';
+
+const logger: HumanPlugin = {
+  name: 'logger',
+  install: (ctx) => console.log(`personality: ${ctx.personality.name}`),
+  beforeAction: (action) => console.log(`▶ ${action.type}`, action.params),
+  afterAction: (action, result) => console.log(`✓ ${action.type} — ${result.durationMs}ms`),
+  onError: (action, error) => console.error(`✕ ${action.type}`, error),
+};
+
+const human = await createHuman(page, { plugins: [logger] });
+```
+
+`install` receives a `PluginContext` (the resolved `personality` and the
+session's seeded `rng`). A runnable example lives in
+[`examples/plugin-logger.ts`](https://github.com/totigm/humanjs/blob/main/examples/plugin-logger.ts).
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Completes the roadmap's "plugin system + community personalities" item. The plugin contract and the stable, exported `Personality` type already shipped in `@humanjs/core` — this makes those extension points **usable and discoverable**, without any API change.

- **`@humanjs/core` README** — two authoring guides:
  - *Authoring a personality* — extend a preset (`PersonalityExtension`) or ship a full `Personality`, and **publish as `@yourname/personality-*`** (with consumer usage).
  - *Writing a plugin* — `HumanPlugin` hooks + `PluginContext`.
- **Runnable examples** (+ `pnpm` scripts):
  - `examples/personality-grandma.ts` — a community-style personality (`pnpm --filter @humanjs/examples grandma`)
  - `examples/plugin-logger.ts` — an observability plugin (`pnpm --filter @humanjs/examples plugin`)
- **Roadmap** flipped to shipped: `Plugin system + community personality authoring (@yourname/personality-*)`.

## Why not ship a first-party personality package?

Community personalities are meant to be *community* packages — shipping our own `@humanjs/personality-*` would be faux-community. The right deliverable is enabling + documenting + exemplifying the pattern, which this does.

## Test plan

- [x] `pnpm -w typecheck` — 9/9
- [x] Both example files explicitly type-check (`examples/` isn't covered by `-w typecheck`)
- [x] `plugin-logger.ts` runs end-to-end — `install` / `beforeAction` / `afterAction` fire with correct params + durations
- [x] biome clean

## Changeset

`@humanjs/core` **patch** — the README ships on npm, so the new authoring docs reach the package page on next release.

> Note: no `Personality`/`HumanPlugin` API changes — purely docs + examples activating what's already exported and stable.