### PR TITLE
chore: package health — ship LICENSE, strict publint export checks, broaden keywords

### DIFF
--- a/.changeset/package-health-license-publint.md
+++ b/.changeset/package-health-license-publint.md
@@ -6,6 +6,6 @@
 "@humanjs/skill": patch
 ---
 
-Ship the MIT `LICENSE` file inside every package tarball. Each package listed `LICENSE` in its `files` array but had no license file in its own directory, so published tarballs omitted it — this adds the file to each package. Also broadens `@humanjs/core`'s npm keywords.
+Ship the MIT `LICENSE` file inside every package tarball. Each package listed `LICENSE` in its `files` array but had no license file in its own directory, so published tarballs omitted it — this adds the file to each package. Also broadens every package's npm keywords for discoverability.
 
-Tooling (not published): a `check:exports` task runs `publint` on every package in CI, validating the published exports map, `files`, and type fields against the packed output.
+Tooling (not published): a `check:exports` task runs `publint --strict` on every package in CI, validating the published exports map, `files`, and type fields against the packed output (warnings fail the check).

--- a/.changeset/package-health-license-publint.md
+++ b/.changeset/package-health-license-publint.md
@@ -1,0 +1,11 @@
+---
+"@humanjs/core": patch
+"@humanjs/playwright": patch
+"@humanjs/recorder": patch
+"@humanjs/mcp": patch
+"@humanjs/skill": patch
+---
+
+Ship the MIT `LICENSE` file inside every package tarball. Each package listed `LICENSE` in its `files` array but had no license file in its own directory, so published tarballs omitted it — this adds the file to each package. Also broadens `@humanjs/core`'s npm keywords.
+
+Tooling (not published): a `check:exports` task runs `publint` on every package in CI, validating the published exports map, `files`, and type fields against the packed output.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,6 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: Check package exports
+        run: pnpm check:exports

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test": "turbo run test",
     "test:integration": "turbo run test:integration",
     "typecheck": "turbo run typecheck",
+    "check:exports": "turbo run check:exports",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gonzalo Muñoz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,7 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
-    "check:exports": "publint",
+    "check:exports": "publint --strict",
     "clean": "rm -rf dist .turbo"
   },
   "publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
     "bezier",
     "typing-rhythm",
     "plugin",
+    "ai-agent",
     "ai-agents",
     "qa-testing"
   ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,13 @@
     "humanjs",
     "humanize",
     "playwright",
-    "browser-automation"
+    "browser-automation",
+    "personality",
+    "bezier",
+    "typing-rhythm",
+    "plugin",
+    "ai-agents",
+    "qa-testing"
   ],
   "author": "Gonzalo Muñoz <toti@eventurex.com.ar>",
   "license": "MIT",
@@ -50,6 +56,7 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
+    "check:exports": "publint",
     "clean": "rm -rf dist .turbo"
   },
   "publishConfig": {

--- a/packages/mcp/LICENSE
+++ b/packages/mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gonzalo Muñoz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -12,7 +12,10 @@
     "codex",
     "ai-agent",
     "browser-automation",
-    "humanize"
+    "humanize",
+    "mcp-server",
+    "claude-code",
+    "llm"
   ],
   "author": "Gonzalo Muñoz <toti@eventurex.com.ar>",
   "license": "MIT",
@@ -59,7 +62,7 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
-    "check:exports": "publint",
+    "check:exports": "publint --strict",
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -59,6 +59,7 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
+    "check:exports": "publint",
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -11,6 +11,7 @@
     "cursor",
     "codex",
     "ai-agent",
+    "ai-agents",
     "browser-automation",
     "humanize",
     "mcp-server",

--- a/packages/playwright/LICENSE
+++ b/packages/playwright/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gonzalo Muñoz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -53,6 +53,7 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
+    "check:exports": "publint",
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -8,6 +8,7 @@
     "humanize",
     "browser-automation",
     "qa",
+    "ai-agent",
     "ai-agents",
     "human-like",
     "bezier",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -8,7 +8,12 @@
     "humanize",
     "browser-automation",
     "qa",
-    "ai-agents"
+    "ai-agents",
+    "human-like",
+    "bezier",
+    "typing-rhythm",
+    "e2e-testing",
+    "test-automation"
   ],
   "author": "Gonzalo Muñoz <toti@eventurex.com.ar>",
   "license": "MIT",
@@ -53,7 +58,7 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
-    "check:exports": "publint",
+    "check:exports": "publint --strict",
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {

--- a/packages/recorder/LICENSE
+++ b/packages/recorder/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gonzalo Muñoz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/recorder/package.json
+++ b/packages/recorder/package.json
@@ -11,7 +11,11 @@
     "webm",
     "gif",
     "humanize",
-    "browser-automation"
+    "browser-automation",
+    "screen-recording",
+    "test-generation",
+    "demo",
+    "tutorial"
   ],
   "author": "Gonzalo Muñoz <toti@eventurex.com.ar>",
   "license": "MIT",
@@ -56,7 +60,7 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
-    "check:exports": "publint",
+    "check:exports": "publint --strict",
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {

--- a/packages/recorder/package.json
+++ b/packages/recorder/package.json
@@ -56,6 +56,7 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
+    "check:exports": "publint",
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {

--- a/packages/skill/LICENSE
+++ b/packages/skill/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gonzalo Muñoz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/skill/package.json
+++ b/packages/skill/package.json
@@ -15,6 +15,7 @@
     "browser-automation",
     "humanize",
     "coding-agent",
+    "ai-agent",
     "ai-agents"
   ],
   "author": "Gonzalo Muñoz <toti@eventurex.com.ar>",

--- a/packages/skill/package.json
+++ b/packages/skill/package.json
@@ -60,6 +60,7 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
+    "check:exports": "publint",
     "clean": "rm -rf dist .turbo"
   },
   "devDependencies": {

--- a/packages/skill/package.json
+++ b/packages/skill/package.json
@@ -12,7 +12,10 @@
     "cursor",
     "codex",
     "agents-md",
-    "browser-automation"
+    "browser-automation",
+    "humanize",
+    "coding-agent",
+    "ai-agents"
   ],
   "author": "Gonzalo Muñoz <toti@eventurex.com.ar>",
   "license": "MIT",
@@ -60,7 +63,7 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
-    "check:exports": "publint",
+    "check:exports": "publint --strict",
     "clean": "rm -rf dist .turbo"
   },
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -36,6 +36,10 @@
       "dependsOn": ["^build"],
       "inputs": ["src/**", "test/**", "tsconfig.json"]
     },
+    "check:exports": {
+      "dependsOn": ["build"],
+      "inputs": ["dist/**", "package.json"]
+    },
     "lint": {
       "inputs": ["src/**", "test/**", "biome.json", "package.json"]
     },


### PR DESCRIPTION
## What & why

Three packaging-health fixes plus metadata, across all five published packages (`@humanjs/{core,playwright,recorder,mcp,skill}`).

**1. Ship `LICENSE` in every published tarball (real bug).** Each package listed `LICENSE` in its `files` array but had no license file in its own directory — so the npm tarballs shipped *without* a license. Confirmed via `npm pack`: before, the packages packed with no `LICENSE`; now all five include it. Adds the MIT `LICENSE` (byte-identical to root) to each package dir.

**2. Gate the published export shape with `publint --strict`.** `publint` was already a devDep but unused. A new `check:exports` turbo task (`dependsOn: build`) runs `publint --strict` on every package, plus a CI step after Build. It validates each package's `exports` map, `files`, and type fields against the actual packed output — and with `--strict`, warnings fail CI, not just errors. All five pass clean.

**3. Broaden npm keywords on every package** for discoverability (e.g. `bezier`, `typing-rhythm`, `mcp-server`, `claude-code`, `screen-recording`, `coding-agent`). Agent-facing packages (core, playwright, mcp, skill) now consistently carry both `ai-agent` and `ai-agents`; `recorder` stays out of the agent keywords (positioned for recording/QA/demos). No non-goal terms (nothing about scraping/stealth/undetectable).

A changeset bumps all five packages `patch` so the `LICENSE` actually lands in the next publish.

## Notes

- `@arethetypeswrong/cli` (attw) was evaluated for the same `check:exports` step but **crashes universally** in this environment (`Cannot read properties of undefined (reading 'filename')` on every package, run directly) — a tooling bug, not a package defect, since `publint` passes clean. Left out rather than wiring a check that always fails CI. Worth revisiting when the upstream bug is fixed.

## Checklist

- [x] `pnpm typecheck` (9/9), `pnpm lint`, and `pnpm check:exports` (11/11, publint --strict "All good!") pass locally
- [x] LICENSE confirmed present in all 5 tarballs via `npm pack --dry-run`
- [x] Changeset added (`patch` × 5 — so the LICENSE ships next publish)
- [x] Conventional commit titles
- [x] Not a non-goal

🤖 Generated with [Claude Code](https://claude.com/claude-code)