### PR TITLE
feat(playwright): form-interaction primitives (doubleClick, check/uncheck, selectOption, upload) + MCP tools

### DIFF
--- a/.changeset/form-interaction-primitives.md
+++ b/.changeset/form-interaction-primitives.md
@@ -1,0 +1,15 @@
+---
+"@humanjs/playwright": minor
+"@humanjs/mcp": minor
+"@humanjs/core": minor
+"@humanjs/skill": patch
+---
+
+Add form-interaction primitives so real flows (forms, checkout, settings) stay fully humanized instead of dropping back to raw Playwright:
+
+- **`human.doubleClick(target)`** — same humanized approach as `click()`, double-click dispatch.
+- **`human.check(target)` / `human.uncheck(target)`** — tick/untick a checkbox or radio; clicks only when the state needs to change (a real user doesn't re-click an already-ticked box), and verifies the result.
+- **`human.selectOption(target, values)`** — choose option(s) in a native `<select>`; the cursor moves to the dropdown, then the value is set (firing `input`/`change`).
+- **`human.upload(target, files)`** — attach file(s) to a file input; the cursor moves to the control, then files are set directly (never opens the OS dialog).
+
+Each is mirrored as an MCP tool (`human_doubleClick`, `human_check`, `human_uncheck`, `human_selectOption`, `human_upload`), exported by the recorder's code generators (`toPlaywright` / `toHumanJS`), and documented in the `@humanjs/skill` primitives reference. `@humanjs/core` gains the matching `KnownActionType` entries so plugins can observe them.

--- a/.changeset/form-interaction-primitives.md
+++ b/.changeset/form-interaction-primitives.md
@@ -13,3 +13,5 @@ Add form-interaction primitives so real flows (forms, checkout, settings) stay f
 - **`human.upload(target, files)`** — attach file(s) to a file input; the cursor moves to the control, then files are set directly (never opens the OS dialog).
 
 Each is mirrored as an MCP tool (`human_doubleClick`, `human_check`, `human_uncheck`, `human_selectOption`, `human_upload`), exported by the recorder's code generators (`toPlaywright` / `toHumanJS`), and documented in the `@humanjs/skill` primitives reference. `@humanjs/core` gains the matching `KnownActionType` entries so plugins can observe them.
+
+`human_upload` confines reads to `HUMANJS_UPLOAD_DIR` (default: the server's working dir) and accepts a basename only — `../`, subdirectories, and absolute paths are rejected — so a prompt-injected filename can't read and exfiltrate arbitrary local files to a web form (same path-safety model as the output tools).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,11 +72,16 @@ const human = await createHuman(page, {
 await human.goto(url);
 await human.click(selector);              // hover, micro-move, click
 await human.rightClick(selector);         // context-menu click
+await human.doubleClick(selector);        // same motion as click; double-click dispatch
 await human.hover(selector);              // hover without clicking
 await human.move(target);                 // selector | Locator | Point — positional, no settle dwell
 await human.drag(from, to);               // each endpoint: selector | Locator | Point
 await human.type(selector, value);        // click, then realistic typing rhythm
 await human.paste(selector, value);       // Cmd-V style (no per-char timing)
+await human.check(selector);              // tick a checkbox/radio (clicks only if needed)
+await human.uncheck(selector);            // untick a checkbox
+await human.selectOption(selector, value);// native <select> — cursor moves to it, then sets value
+await human.upload(selector, files);      // attach file(s) to a file input (no OS dialog)
 await human.read(text);                   // dwell based on word count
 await human.scroll('natural');
 await human.press('Mod+S');               // chord — 'Mod' auto-maps: Meta on Mac, Control elsewhere

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ await human.goto('https://example.com');
 await human.click('Sign in');
 await human.type('Email', 'gonzalo@example.com');
 await human.paste('Password', process.env.PW!);
+await human.check('Remember me');
 await human.read('Welcome back');
 await human.scroll('natural');
 ```

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -59,7 +59,9 @@ export interface PluginContext {
  * action types without a core release.
  */
 export type KnownActionType =
+  | 'check'
   | 'click'
+  | 'doubleClick'
   | 'drag'
   | 'goBack'
   | 'goForward'
@@ -71,9 +73,12 @@ export type KnownActionType =
   | 'reload'
   | 'rightClick'
   | 'scroll'
+  | 'selectOption'
   | 'press'
   | 'sleep'
-  | 'type';
+  | 'type'
+  | 'uncheck'
+  | 'upload';
 
 /**
  * Loose action-type string: known names autocomplete in IDEs while any

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -71,6 +71,7 @@ The `config` payload is base64 of `{"command":"npx","args":["-y","@humanjs/mcp"]
 | `HUMANJS_SPEED` | `human` \| `fast` \| `instant` | `human` | Humanization pace. `human` = full realistic motion; `fast` = humanized but quick; `instant` = no humanized motion. Changes how long each action *executes*, not the wait between actions. |
 | `HUMANJS_HEADLESS` | `true` \| `false` | `false` | Headless browser. Default is visible — the point of the MCP. |
 | `HUMANJS_OUTPUT_DIR` | path | server's CWD | Where screenshots and recordings are written. |
+| `HUMANJS_UPLOAD_DIR` | path | server's CWD | Folder `human_upload` reads files from (basename only — can't escape it). |
 | `HUMANJS_VIEWPORT` | `WIDTHxHEIGHT` | `1440x900` | Default viewport for new sessions. Bump to `1920x1080` for crisper recordings. |
 | `HUMANJS_AUTO_INSTALL` | `true` \| `false` | `true` | Auto-download the Chromium binary on first launch if missing. Set `false` to require a manual `npx playwright install chromium`. |
 | `HUMANJS_PERSIST` | `true` \| `false` | `false` | Persist a profile across runs (logins/cookies survive). Uses `~/.humanjs/profile` unless `HUMANJS_USER_DATA_DIR` is set. See [Browser modes](#browser-modes). |
@@ -232,6 +233,7 @@ The server ships **built-in guidance** (sent to the agent on connect via MCP `in
 
 - **No arbitrary-JS `evaluate` tool.** Executing page-supplied JavaScript is a prompt-injection cliff — a malicious page could trick the agent into running code that exfiltrates data. The read-only inspection tools cover the legitimate "what's on the page" need.
 - **File-path safety.** Tools that write files accept a basename only; path components (`../`, absolute paths) are rejected, so a prompt-injected filename can't escape `HUMANJS_OUTPUT_DIR`.
+- **Upload path safety.** `human_upload` can attach a local file to a web form — a potential exfiltration path if a page prompt-injects the agent. So it reads files by **basename only** from `HUMANJS_UPLOAD_DIR` (default: the server's working dir); subdirectories, `../`, and absolute paths are rejected, so the agent can't reach (and send) files outside that folder. Point `HUMANJS_UPLOAD_DIR` at where your upload fixtures live.
 - **No credentials handling.** The server drives the browser; it doesn't manage logins, payment details, or secrets on your behalf.
 - **Attaching to your real browser (CDP) is opt-in and env-only.** When you point `HUMANJS_CDP_URL` at your running browser, the agent acts with *your* live sessions — a bigger blast radius if a page tries to manipulate it. That's why it's a deliberate config choice you make up front, never something a tool can switch on.
 

--- a/packages/mcp/src/env.ts
+++ b/packages/mcp/src/env.ts
@@ -47,6 +47,15 @@ export interface McpEnv {
    */
   readonly outputDir: string;
   /**
+   * Directory `human_upload` reads files from. Defaults to the MCP server's
+   * working directory at startup. Like the output tools, `human_upload`
+   * accepts a basename only — `../`, subdirectories, and absolute paths are
+   * rejected — so a prompt-injected filename can't read (and exfiltrate to a
+   * web form) files outside this directory. Set `HUMANJS_UPLOAD_DIR` to the
+   * folder your upload fixtures live in.
+   */
+  readonly uploadDir: string;
+  /**
    * Default viewport for new sessions. Per-session overrides (via
    * `human_create_session`) and runtime resizes (via `human_set_viewport`)
    * take precedence. Defaults to 1440×900 — a comfortable desktop size
@@ -103,6 +112,7 @@ export function readEnv(): McpEnv {
     speed: parseSpeed(process.env.HUMANJS_SPEED),
     headless: parseBool(process.env.HUMANJS_HEADLESS, false),
     outputDir: process.env.HUMANJS_OUTPUT_DIR ?? process.cwd(),
+    uploadDir: process.env.HUMANJS_UPLOAD_DIR ?? process.cwd(),
     viewport: parseViewport(process.env.HUMANJS_VIEWPORT),
     autoInstall: parseBool(process.env.HUMANJS_AUTO_INSTALL, true),
     browser: resolveBrowserConfig(),

--- a/packages/mcp/src/output.test.ts
+++ b/packages/mcp/src/output.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { resolveOutputPath, resolveRecordingFormat } from './output';
+import { resolveOutputPath, resolveRecordingFormat, resolveUploadPath } from './output';
 
 describe('resolveOutputPath', () => {
   const OUT = '/out/dir';
@@ -25,6 +25,21 @@ describe('resolveOutputPath', () => {
 
   it('rejects an empty name', () => {
     expect(() => resolveOutputPath(OUT, '')).toThrow(/path components/i);
+  });
+});
+
+describe('resolveUploadPath', () => {
+  const UP = '/upload/dir';
+
+  it('joins a plain basename to the upload dir', () => {
+    expect(resolveUploadPath(UP, 'photo.png')).toBe(join(UP, 'photo.png'));
+  });
+
+  it('rejects parent-traversal, nested, absolute, and empty names', () => {
+    expect(() => resolveUploadPath(UP, '../../etc/passwd')).toThrow(/path components/i);
+    expect(() => resolveUploadPath(UP, 'sub/photo.png')).toThrow(/path components/i);
+    expect(() => resolveUploadPath(UP, '/etc/passwd')).toThrow(/path components/i);
+    expect(() => resolveUploadPath(UP, '')).toThrow(/path components/i);
   });
 });
 

--- a/packages/mcp/src/output.ts
+++ b/packages/mcp/src/output.ts
@@ -18,6 +18,25 @@ export function resolveOutputPath(outputDir: string, filename: string): string {
   return join(outputDir, base);
 }
 
+/**
+ * Resolves a user/AI-supplied upload filename to a safe absolute path inside
+ * `uploadDir`. The mirror of {@link resolveOutputPath} for *reading* a file to
+ * attach to a form: rejects path components (`../`, `sub/dir`, absolute paths)
+ * so a prompt-injected filename can't read — and exfiltrate to a web form —
+ * files outside the configured upload directory. `human_upload` can otherwise
+ * read+send any server-readable file, so this confinement is the safety
+ * boundary that makes exposing upload over MCP acceptable.
+ */
+export function resolveUploadPath(uploadDir: string, filename: string): string {
+  const base = basename(filename);
+  if (base !== filename || base.length === 0) {
+    throw new Error(
+      `upload filename must be a plain name with no path components, got "${filename}". Files are read from HUMANJS_UPLOAD_DIR — place the file there (or point HUMANJS_UPLOAD_DIR at its folder) and pass just the name.`,
+    );
+  }
+  return join(uploadDir, base);
+}
+
 /** Export format a recording filename maps to. */
 export type RecordingFormat = 'video' | 'gif' | 'timeline' | 'humanjs' | 'playwright';
 

--- a/packages/mcp/src/session.test.ts
+++ b/packages/mcp/src/session.test.ts
@@ -39,6 +39,7 @@ function makeEnv(browser: BrowserConfig = { mode: 'ephemeral' }, channel?: strin
     speed: 'human',
     headless: true,
     outputDir: '/tmp/out',
+    uploadDir: '/tmp/uploads',
     viewport: { width: 1440, height: 900 },
     autoInstall: true,
     browser,

--- a/packages/mcp/src/tools/primitives.ts
+++ b/packages/mcp/src/tools/primitives.ts
@@ -76,6 +76,24 @@ export function registerPrimitiveTools(server: McpServer, { sessions }: ToolCont
   );
 
   server.registerTool(
+    'human_doubleClick',
+    {
+      title: 'Double-click (humanized)',
+      description:
+        'Double-clicks the target — same humanized motion as human_click, but two presses within the OS double-click window. Use for things that open/activate on double-click (list rows, file items, editable cells). Target is a selector OR x/y coordinates.',
+      inputSchema: { ...targetFields, session: sessionArg },
+    },
+    async ({ selector, x, y, session }) => {
+      const { human } = await sessions.get(session);
+      const target = resolveTarget({ selector, x, y });
+      await human.doubleClick(target);
+      return {
+        content: [{ type: 'text', text: `double-clicked ${describeTarget(selector, x, y)}` }],
+      };
+    },
+  );
+
+  server.registerTool(
     'human_hover',
     {
       title: 'Hover an element (humanized)',
@@ -182,6 +200,89 @@ export function registerPrimitiveTools(server: McpServer, { sessions }: ToolCont
       const { human } = await sessions.get(session);
       await human.paste(selector, value);
       return { content: [{ type: 'text', text: `pasted ${value.length} chars into ${selector}` }] };
+    },
+  );
+
+  server.registerTool(
+    'human_check',
+    {
+      title: 'Check a box (humanized)',
+      description:
+        'Ticks a checkbox or radio — moves the cursor to it and clicks, but only if it is not already checked (a real user does not re-click a ticked box). Verifies the resulting state. Element-bound: pass the input (or its label) selector.',
+      inputSchema: {
+        selector: z.string().describe('Selector of the checkbox/radio (or its label).'),
+        session: sessionArg,
+      },
+    },
+    async ({ selector, session }) => {
+      const { human } = await sessions.get(session);
+      await human.check(selector);
+      return { content: [{ type: 'text', text: `checked ${selector}` }] };
+    },
+  );
+
+  server.registerTool(
+    'human_uncheck',
+    {
+      title: 'Uncheck a box (humanized)',
+      description:
+        'Unticks a checkbox — humanized click only if currently checked. Radios cannot be unchecked by clicking (select a different option instead). Element-bound: pass the input (or its label) selector.',
+      inputSchema: {
+        selector: z.string().describe('Selector of the checkbox (or its label).'),
+        session: sessionArg,
+      },
+    },
+    async ({ selector, session }) => {
+      const { human } = await sessions.get(session);
+      await human.uncheck(selector);
+      return { content: [{ type: 'text', text: `unchecked ${selector}` }] };
+    },
+  );
+
+  server.registerTool(
+    'human_selectOption',
+    {
+      title: 'Select dropdown option (humanized)',
+      description:
+        "Chooses option(s) in a native <select> — moves the cursor to the dropdown, then sets the value (native selects open an OS menu automation can't drive, so the value is set programmatically, firing change/input). For custom DOM dropdowns, use human_click on the rendered options instead. Match by value(s); pass one string or an array for multi-selects.",
+      inputSchema: {
+        selector: z.string().describe('Selector of the <select> element.'),
+        values: z
+          .union([z.string(), z.array(z.string())])
+          .describe('Option value, or array of values for a multi-select.'),
+        session: sessionArg,
+      },
+    },
+    async ({ selector, values, session }) => {
+      const { human } = await sessions.get(session);
+      const selected = await human.selectOption(selector, values);
+      return {
+        content: [{ type: 'text', text: `selected ${selected.join(', ')} in ${selector}` }],
+      };
+    },
+  );
+
+  server.registerTool(
+    'human_upload',
+    {
+      title: 'Upload file(s) (humanized)',
+      description:
+        'Attaches file(s) to a file input — moves the cursor to the control, then sets the files. Never opens the OS file dialog (which would hang); files are attached directly. Paths are resolved on the machine running this MCP server. Pass the <input type="file"> selector.',
+      inputSchema: {
+        selector: z.string().describe('Selector of the file input.'),
+        files: z
+          .union([z.string(), z.array(z.string())])
+          .describe('Absolute path, or array of paths, on the server filesystem.'),
+        session: sessionArg,
+      },
+    },
+    async ({ selector, files, session }) => {
+      const { human } = await sessions.get(session);
+      await human.upload(selector, files);
+      const count = Array.isArray(files) ? files.length : 1;
+      return {
+        content: [{ type: 'text', text: `uploaded ${count} file(s) to ${selector}` }],
+      };
     },
   );
 

--- a/packages/mcp/src/tools/primitives.ts
+++ b/packages/mcp/src/tools/primitives.ts
@@ -13,6 +13,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { ToolContext } from '../context';
+import { resolveUploadPath } from '../output';
 import { resolveTarget, targetFields } from './targets';
 
 const sessionArg = z
@@ -22,7 +23,7 @@ const sessionArg = z
     'Session ID to act on. Omit to use the default session (created lazily on first call). Use human_create_session for parallel browsers.',
   );
 
-export function registerPrimitiveTools(server: McpServer, { sessions }: ToolContext): void {
+export function registerPrimitiveTools(server: McpServer, { sessions, env }: ToolContext): void {
   server.registerTool(
     'human_goto',
     {
@@ -208,9 +209,9 @@ export function registerPrimitiveTools(server: McpServer, { sessions }: ToolCont
     {
       title: 'Check a box (humanized)',
       description:
-        'Ticks a checkbox or radio — moves the cursor to it and clicks, but only if it is not already checked (a real user does not re-click a ticked box). Verifies the resulting state. Element-bound: pass the input (or its label) selector.',
+        'Ticks a checkbox or radio — moves the cursor to it and clicks, but only if it is not already checked (a real user does not re-click a ticked box). Verifies the resulting state. Pass the checkbox/radio input itself (or a [role=checkbox]) — not a wrapping <label> — so the current state can be read and the click stays idempotent.',
       inputSchema: {
-        selector: z.string().describe('Selector of the checkbox/radio (or its label).'),
+        selector: z.string().describe('Selector of the checkbox/radio input.'),
         session: sessionArg,
       },
     },
@@ -226,9 +227,9 @@ export function registerPrimitiveTools(server: McpServer, { sessions }: ToolCont
     {
       title: 'Uncheck a box (humanized)',
       description:
-        'Unticks a checkbox — humanized click only if currently checked. Radios cannot be unchecked by clicking (select a different option instead). Element-bound: pass the input (or its label) selector.',
+        'Unticks a checkbox — humanized click only if currently checked. Radios cannot be unchecked by clicking (select a different option instead). Pass the checkbox input itself (or a [role=checkbox]) — not a wrapping <label> — so its state can be read and the click stays idempotent.',
       inputSchema: {
-        selector: z.string().describe('Selector of the checkbox (or its label).'),
+        selector: z.string().describe('Selector of the checkbox input.'),
         session: sessionArg,
       },
     },
@@ -267,21 +268,24 @@ export function registerPrimitiveTools(server: McpServer, { sessions }: ToolCont
     {
       title: 'Upload file(s) (humanized)',
       description:
-        'Attaches file(s) to a file input — moves the cursor to the control, then sets the files. Never opens the OS file dialog (which would hang); files are attached directly. Paths are resolved on the machine running this MCP server. Pass the <input type="file"> selector.',
+        'Attaches file(s) to a file input — moves the cursor to the control, then sets the files (never opens the OS dialog, which would hang). For safety, files are read by basename from HUMANJS_UPLOAD_DIR (default: the server working dir) — subdirectories, "../", and absolute paths are rejected, so the agent can\'t read and exfiltrate arbitrary local files. Pass the <input type="file"> selector and the filename(s).',
       inputSchema: {
         selector: z.string().describe('Selector of the file input.'),
         files: z
           .union([z.string(), z.array(z.string())])
-          .describe('Absolute path, or array of paths, on the server filesystem.'),
+          .describe('Filename(s) inside HUMANJS_UPLOAD_DIR — a basename only, no path components.'),
         session: sessionArg,
       },
     },
     async ({ selector, files, session }) => {
       const { human } = await sessions.get(session);
-      await human.upload(selector, files);
-      const count = Array.isArray(files) ? files.length : 1;
+      const names = Array.isArray(files) ? files : [files];
+      // Confine reads to HUMANJS_UPLOAD_DIR — upload can read+send local files,
+      // so a prompt-injected path must not escape the configured directory.
+      const paths = names.map((name) => resolveUploadPath(env.uploadDir, name));
+      await human.upload(selector, paths);
       return {
-        content: [{ type: 'text', text: `uploaded ${count} file(s) to ${selector}` }],
+        content: [{ type: 'text', text: `uploaded ${paths.length} file(s) to ${selector}` }],
       };
     },
   );

--- a/packages/playwright/src/forms/forms.test.ts
+++ b/packages/playwright/src/forms/forms.test.ts
@@ -1,0 +1,153 @@
+import type { Page } from 'playwright';
+import { describe, expect, it, vi } from 'vitest';
+import { createHuman } from '../index';
+
+const defaultBox = { x: 100, y: 200, width: 80, height: 30 };
+
+interface MockLocatorOptions {
+  readonly box?: { x: number; y: number; width: number; height: number } | null;
+  readonly isChecked?: ReturnType<typeof vi.fn>;
+  readonly selectOptionReturn?: string[];
+}
+
+function makeMock(opts: MockLocatorOptions = {}) {
+  const locator = {
+    boundingBox: vi.fn().mockResolvedValue(opts.box === undefined ? defaultBox : opts.box),
+    scrollIntoViewIfNeeded: vi.fn().mockResolvedValue(undefined),
+    click: vi.fn().mockResolvedValue(undefined),
+    isChecked: opts.isChecked ?? vi.fn().mockResolvedValue(false),
+    check: vi.fn().mockResolvedValue(undefined),
+    uncheck: vi.fn().mockResolvedValue(undefined),
+    selectOption: vi.fn().mockResolvedValue(opts.selectOptionReturn ?? ['a']),
+    setInputFiles: vi.fn().mockResolvedValue(undefined),
+  };
+  const mouseMove = vi.fn().mockResolvedValue(undefined);
+  const mouseClick = vi.fn().mockResolvedValue(undefined);
+  const page = {
+    locator: vi.fn(() => locator),
+    evaluate: vi.fn().mockResolvedValue(0),
+    mouse: {
+      move: mouseMove,
+      click: mouseClick,
+      wheel: vi.fn().mockResolvedValue(undefined),
+      down: vi.fn().mockResolvedValue(undefined),
+      up: vi.fn().mockResolvedValue(undefined),
+    },
+    viewportSize: () => ({ width: 1280, height: 720 }),
+  } as unknown as Page;
+  return { page, locator, mouseMove, mouseClick };
+}
+
+describe('human.check / uncheck', () => {
+  it('clicks to tick an unchecked box and verifies the new state', async () => {
+    const isChecked = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const { page, mouseClick } = makeMock({ isChecked });
+    const human = await createHuman(page, { speed: 'fast' });
+    await human.check('#agree');
+    expect(mouseClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not click when the box is already in the desired state', async () => {
+    const isChecked = vi.fn().mockResolvedValue(true);
+    const { page, mouseClick } = makeMock({ isChecked });
+    const human = await createHuman(page, { speed: 'fast' });
+    await human.check('#agree');
+    expect(mouseClick).not.toHaveBeenCalled();
+  });
+
+  it('throws when the state does not change after clicking', async () => {
+    const isChecked = vi.fn().mockResolvedValue(false); // stays false after click
+    const { page } = makeMock({ isChecked });
+    const human = await createHuman(page, { speed: 'fast' });
+    await expect(human.check('#radio')).rejects.toThrow(/did not reach the checked state/);
+  });
+
+  it('still toggles when the element is not directly checkable (label/role)', async () => {
+    // isChecked throws → readChecked returns null → click fires, no verify
+    const isChecked = vi.fn().mockRejectedValue(new Error('not a checkbox'));
+    const { page, mouseClick } = makeMock({ isChecked });
+    const human = await createHuman(page, { speed: 'fast' });
+    await human.check('label.toggle');
+    expect(mouseClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('uncheck clicks a checked box', async () => {
+    const isChecked = vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    const { page, mouseClick } = makeMock({ isChecked });
+    const human = await createHuman(page, { speed: 'fast' });
+    await human.uncheck('#agree');
+    expect(mouseClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('instant mode delegates to native check()/uncheck()', async () => {
+    const { page, locator, mouseClick } = makeMock();
+    const human = await createHuman(page, { speed: 'instant' });
+    await human.check('#a');
+    await human.uncheck('#b');
+    expect(locator.check).toHaveBeenCalledTimes(1);
+    expect(locator.uncheck).toHaveBeenCalledTimes(1);
+    expect(mouseClick).not.toHaveBeenCalled();
+  });
+});
+
+describe('human.selectOption', () => {
+  it('moves the cursor to the select, then sets the value', async () => {
+    const { page, locator, mouseMove } = makeMock({ selectOptionReturn: ['AR'] });
+    const human = await createHuman(page, { speed: 'fast' });
+    const selected = await human.selectOption('#country', 'AR');
+    expect(mouseMove).toHaveBeenCalled(); // humanized approach
+    expect(locator.selectOption).toHaveBeenCalledWith('AR');
+    expect(selected).toEqual(['AR']);
+  });
+
+  it('instant mode sets the value with no cursor motion', async () => {
+    const { page, locator, mouseMove } = makeMock();
+    const human = await createHuman(page, { speed: 'instant' });
+    await human.selectOption('#country', ['a', 'b']);
+    expect(locator.selectOption).toHaveBeenCalledWith(['a', 'b']);
+    expect(mouseMove).not.toHaveBeenCalled();
+  });
+});
+
+describe('human.upload', () => {
+  it('moves to the control, then attaches the files', async () => {
+    const { page, locator, mouseMove } = makeMock();
+    const human = await createHuman(page, { speed: 'fast' });
+    await human.upload('#file', '/tmp/a.png');
+    expect(mouseMove).toHaveBeenCalled();
+    expect(locator.setInputFiles).toHaveBeenCalledWith('/tmp/a.png');
+  });
+
+  it('tolerates a hidden file input (no bounding box) and still attaches', async () => {
+    const { page, locator } = makeMock({ box: null });
+    const human = await createHuman(page, { speed: 'fast' });
+    await human.upload('#hidden-file', ['/tmp/a.png', '/tmp/b.png']);
+    expect(locator.setInputFiles).toHaveBeenCalledWith(['/tmp/a.png', '/tmp/b.png']);
+  });
+
+  it('instant mode attaches with no cursor motion', async () => {
+    const { page, locator, mouseMove } = makeMock();
+    const human = await createHuman(page, { speed: 'instant' });
+    await human.upload('#file', '/tmp/a.png');
+    expect(locator.setInputFiles).toHaveBeenCalledWith('/tmp/a.png');
+    expect(mouseMove).not.toHaveBeenCalled();
+  });
+});
+
+describe('human.doubleClick', () => {
+  it('dispatches a double-click after the humanized approach', async () => {
+    const { page, mouseClick } = makeMock();
+    const human = await createHuman(page, { speed: 'fast' });
+    await human.doubleClick('#row');
+    expect(mouseClick).toHaveBeenCalledTimes(1);
+    const [, , opts] = mouseClick.mock.calls[0] ?? [];
+    expect(opts).toMatchObject({ clickCount: 2 });
+  });
+
+  it('instant mode uses locator.click with clickCount 2', async () => {
+    const { page, locator } = makeMock();
+    const human = await createHuman(page, { speed: 'instant' });
+    await human.doubleClick('#row');
+    expect(locator.click).toHaveBeenCalledWith(expect.objectContaining({ clickCount: 2 }));
+  });
+});

--- a/packages/playwright/src/forms/index.ts
+++ b/packages/playwright/src/forms/index.ts
@@ -1,0 +1,143 @@
+import type { Locator } from 'playwright';
+import { executeClick, executeHover, type MouseContext } from '../mouse';
+
+/** Values accepted by {@link executeSelectOption} — the Playwright `selectOption` shape. */
+export type SelectOptionValues = Parameters<Locator['selectOption']>[0];
+/** Files accepted by {@link executeUpload} — the Playwright `setInputFiles` shape. */
+export type UploadFiles = Parameters<Locator['setInputFiles']>[0];
+
+/** Form targets are element-bound: a selector or a pre-built `Locator`. */
+export type FormTarget = Locator | string;
+
+function toLocator(target: FormTarget, ctx: MouseContext): Locator {
+  return typeof target === 'string' ? ctx.page.locator(target) : target;
+}
+
+function describe(target: FormTarget): string {
+  return typeof target === 'string' ? target : (target.toString?.() ?? 'locator');
+}
+
+/**
+ * Reads a checkable element's state, returning `null` when the element isn't
+ * directly checkable (e.g. the target is a wrapping `<label>` or a styled
+ * control). Used by {@link executeSetChecked} to guard idempotency and verify
+ * the toggle only when the element actually reports a checked state.
+ */
+async function readChecked(locator: Locator): Promise<boolean | null> {
+  try {
+    return await locator.isChecked();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Humanized checkbox/radio toggle. Moves the cursor to the control along a
+ * Bezier path and clicks it (with the same hover dwell and occasional
+ * near-miss as {@link executeClick}) — but only when a click is actually
+ * needed:
+ *
+ *  - If the element already reports the desired state, no click fires. A
+ *    real user doesn't re-click a box that's already in the state they want.
+ *  - After toggling, the new state is verified. If it didn't change (e.g.
+ *    trying to `uncheck` a radio, which can't be unchecked by clicking), a
+ *    clear error is thrown rather than silently passing.
+ *
+ * The idempotency guard and verification are skipped when the element isn't
+ * directly checkable (a `<label>` or `role`-based control where `isChecked()`
+ * doesn't apply) — there the humanized click still toggles the associated
+ * input, we just can't read/verify the state from this node.
+ *
+ * In `speed: 'instant'`, delegates to Playwright's native
+ * `locator.check()` / `locator.uncheck()` (idempotent + actionability-checked).
+ */
+export async function executeSetChecked(
+  target: FormTarget,
+  ctx: MouseContext,
+  checked: boolean,
+): Promise<void> {
+  const locator = toLocator(target, ctx);
+
+  if (ctx.speed === 'instant') {
+    if (checked) await locator.check();
+    else await locator.uncheck();
+    return;
+  }
+
+  const before = await readChecked(locator);
+  // Already in the desired state — nothing to do (only short-circuit when the
+  // state is actually readable; `null` means "not directly checkable", fall
+  // through to a humanized click and let it toggle the associated control).
+  if (before === checked) return;
+
+  await executeClick(locator, ctx);
+
+  const after = await readChecked(locator);
+  if (after !== null && after !== checked) {
+    throw new Error(
+      `Cannot ${checked ? 'check' : 'uncheck'}: element did not reach the ${
+        checked ? 'checked' : 'unchecked'
+      } state after clicking (target: ${describe(target)}). Radios can't be unchecked by clicking — select a different option instead.`,
+    );
+  }
+}
+
+/**
+ * Humanized native `<select>` choice. Moves the cursor to the dropdown along a
+ * Bezier path and settles on it (the {@link executeHover} dwell), then sets the
+ * value via Playwright's `selectOption`.
+ *
+ * Native selects open an OS-level menu Playwright can't drive visually, so the
+ * humanized part is the *approach* — the value itself is set programmatically
+ * (firing `input`/`change` events) the same way Playwright does. For custom,
+ * DOM-rendered dropdowns, drive them with `click` + `click` on the rendered
+ * options instead.
+ *
+ * In `speed: 'instant'`, sets the value with no cursor motion.
+ *
+ * Returns the list of option values that ended up selected.
+ */
+export async function executeSelectOption(
+  target: FormTarget,
+  values: SelectOptionValues,
+  ctx: MouseContext,
+): Promise<string[]> {
+  const locator = toLocator(target, ctx);
+  if (ctx.speed !== 'instant') {
+    await executeHover(locator, ctx);
+  }
+  return locator.selectOption(values);
+}
+
+/**
+ * Humanized file upload. Moves the cursor to the upload control along a Bezier
+ * path (so the motion is visible in recordings / to the overlay), then sets the
+ * files via Playwright's `setInputFiles`.
+ *
+ * The OS file picker can't be driven by automation, so — unlike a real click —
+ * this never *clicks* the control (a click on `<input type="file">` would open
+ * the native dialog and hang). Files are attached directly, which is how
+ * Playwright models uploads. `target` should be the `<input type="file">`
+ * itself; for the common "hidden input behind a styled button" pattern there's
+ * no visible control to approach, so the cursor motion is skipped and the files
+ * are attached directly.
+ *
+ * In `speed: 'instant'`, attaches the files with no cursor motion.
+ */
+export async function executeUpload(
+  target: FormTarget,
+  files: UploadFiles,
+  ctx: MouseContext,
+): Promise<void> {
+  const locator = toLocator(target, ctx);
+  if (ctx.speed !== 'instant') {
+    try {
+      await executeHover(locator, ctx);
+    } catch {
+      // Hidden file input (no bounding box) — common when a styled button
+      // proxies a `display:none` input. No visible control to approach;
+      // attach the files directly.
+    }
+  }
+  await locator.setInputFiles(files);
+}

--- a/packages/playwright/src/forms/index.ts
+++ b/packages/playwright/src/forms/index.ts
@@ -104,7 +104,14 @@ export async function executeSelectOption(
 ): Promise<string[]> {
   const locator = toLocator(target, ctx);
   if (ctx.speed !== 'instant') {
-    await executeHover(locator, ctx);
+    try {
+      await executeHover(locator, ctx);
+    } catch {
+      // No visible control to approach (zero-box / not yet rendered). Don't
+      // surface a "Cannot hover" error for a selectOption call — fall through
+      // and let `selectOption` raise the authoritative error (or succeed via
+      // its own actionability) so the failure is attributed correctly.
+    }
   }
   return locator.selectOption(values);
 }

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -11,6 +11,13 @@ import {
   sleep,
 } from '@humanjs/core';
 import type { Locator, Page } from 'playwright';
+import {
+  executeSelectOption,
+  executeSetChecked,
+  executeUpload,
+  type SelectOptionValues,
+  type UploadFiles,
+} from './forms';
 import { executePaste, executePress, executeType, type KeyOrChord } from './keyboard';
 import { executeClick, executeDrag, executeHover, executeMove, type MouseTarget } from './mouse';
 import { executeRead, type ReadOptions, type ReadResult, type ReadTarget } from './reading';
@@ -86,6 +93,7 @@ export {
   type Page,
   webkit,
 } from 'playwright';
+export type { SelectOptionValues, UploadFiles } from './forms';
 export type { KeyModifier, KeyName, KeyOrChord, PressResult } from './keyboard';
 export type { MouseTarget } from './mouse';
 export type { InstallMouseHelperOptions } from './mouse-helper';
@@ -169,6 +177,17 @@ export interface Human {
    */
   rightClick(target: MouseTarget): Promise<void>;
   /**
+   * Double-click `target`. Identical humanized approach to `click()` — same
+   * Bezier path, hover dwell, and occasional near-miss — but the final
+   * dispatch is a double-click (two presses within the OS double-click
+   * window). Accepts the same selector / `Locator` / `Point` targets.
+   *
+   * In `speed: 'instant'`, element targets fall back to
+   * `locator.click({ clickCount: 2 })`; a `Point` dispatches
+   * `mouse.click(x, y, { clickCount: 2 })`.
+   */
+  doubleClick(target: MouseTarget): Promise<void>;
+  /**
    * Move the cursor to `target` along a humanized Bezier path and settle
    * on it — no click is dispatched. Useful for hover-triggered UI
    * (tooltips, dropdowns), for positioning the cursor before a non-target
@@ -234,6 +253,57 @@ export interface Human {
    * by nature.
    */
   paste(target: Locator | string, value: string): Promise<void>;
+  /**
+   * Tick a checkbox or radio `target`. Moves the cursor to the control and
+   * clicks it with the same humanized motion as `click()` — but only when
+   * needed: if it already reports checked, no click fires (a real user
+   * doesn't re-click a box that's already ticked). The resulting state is
+   * verified; trying to `check` something that won't toggle throws.
+   *
+   * `target` is element-bound (selector or `Locator`). In `speed: 'instant'`,
+   * delegates to Playwright's native `locator.check()`.
+   */
+  check(target: Locator | string): Promise<void>;
+  /**
+   * Untick a checkbox `target`. Mirror of `check()` — humanized click only if
+   * currently checked, with state verification afterward. Radios can't be
+   * unchecked by clicking (select a different option instead); attempting it
+   * throws a clear error.
+   *
+   * In `speed: 'instant'`, delegates to `locator.uncheck()`.
+   */
+  uncheck(target: Locator | string): Promise<void>;
+  /**
+   * Choose option(s) in a native `<select>` `target`. The cursor moves to the
+   * dropdown and settles on it (humanized), then the value is set — native
+   * selects open an OS menu automation can't drive visually, so the *approach*
+   * is humanized while the choice itself is set programmatically (firing
+   * `input`/`change`), exactly as Playwright does. For custom DOM dropdowns,
+   * drive the rendered options with `click` instead.
+   *
+   * `values` takes the Playwright `selectOption` shape — a value string, an
+   * array of values, or `{ value | label | index }`. Returns the option
+   * values that ended up selected.
+   *
+   * In `speed: 'instant'`, sets the value with no cursor motion.
+   */
+  selectOption(target: Locator | string, values: SelectOptionValues): Promise<string[]>;
+  /**
+   * Attach file(s) to a file-input `target`. The cursor moves to the control
+   * (visible in recordings / the overlay), then the files are attached via
+   * `setInputFiles`. Unlike a real click this never opens the OS file dialog
+   * (which would hang) — files are set directly, the way Playwright models
+   * uploads.
+   *
+   * `target` should be the `<input type="file">`. For the common hidden-input-
+   * behind-a-styled-button pattern there's no visible control to approach, so
+   * the motion is skipped and the files are attached directly. `files` takes
+   * the Playwright `setInputFiles` shape (a path, an array of paths, or
+   * in-memory `{ name, mimeType, buffer }` payloads).
+   *
+   * In `speed: 'instant'`, attaches the files with no cursor motion.
+   */
+  upload(target: Locator | string, files: UploadFiles): Promise<void>;
   /**
    * Press a single key (`'Tab'`, `'Enter'`, `'Escape'`, `'ArrowDown'`, …)
    * or a keyboard chord (`'Mod+S'`, `'Cmd+Shift+P'`, `'Ctrl+C'`, …).
@@ -678,6 +748,12 @@ export async function createHuman(page: Page, options: CreateHumanOptions = {}):
         await executeClick(target, mouseCtx(), { button: 'right' });
       });
     },
+    async doubleClick(target) {
+      const description = describeMouseTarget(target);
+      await performAction({ type: 'doubleClick', params: { target: description } }, async () => {
+        await executeClick(target, mouseCtx(), { clickCount: 2 });
+      });
+    },
     async hover(target) {
       const description = describeMouseTarget(target);
       await performAction({ type: 'hover', params: { target: description } }, async () => {
@@ -741,6 +817,39 @@ export async function createHuman(page: Page, options: CreateHumanOptions = {}):
           await executePaste(target, value, { page, personality, rng, speed });
         },
         inputValue !== undefined ? { inputValue } : undefined,
+      );
+    },
+    async check(target) {
+      await performAction(
+        { type: 'check', params: { target: describeMouseTarget(target) } },
+        async () => {
+          await executeSetChecked(target, mouseCtx(), true);
+        },
+      );
+    },
+    async uncheck(target) {
+      await performAction(
+        { type: 'uncheck', params: { target: describeMouseTarget(target) } },
+        async () => {
+          await executeSetChecked(target, mouseCtx(), false);
+        },
+      );
+    },
+    async selectOption(target, values) {
+      return performAction(
+        { type: 'selectOption', params: { target: describeMouseTarget(target), values } },
+        () => executeSelectOption(target, values, mouseCtx()),
+      );
+    },
+    async upload(target, files) {
+      await performAction(
+        {
+          type: 'upload',
+          params: { target: describeMouseTarget(target), files: sanitizeUploadFiles(files) },
+        },
+        async () => {
+          await executeUpload(target, files, mouseCtx());
+        },
       );
     },
     async press(key) {
@@ -914,6 +1023,21 @@ export async function createHuman(page: Page, options: CreateHumanOptions = {}):
       return page.pdf(opts);
     },
   };
+}
+
+/**
+ * JSON-safe projection of upload files for the timeline / plugin params.
+ * Paths pass through; in-memory `{ name, mimeType, buffer }` payloads collapse
+ * to their `name` so a Buffer never bloats (or breaks) the serialized timeline.
+ */
+function sanitizeUploadFiles(files: UploadFiles): string | string[] {
+  const one = (f: unknown): string =>
+    typeof f === 'string'
+      ? f
+      : f && typeof f === 'object' && 'name' in f
+        ? String((f as { name: unknown }).name)
+        : 'file';
+  return Array.isArray(files) ? files.map(one) : one(files);
 }
 
 /**

--- a/packages/playwright/src/mouse/index.ts
+++ b/packages/playwright/src/mouse/index.ts
@@ -53,6 +53,13 @@ export interface ClickOptions {
    * context-menu click; `'middle'` is the wheel-button click (rarely used).
    */
   readonly button?: 'left' | 'right' | 'middle';
+  /**
+   * Number of clicks at the target. `2` dispatches a double-click (the two
+   * presses fire back-to-back within the OS double-click window). Defaults
+   * to `1`. The humanized approach motion (path + hover dwell) is identical
+   * regardless of count — only the final dispatch differs.
+   */
+  readonly clickCount?: 1 | 2;
 }
 
 /**
@@ -85,10 +92,14 @@ export async function executeClick(
   options: ClickOptions = {},
 ): Promise<ClickResult> {
   const button = options.button ?? 'left';
+  const clickCount = options.clickCount ?? 1;
+  // Only surface `clickCount` when it's a double-click — keeps the common
+  // single-click dispatch as `{ button }` (no behavioral change for clicks).
+  const clickOpts = clickCount > 1 ? { button, clickCount } : { button };
 
   if (ctx.speed === 'instant') {
     if (isPoint(target)) {
-      await ctx.page.mouse.click(target.x, target.y, { button });
+      await ctx.page.mouse.click(target.x, target.y, clickOpts);
       ctx.setMousePosition(target);
       return { target };
     }
@@ -98,7 +109,7 @@ export async function executeClick(
     // remove the element, after which `boundingBox()` returns null.
     const locator = typeof target === 'string' ? ctx.page.locator(target) : target;
     const box = await locator.boundingBox();
-    await locator.click({ button });
+    await locator.click(clickOpts);
     const center = box
       ? { x: box.x + box.width / 2, y: box.y + box.height / 2 }
       : ctx.getMousePosition();
@@ -128,7 +139,7 @@ export async function executeClick(
   // (page closed, target removed mid-flight), the next action still starts
   // from the correct mouse position.
   ctx.setMousePosition(targetPoint);
-  await ctx.page.mouse.click(targetPoint.x, targetPoint.y, { button });
+  await ctx.page.mouse.click(targetPoint.x, targetPoint.y, clickOpts);
 
   // Post-action dwell — a beat after the click before the next action.
   const postActionMs = computeDwellTime(

--- a/packages/playwright/src/recording/codegen.ts
+++ b/packages/playwright/src/recording/codegen.ts
@@ -41,6 +41,22 @@ function createHumanOptions(timeline: Timeline, ciSpeed = false): string {
   return `{\n${parts.join('\n')}\n  }`;
 }
 
+/** Render `selectOption` values (string / string[] / `{value|label|index}`) as a call arg. */
+function serializeSelectValues(values: unknown): string {
+  if (typeof values === 'string') return q(values);
+  if (Array.isArray(values)) {
+    return `[${values.map((v) => (typeof v === 'string' ? q(v) : JSON.stringify(v))).join(', ')}]`;
+  }
+  // Object form ({ value } / { label } / { index }) — JSON is valid JS here.
+  return JSON.stringify(values ?? '');
+}
+
+/** Render `upload` files (recorded as a path string or array of paths) as a call arg. */
+function serializeFiles(files: unknown): string {
+  if (Array.isArray(files)) return `[${files.map((f) => q(String(f))).join(', ')}]`;
+  return q(String(files ?? ''));
+}
+
 function emitScroll(target: unknown): string {
   const s = String(target ?? 'natural');
   if (s === 'natural') return "  await human.scroll('natural');";
@@ -75,10 +91,24 @@ function emitAction(e: TimelineEvent, opts: EmitOptions = {}): string {
     }
     case 'click':
     case 'rightClick':
+    case 'doubleClick':
     case 'hover':
     case 'move': {
       const { code, isPoint } = targetArg(p.target);
       return `  await human.${e.type}(${code});${isPoint ? POINT_COMMENT : ''}`;
+    }
+    case 'check':
+    case 'uncheck': {
+      const { code } = targetArg(p.target);
+      return `  await human.${e.type}(${code});`;
+    }
+    case 'selectOption': {
+      const { code } = targetArg(p.target);
+      return `  await human.selectOption(${code}, ${serializeSelectValues(p.values)});`;
+    }
+    case 'upload': {
+      const { code } = targetArg(p.target);
+      return `  await human.upload(${code}, ${serializeFiles(p.files)});`;
     }
     case 'drag': {
       const from = targetArg(p.from);

--- a/packages/skill/templates/skill-body.md
+++ b/packages/skill/templates/skill-body.md
@@ -86,11 +86,15 @@ All await; selectors are strings or Playwright `Locator`s (`move`/`drag` also ac
 | `human.goto(url)` | Navigate. |
 | `human.click(target)` | Hover → micro-move → click. Occasional near-miss + recovery. |
 | `human.rightClick(target)` | Context-menu click. |
+| `human.doubleClick(target)` | Same motion as click; double-click dispatch. |
 | `human.hover(target)` | Hover and settle (no click). |
 | `human.move(target)` | Positional move, no dwell. |
 | `human.drag(from, to)` | Humanized drag; endpoints are selector / Locator / Point. |
 | `human.type(target, value)` | Click to focus, then realistic typing rhythm (+ optional typos/backspace). |
 | `human.paste(target, value)` | Cmd-V style insert — no per-char timing. |
+| `human.check(target)` / `human.uncheck(target)` | Tick/untick a checkbox or radio — clicks only if the state needs to change. |
+| `human.selectOption(target, values)` | Choose option(s) in a native `<select>` (cursor moves to it, then sets the value). |
+| `human.upload(target, files)` | Attach file(s) to a file input (no OS dialog). |
 | `human.press(key)` | Single key (`'Tab'`) or chord (`'Mod+S'` — `Mod` = Meta on macOS, Control elsewhere). |
 | `human.read(target)` | Dwell based on word count. |
 | `human.scroll('natural')` | Humanized scroll; also `{ by }` / `{ to }` / a selector. |


### PR DESCRIPTION
## What & why

Real flows — forms, checkout, settings — hit checkboxes, dropdowns, double-clicks, and file inputs. Until now those weren't in `@humanjs/playwright`, so anyone running a real flow had to drop back to raw Playwright exactly where the humanization matters. This closes that gap.

## New primitives (`@humanjs/playwright`)

- **`human.doubleClick(target)`** — same humanized approach as `click()` (Bezier path, hover dwell, near-miss), double-click dispatch. Reuses `executeClick` via a `clickCount` option; the single-click path is unchanged.
- **`human.check(target)` / `human.uncheck(target)`** — tick/untick a checkbox or radio. Clicks **only when the state needs to change** (a real user doesn't re-click a ticked box) and verifies the result. Tolerates non-checkable `<label>`/`role` targets (toggles without verifying). Radios can't be unchecked by clicking → clear error.
- **`human.selectOption(target, values)`** — native `<select>`: cursor moves to the dropdown, then the value is set (firing `input`/`change`). Returns the selected values.
- **`human.upload(target, files)`** — file input: cursor moves to the control, then `setInputFiles`. Never opens the OS dialog (would hang); tolerates hidden inputs behind styled buttons.

## Parity (the "mirror the MCP surface" rule)

- **MCP**: `human_doubleClick`, `human_check`, `human_uncheck`, `human_selectOption`, `human_upload`.
- **Recorder codegen**: all five export via `toPlaywright` / `toHumanJS`.
- **Skill**: added to the primitives reference in `skill-body.md`.
- **Core**: matching `KnownActionType` entries so plugins observe them.
- Docs: `CLAUDE.md` API shape + README quick-start.

## Tests

Colocated `forms/forms.test.ts` covers humanized + instant paths, the idempotency guard (no click when already in state), state verification (throws when a toggle doesn't take), hidden-input tolerance for upload, and the `clickCount: 2` dispatch for doubleClick. Full gate green: lint, typecheck (9/9), tests (222+), build, `check:exports` (publint, 11/11).

## Changeset

`minor` for `@humanjs/{playwright,mcp,core}`, `patch` for `@humanjs/skill`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)