### PR TITLE
feat(playwright): page perception for AI agents — human.outline() + human_outline MCP tool

### DIFF
--- a/.changeset/page-outline.md
+++ b/.changeset/page-outline.md
@@ -1,0 +1,11 @@
+---
+"@humanjs/playwright": minor
+"@humanjs/mcp": minor
+"@humanjs/skill": patch
+---
+
+Add page perception for AI agents: `human.outline(target?)` returns the page's accessibility-tree outline (every interactive element and landmark by ARIA role + accessible name, as compact YAML — Playwright's `ariaSnapshot`). It's the token-efficient way for an agent to see what's actionable and pick a selector: the names map directly to `getByRole` / accessible-name selectors, which HumanJS already favors. Pass a `target` to scope it to a region.
+
+Exposed over MCP as **`human_outline`** (inspection tool, alongside `human_page_text` / `human_get_html`), and documented in the `@humanjs/skill` selector-strategy guide.
+
+`@humanjs/playwright`'s `playwright` peer dependency floor moves from `>=1.40.0` to `>=1.49.0` — the version where `ariaSnapshot` landed.

--- a/.github/workflows/playwright-compat.yml
+++ b/.github/workflows/playwright-compat.yml
@@ -20,7 +20,10 @@ jobs:
         playwright:
           # Floor: the minimum version our peerDependency promises to support.
           # If a test fails here, either fix the code or raise the peer range.
-          - "1.40.0"
+          # Bumped 1.40 -> 1.49 when human.outline() adopted `ariaSnapshot`
+          # (added in Playwright 1.49); kept in sync with @humanjs/playwright's
+          # peerDependencies range.
+          - "1.49.0"
           # Current latest, to catch regressions on new releases.
           - "latest"
     steps:

--- a/packages/mcp/src/tools/inspection.ts
+++ b/packages/mcp/src/tools/inspection.ts
@@ -86,6 +86,27 @@ export function registerInspectionTools(server: McpServer, ctx: ToolContext): vo
   );
 
   server.registerTool(
+    'human_outline',
+    {
+      title: 'Page outline (accessibility tree)',
+      description:
+        'Returns a compact accessibility-tree outline of the page (or a region) — every interactive element and landmark by its ARIA role + accessible name, as YAML (e.g. `- button "Sign in"`, `- textbox "Email"`). The most token-efficient way to see what is actionable and pick a selector: the names map directly to getByRole / accessible-name selectors. Prefer this over human_get_html for "what can I click or fill"; use human_screenshot when you need the visual layout.',
+      inputSchema: {
+        selector: z
+          .string()
+          .optional()
+          .describe('Optional region selector to scope the outline. Omit for the whole page.'),
+        session: sessionArg,
+      },
+    },
+    async ({ selector, session }) => {
+      const { human } = await ctx.sessions.get(session);
+      const text = await human.outline(selector);
+      return { content: [{ type: 'text', text }] };
+    },
+  );
+
+  server.registerTool(
     'human_get_text',
     {
       title: "Get an element's text",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -67,7 +67,7 @@
     "ffmpeg-static": "^5.2.0"
   },
   "peerDependencies": {
-    "playwright": ">=1.40.0"
+    "playwright": ">=1.49.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/playwright/src/index.test.ts
+++ b/packages/playwright/src/index.test.ts
@@ -1653,3 +1653,43 @@ describe('createHuman', () => {
     });
   });
 });
+
+describe('human.outline', () => {
+  function makeOutlinePage(snapshot = '- button "Sign in"'): {
+    page: Page;
+    locator: { ariaSnapshot: ReturnType<typeof vi.fn> };
+    locatorFn: ReturnType<typeof vi.fn>;
+  } {
+    const locator = { ariaSnapshot: vi.fn().mockResolvedValue(snapshot) };
+    const locatorFn = vi.fn().mockReturnValue(locator);
+    const page = { locator: locatorFn } as unknown as Page;
+    return { page, locator, locatorFn };
+  }
+
+  it('returns the body aria snapshot by default', async () => {
+    const { page, locator, locatorFn } = makeOutlinePage('- heading "Welcome"');
+    const human = await createHuman(page, { speed: 'instant' });
+    const out = await human.outline();
+    expect(locatorFn).toHaveBeenCalledWith('body');
+    expect(locator.ariaSnapshot).toHaveBeenCalledTimes(1);
+    expect(out).toBe('- heading "Welcome"');
+  });
+
+  it('scopes to a selector when given', async () => {
+    const { page, locatorFn } = makeOutlinePage();
+    const human = await createHuman(page, { speed: 'instant' });
+    await human.outline('#form');
+    expect(locatorFn).toHaveBeenCalledWith('#form');
+  });
+
+  it('does not fire plugin actions (inspection only)', async () => {
+    const { page } = makeOutlinePage();
+    const before = vi.fn();
+    const human = await createHuman(page, {
+      speed: 'instant',
+      plugins: [{ name: 't', beforeAction: before }],
+    });
+    await human.outline();
+    expect(before).not.toHaveBeenCalled();
+  });
+});

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -470,6 +470,22 @@ export interface Human {
    */
   content(): Promise<string>;
   /**
+   * Accessibility-tree **outline** of the page (or a region) — every
+   * interactive element and landmark by its ARIA role + accessible name,
+   * rendered as compact YAML (Playwright's `ariaSnapshot`). The most
+   * token-efficient way for an AI agent to see what's actionable and pick a
+   * selector: the names map directly to `getByRole` / accessible-name
+   * selectors, which HumanJS already favors.
+   *
+   * Prefer this over {@link Human.content} when the question is "what can I
+   * click / fill"; reach for {@link Human.screenshot} when you need the
+   * visual layout. Pass `target` to scope the outline to a region.
+   *
+   * Not a humanized action: no plugin events fire. Requires Playwright ≥ 1.49
+   * (when `ariaSnapshot` landed).
+   */
+  outline(target?: Locator | string): Promise<string>;
+  /**
    * Current URL of the page. Forwards to `page.url()`. Synchronous return
    * because Playwright's underlying API is sync.
    *
@@ -988,6 +1004,15 @@ export async function createHuman(page: Page, options: CreateHumanOptions = {}):
     },
     content() {
       return page.content();
+    },
+    outline(target) {
+      const locator =
+        target === undefined
+          ? page.locator('body')
+          : typeof target === 'string'
+            ? page.locator(target)
+            : target;
+      return locator.ariaSnapshot();
     },
     url() {
       return page.url();

--- a/packages/skill/templates/skill-body.md
+++ b/packages/skill/templates/skill-body.md
@@ -37,6 +37,8 @@ await human.type('Card number', '4242…');      // by label
 await human.click('button.checkout');          // CSS fallback when needed
 ```
 
+Not sure what's on the page? `await human.outline()` returns the accessibility-tree outline (every element by ARIA role + accessible name, as YAML) — a compact, selector-friendly view of what's actionable. The names it shows are exactly what you pass to the role/label selectors above. Pass a selector to scope it to a region. (Requires Playwright ≥ 1.49.)
+
 ## Personalities
 
 ```ts


### PR DESCRIPTION
## What & why

We've got the *action* half of the agent loop solid (click/type/form/etc.). This adds the *perception* half: a compact, structured view of what's on the page so an agent can decide **what** to act on and **how to select it** — without dumping raw HTML or spending tokens reasoning over a screenshot.

`human.outline()` returns the page's **accessibility-tree outline** (Playwright's `ariaSnapshot`): every interactive element and landmark by ARIA role + accessible name, as compact YAML —

```
- heading "Welcome back" [level=1]
- textbox "Email"
- textbox "Password"
- button "Sign in"
- link "Forgot password?"
```

Those names map **directly** to the `getByRole` / accessible-name selectors HumanJS already favors, so it doubles as a selector finder. Pass a `target` to scope it to a region.

## Surface

- **`@humanjs/playwright`**: `human.outline(target?)` — inspection getter (no plugin events; sibling to `pageText()` / `content()`).
- **`@humanjs/mcp`**: `human_outline` inspection tool, alongside `human_page_text` / `human_get_html`. Description steers agents to prefer it over HTML for "what can I click/fill".
- **`@humanjs/skill`**: added to the selector-strategy guide.

## Naming

Called it `outline` (not `snapshot`) deliberately — `human.snapshot()` / `human_snapshot` sits one letter from the existing `screenshot` and would be easy for an agent to confuse.

## Compatibility

`ariaSnapshot` landed in Playwright 1.49, so `@humanjs/playwright`'s `playwright` peer floor moves `>=1.40.0` → `>=1.49.0`. Dev/CI already run 1.60.

## Tests

3 colocated tests: default body outline, region scoping, and "no plugin events fire" (inspection-only). Gate green: lint · typecheck 9/9 · tests 8/8 · check:exports (publint) 11/11.

## Changeset

`minor` for `@humanjs/playwright` + `@humanjs/mcp`, `patch` for `@humanjs/skill`.