### PR TITLE
chore: add community health files (CoC, contributing, security, templates)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in the repo.
+# Auto-requests review from the maintainer on every PR.
+* @totigm

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Something in HumanJS behaves incorrectly or crashes.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report. A small, runnable reproduction is the single most helpful thing you can include.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you observe, and what did you expect instead?
+      placeholder: human.type() dropped characters when the personality was set to "fast"...
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: A minimal code snippet or, ideally, a link to a repo / Playwright trace. Include the page or a stand-in if the behaviour is site-specific.
+      render: ts
+      placeholder: |
+        const human = await createHuman(page, { personality: 'fast', seed: 'repro' });
+        await human.type('#email', 'a@b.com');
+    validations:
+      required: true
+  - type: dropdown
+    id: package
+    attributes:
+      label: Which package?
+      multiple: true
+      options:
+        - "@humanjs/core"
+        - "@humanjs/playwright"
+        - "@humanjs/recorder"
+        - "@humanjs/mcp"
+        - "@humanjs/skill"
+        - Not sure
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Package version(s)
+      description: The version of the affected package(s) — e.g. `@humanjs/playwright@0.7.0`.
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: OS, Node version, Playwright version, browser, and whether you run headed or headless / CDP.
+      placeholder: macOS 14, Node 22, Playwright 1.49, Chromium headless
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / errors
+      description: Any relevant stack trace or console output. This is automatically formatted as code.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or usage help
+    url: https://github.com/totigm/humanjs/discussions
+    about: Ask how to do something, share a setup, or discuss an idea before filing a request.
+  - name: Documentation
+    url: https://humanjs.dev
+    about: API reference, personalities, and guides.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest a new primitive, personality, adapter, or behaviour.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        HumanJS humanizes browser automation for **AI agents, QA tests, and demo/tutorial recordings**. Requests are weighed against that scope.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case, not just the feature. What are you trying to do that HumanJS makes hard today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would the API or behaviour look like? A sketch of the call signature helps.
+      render: ts
+    validations:
+      required: false
+  - type: checkboxes
+    id: not-a-non-goal
+    attributes:
+      label: Scope check
+      description: "HumanJS will not implement these — see the [non-goals](https://github.com/totigm/humanjs#non-goals). Requests for them will be closed."
+      options:
+        - label: This is **not** captcha solving / bypass, fingerprint masking, proxy rotation, TLS / network stealth, "undetectable" framing, time-of-day variation, or AI-generated mouse trajectories.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -26,7 +26,7 @@ body:
     id: not-a-non-goal
     attributes:
       label: Scope check
-      description: "HumanJS will not implement these — see the [non-goals](https://github.com/totigm/humanjs#non-goals). Requests for them will be closed."
+      description: "HumanJS will not implement these — see the [non-goals](https://github.com/totigm/humanjs#what-humanjs-is-not). Requests for them will be closed."
       options:
         - label: This is **not** captcha solving / bypass, fingerprint masking, proxy rotation, TLS / network stealth, "undetectable" framing, time-of-day variation, or AI-generated mouse trajectories.
           required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!-- Thanks for contributing to HumanJS! Keep PRs to one logical change. -->
+
+## What & why
+
+<!-- What does this change, and what problem does it solve? Link any related issue (e.g. "Closes #123"). -->
+
+## Checklist
+
+- [ ] One logical change, with a [conventional commit](https://www.conventionalcommits.org/) title (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`)
+- [ ] Added a changeset (`pnpm changeset`) if this touches a published package
+- [ ] `pnpm typecheck`, `pnpm test`, and `pnpm lint` pass locally
+- [ ] Tests added/updated for the change
+- [ ] Docs / README updated if behaviour or public API changed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,3 +11,4 @@
 - [ ] `pnpm typecheck`, `pnpm test`, and `pnpm lint` pass locally
 - [ ] Tests added/updated for the change
 - [ ] Docs / README updated if behaviour or public API changed
+- [ ] This is **not** a [non-goal](https://github.com/totigm/humanjs#what-humanjs-is-not) (captcha, fingerprint masking, proxy rotation, stealth)

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ build
 *.tsbuildinfo
 next-env.d.ts
 
+# Package tarballs (npm pack output)
+*.tgz
+
 # Test outputs
 coverage
 .nyc_output

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at toti@eventurex.com.ar. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ By participating, you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.
 
 ## Before you start: scope
 
-HumanJS humanizes browser automation for **AI agents, QA tests, and demo/tutorial recordings**. Some things are deliberately out of scope and we will not merge them — captcha solving/bypass, fingerprint masking, proxy rotation, TLS/network stealth, "undetectable" framing, time-of-day variation, and AI-generated mouse trajectories. See the [non-goals](https://github.com/totigm/humanjs#non-goals) before opening a feature PR. If you're unsure whether an idea fits, open a [Discussion](https://github.com/totigm/humanjs/discussions) first.
+HumanJS humanizes browser automation for **AI agents, QA tests, and demo/tutorial recordings**. Some things are deliberately out of scope and we will not merge them — captcha solving/bypass, fingerprint masking, proxy rotation, TLS/network stealth, "undetectable" framing, time-of-day variation, and AI-generated mouse trajectories. See the [non-goals](https://github.com/totigm/humanjs#what-humanjs-is-not) before opening a feature PR. If you're unsure whether an idea fits, open a [Discussion](https://github.com/totigm/humanjs/discussions) first.
 
 ## Prerequisites
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contributing to HumanJS
+
+Thanks for your interest in improving HumanJS! This guide covers how to get the monorepo running, the conventions we follow, and how to land a change.
+
+By participating, you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Before you start: scope
+
+HumanJS humanizes browser automation for **AI agents, QA tests, and demo/tutorial recordings**. Some things are deliberately out of scope and we will not merge them — captcha solving/bypass, fingerprint masking, proxy rotation, TLS/network stealth, "undetectable" framing, time-of-day variation, and AI-generated mouse trajectories. See the [non-goals](https://github.com/totigm/humanjs#non-goals) before opening a feature PR. If you're unsure whether an idea fits, open a [Discussion](https://github.com/totigm/humanjs/discussions) first.
+
+## Prerequisites
+
+- **Node** — version in [`.nvmrc`](./.nvmrc) (currently 22). `nvm use` picks it up.
+- **pnpm** — this repo pins `pnpm@9.15.0` via `packageManager`. Use [Corepack](https://nodejs.org/api/corepack.html): `corepack enable`.
+
+## Getting started
+
+```bash
+git clone https://github.com/totigm/humanjs.git
+cd humanjs
+pnpm install
+pnpm build      # build all packages once (turbo)
+```
+
+It's a [pnpm workspace](https://pnpm.io/workspaces) driven by [Turborepo](https://turbo.build/). Packages live in `packages/*`; the docs site and runnable examples live in `apps/*`.
+
+## Development workflow
+
+Common root scripts (all fan out across the workspace via turbo):
+
+| Command | What it does |
+|---|---|
+| `pnpm build` | Build every package |
+| `pnpm test` | Run unit tests (vitest) |
+| `pnpm typecheck` | `tsc --noEmit` across packages |
+| `pnpm lint` | Biome check |
+| `pnpm lint:fix` | Biome check + autofix |
+| `pnpm check:exports` | `publint --strict` on every package |
+
+To work on a single package, scope it: `pnpm --filter @humanjs/playwright build`. The `pnpm demo:*` scripts run the examples in `apps/examples` against a live browser.
+
+## Before you commit
+
+Run the same gate CI runs:
+
+```bash
+pnpm typecheck && pnpm test && pnpm lint && pnpm check:exports
+```
+
+A [lefthook](https://github.com/evilmartians/lefthook) pre-commit hook runs Biome, and a commit-msg hook runs commitlint — so a malformed commit or unformatted file is caught locally.
+
+## Commits
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) with a **lowercase subject** (enforced by commitlint):
+
+```
+feat(playwright): add human.rightClick()
+fix(recorder): stop dropping frames on slow CI
+docs: clarify CDP viewport limitation
+```
+
+Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`. Keep each commit to **one logical change** — no squash-bombs.
+
+## Changesets
+
+If your change touches a **published package** (`@humanjs/*`), add a changeset so it gets a version bump and a changelog entry:
+
+```bash
+pnpm changeset
+```
+
+Pick the affected packages and a bump level (`patch` / `minor` / `major`), and write a short user-facing summary. Changes that only touch `apps/*` (private), tests, or repo config don't need one. Maintainers release by merging the changesets-generated "Version Packages" PR.
+
+## Tests
+
+- Unit tests are **colocated** with the module they test (`src/<module>/<module>.test.ts`) and run with [vitest](https://vitest.dev/).
+- Playwright end-to-end tests go in `e2e/`.
+- HumanJS is deterministic given a `seed`, and `{ speed: 'instant' }` bypasses humanization — use both so tests are stable and fast:
+
+  ```ts
+  const human = await createHuman(page, {
+    speed: process.env.CI ? 'instant' : 'human',
+    seed: test.info().title,
+  });
+  ```
+
+## Opening a pull request
+
+1. Branch off `main` (`feat/...`, `fix/...`, `chore/...`).
+2. Make your change, add tests, and add a changeset if a published package changed.
+3. Make sure the gate above is green.
+4. Open the PR and fill out the template. Link any related issue (`Closes #123`).
+
+A maintainer will review. Thanks for contributing! 💛

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ We do not accept PRs that:
 - Implement captcha solvers, fingerprint masking, or proxy management
 - Position HumanJS as a stealth tool
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md).
+See [CONTRIBUTING.md](./CONTRIBUTING.md) to get started, and please follow our [Code of Conduct](./CODE_OF_CONDUCT.md). To report a security issue, see the [security policy](./SECURITY.md).
 
 ## Credits
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported versions
+
+HumanJS is published as independently versioned `@humanjs/*` packages. Fixes are released against the **latest published version** of each package. If you're on an older release, please upgrade before reporting.
+
+## Reporting a vulnerability
+
+Please report security issues **privately** — don't open a public issue.
+
+Two ways to reach us:
+
+- **GitHub** (preferred): go to the repo's **Security** tab → **Report a vulnerability** ([private advisory](https://github.com/totigm/humanjs/security/advisories/new)).
+- **Email**: [toti@eventurex.com.ar](mailto:toti@eventurex.com.ar).
+
+Please include:
+
+- the affected package and version (e.g. `@humanjs/playwright@0.7.0`),
+- steps to reproduce or a minimal proof of concept,
+- the impact you believe it has.
+
+We aim to acknowledge a report within a few business days and will keep you updated on the fix and disclosure timeline. We'll credit you in the advisory unless you'd prefer to stay anonymous.
+
+## What's in scope
+
+Issues in HumanJS's own code or published packages — for example, a bug that lets untrusted input trigger unintended code execution, or a vulnerable dependency we ship.
+
+## What's *not* in scope
+
+- **The [non-goals](https://github.com/totigm/humanjs#non-goals).** HumanJS does not — and will not — defeat bot detection, solve or bypass captchas, mask fingerprints, rotate proxies, or provide "undetectable" automation. Reports or requests framed around those are feature requests we decline, not security issues.
+- Vulnerabilities in **your own automation scripts**, the **sites you automate**, or **Playwright / the browser** themselves (report those upstream).
+
+## Responsible use
+
+HumanJS drives a real browser and performs real actions. Only use it on sites and in ways you are authorized to.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ Issues in HumanJS's own code or published packages — for example, a bug that l
 
 ## What's *not* in scope
 
-- **The [non-goals](https://github.com/totigm/humanjs#non-goals).** HumanJS does not — and will not — defeat bot detection, solve or bypass captchas, mask fingerprints, rotate proxies, or provide "undetectable" automation. Reports or requests framed around those are feature requests we decline, not security issues.
+- **The [non-goals](https://github.com/totigm/humanjs#what-humanjs-is-not).** HumanJS does not — and will not — defeat bot detection, solve or bypass captchas, mask fingerprints, rotate proxies, or provide "undetectable" automation. Reports or requests framed around those are feature requests we decline, not security issues.
 - Vulnerabilities in **your own automation scripts**, the **sites you automate**, or **Playwright / the browser** themselves (report those upstream).
 
 ## Responsible use


### PR DESCRIPTION
## What & why

Completes GitHub's community-profile checklist for the OSS repo. None of this is published in any npm package — it's repo governance + contributor onboarding.

**Added**
- **`CONTRIBUTING.md`** — prerequisites (Node 22, pnpm 9.15), setup, the workspace scripts, commit conventions (conventional + lowercase, enforced by commitlint/lefthook), the changeset flow, and the deterministic / `speed: 'instant'` testing pattern. Also **fixes the README's previously-broken `CONTRIBUTING.md` link** (it 404'd).
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant v2.1, contact `toti@eventurex.com.ar`.
- **`SECURITY.md`** — private disclosure via GitHub advisories or email, supported-versions note, and an explicit scope section stating the [non-goals](https://github.com/totigm/humanjs#non-goals) (captcha/stealth/fingerprinting) are **not** security issues.
- **`.github/ISSUE_TEMPLATE/`** — structured `bug_report` + `feature_request` forms (the feature form requires a non-goals scope-check), and `config.yml` routing questions to Discussions + docs (blank issues off).
- **`.github/pull_request_template.md`** — checklist: changeset, conventional commit, green gate, not a non-goal.
- **`.github/CODEOWNERS`** — default reviewer.

**Also**
- Link the Code of Conduct + security policy from the README's Contributing section.
- gitignore `*.tgz` so `npm pack` output never gets committed (two strays were cleaned up).

## Notes

- No changeset — nothing here ships in a package.
- `FUNDING.yml` intentionally omitted (no GitHub Sponsors set up yet; easy to add later).

## Checklist

- [x] `pnpm lint` clean (markdown/config only — no code changed)
- [x] Conventional commit title
- [x] Not a non-goal

🤖 Generated with [Claude Code](https://claude.com/claude-code)