### PR TITLE
feat(playwright): human.clear() — humanized field clearing + human_clear MCP tool

### DIFF
--- a/.changeset/human-clear.md
+++ b/.changeset/human-clear.md
@@ -1,0 +1,10 @@
+---
+"@humanjs/playwright": minor
+"@humanjs/mcp": minor
+"@humanjs/core": minor
+"@humanjs/skill": patch
+---
+
+Add `human.clear(target)` — clears a text field (input / textarea / contenteditable) with a real humanized keyboard gesture: click to focus, **select-all**, a beat, then **delete**, firing the `input` events the page expects. Pair it with `type()` to replace an existing value rather than append to it. In `speed: 'instant'` it delegates to Playwright's native `locator.clear()`.
+
+Mirrored as the **`human_clear`** MCP tool, exported by the recorder code generators (`toPlaywright` / `toHumanJS`), documented in the `@humanjs/skill` primitives table, and backed by a new `'clear'` `KnownActionType` in `@humanjs/core`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ await human.move(target);                 // selector | Locator | Point — posi
 await human.drag(from, to);               // each endpoint: selector | Locator | Point
 await human.type(selector, value);        // click, then realistic typing rhythm
 await human.paste(selector, value);       // Cmd-V style (no per-char timing)
+await human.clear(selector);              // wipe a field: select-all + delete (pair with type to replace)
 await human.check(selector);              // tick a checkbox/radio (clicks only if needed)
 await human.uncheck(selector);            // untick a checkbox
 await human.selectOption(selector, value);// native <select> — cursor moves to it, then sets value

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -60,6 +60,7 @@ export interface PluginContext {
  */
 export type KnownActionType =
   | 'check'
+  | 'clear'
   | 'click'
   | 'doubleClick'
   | 'drag'

--- a/packages/mcp/src/tools/primitives.ts
+++ b/packages/mcp/src/tools/primitives.ts
@@ -205,6 +205,24 @@ export function registerPrimitiveTools(server: McpServer, { sessions, env }: Too
   );
 
   server.registerTool(
+    'human_clear',
+    {
+      title: 'Clear a field (humanized)',
+      description:
+        'Clears a text field (input/textarea/contenteditable) with a real keyboard gesture — click to focus, select-all, then delete — firing the input events the page expects. Use before human_type when you need to replace an existing value rather than append to it.',
+      inputSchema: {
+        selector: z.string().describe('Selector of the field to clear.'),
+        session: sessionArg,
+      },
+    },
+    async ({ selector, session }) => {
+      const { human } = await sessions.get(session);
+      await human.clear(selector);
+      return { content: [{ type: 'text', text: `cleared ${selector}` }] };
+    },
+  );
+
+  server.registerTool(
     'human_check',
     {
       title: 'Check a box (humanized)',

--- a/packages/playwright/src/index.test.ts
+++ b/packages/playwright/src/index.test.ts
@@ -1693,3 +1693,52 @@ describe('human.outline', () => {
     expect(before).not.toHaveBeenCalled();
   });
 });
+
+describe('human.clear', () => {
+  function makeClearPage() {
+    const locator = {
+      boundingBox: vi.fn().mockResolvedValue({ x: 100, y: 200, width: 120, height: 30 }),
+      scrollIntoViewIfNeeded: vi.fn().mockResolvedValue(undefined),
+      focus: vi.fn().mockResolvedValue(undefined),
+      clear: vi.fn().mockResolvedValue(undefined),
+      click: vi.fn().mockResolvedValue(undefined),
+    };
+    const press = vi.fn().mockResolvedValue(undefined);
+    const mouseClick = vi.fn().mockResolvedValue(undefined);
+    const page = {
+      locator: vi.fn(() => locator),
+      evaluate: vi.fn().mockResolvedValue(0),
+      keyboard: { press, insertText: vi.fn().mockResolvedValue(undefined) },
+      mouse: {
+        move: vi.fn().mockResolvedValue(undefined),
+        click: mouseClick,
+        wheel: vi.fn().mockResolvedValue(undefined),
+        down: vi.fn().mockResolvedValue(undefined),
+        up: vi.fn().mockResolvedValue(undefined),
+      },
+      viewportSize: () => ({ width: 1280, height: 720 }),
+    } as unknown as Page;
+    return { page, locator, press, mouseClick };
+  }
+
+  it('focuses, selects all, then deletes (humanized gesture)', async () => {
+    const { page, locator, press, mouseClick } = makeClearPage();
+    const human = await createHuman(page, { speed: 'fast' });
+    await human.clear('#name');
+    expect(mouseClick).toHaveBeenCalledTimes(1); // implicit focus click
+    expect(locator.focus).toHaveBeenCalled();
+    const chords = press.mock.calls.map((c) => c[0]);
+    expect(chords[0]).toMatch(/^(Meta|Control)\+A$/); // platform select-all
+    expect(chords[chords.length - 1]).toBe('Delete');
+    expect(locator.clear).not.toHaveBeenCalled();
+  });
+
+  it('instant mode uses native locator.clear() with no gesture', async () => {
+    const { page, locator, press, mouseClick } = makeClearPage();
+    const human = await createHuman(page, { speed: 'instant' });
+    await human.clear('#name');
+    expect(locator.clear).toHaveBeenCalledTimes(1);
+    expect(press).not.toHaveBeenCalled();
+    expect(mouseClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -18,7 +18,7 @@ import {
   type SelectOptionValues,
   type UploadFiles,
 } from './forms';
-import { executePaste, executePress, executeType, type KeyOrChord } from './keyboard';
+import { executeClear, executePaste, executePress, executeType, type KeyOrChord } from './keyboard';
 import { executeClick, executeDrag, executeHover, executeMove, type MouseTarget } from './mouse';
 import { executeRead, type ReadOptions, type ReadResult, type ReadTarget } from './reading';
 import {
@@ -253,6 +253,19 @@ export interface Human {
    * by nature.
    */
   paste(target: Locator | string, value: string): Promise<void>;
+  /**
+   * Clear a text field `target` (input, textarea, or contenteditable) with a
+   * humanized gesture: click to focus, **select-all**, a beat, then **delete**
+   * — the real keyboard motion a person uses to wipe a field before retyping,
+   * not a silent value reset. Fires the keydown/up + `input` events the page
+   * expects.
+   *
+   * Pair with `type()` to edit an existing value:
+   * `await human.clear('#name'); await human.type('#name', 'New');`
+   *
+   * In `speed: 'instant'`, delegates to Playwright's native `locator.clear()`.
+   */
+  clear(target: Locator | string): Promise<void>;
   /**
    * Tick a checkbox or radio `target`. Moves the cursor to the control and
    * clicks it with the same humanized motion as `click()` — but only when
@@ -833,6 +846,20 @@ export async function createHuman(page: Page, options: CreateHumanOptions = {}):
           await executePaste(target, value, { page, personality, rng, speed });
         },
         inputValue !== undefined ? { inputValue } : undefined,
+      );
+    },
+    async clear(target) {
+      await performAction(
+        { type: 'clear', params: { target: describeMouseTarget(target) } },
+        async () => {
+          // Implicit click to focus the field first — same pattern as type/paste
+          // (a real user clicks into a field before wiping it). Skipped in
+          // instant mode, where executeClear uses native locator.clear().
+          if (speed !== 'instant') {
+            await executeClick(target, mouseCtx());
+          }
+          await executeClear(target, { page, personality, rng, speed });
+        },
       );
     },
     async check(target) {

--- a/packages/playwright/src/keyboard/index.ts
+++ b/packages/playwright/src/keyboard/index.ts
@@ -1,7 +1,7 @@
 import { type Personality, planTypeKeystrokes, type Rng } from '@humanjs/core';
 import type { Locator, Page } from 'playwright';
 import type { Speed } from '../index';
-import { sleep, speedModeFactor } from '../internal/timing';
+import { computeDwellTime, sleep, speedModeFactor } from '../internal/timing';
 
 /** Runtime dependencies for a humanized keyboard action. */
 export interface KeyboardContext {
@@ -120,6 +120,45 @@ export async function executePaste(
   await locator.focus();
   await ctx.page.keyboard.insertText(value);
   return { characters: value.length };
+}
+
+/**
+ * Clears a text field the way a person does: select-all, a beat, then delete —
+ * a real keyboard gesture, not a programmatic value reset. The implicit click
+ * that focuses the field is driven by the caller (`human.clear` in the
+ * factory), same pattern as `executeType` / `executePaste`, so this executor
+ * is keyboard-only.
+ *
+ * The select-all chord is platform-aware (`Meta+A` on macOS, `Control+A`
+ * elsewhere) via the same resolver `human.press` uses, then `Delete` clears the
+ * selection. Works for inputs, textareas, and contenteditable.
+ *
+ * In `speed: 'instant'`, delegates to Playwright's native `locator.clear()`
+ * (focus + actionability + value reset) — no visible gesture, same as the rest
+ * of instant mode.
+ */
+export async function executeClear(target: Locator | string, ctx: KeyboardContext): Promise<void> {
+  const locator = typeof target === 'string' ? ctx.page.locator(target) : target;
+
+  if (ctx.speed === 'instant') {
+    await locator.clear();
+    return;
+  }
+
+  await locator.focus();
+  // Select all, then delete the selection — the human "wipe the field" gesture.
+  await ctx.page.keyboard.press(resolveChord('Mod+A'));
+  // A short beat so the selection visibly registers before it's deleted,
+  // scaled by personality + speed like the other humanized dwells.
+  const beatMs = computeDwellTime(
+    ctx.personality.dwell.preClickMs,
+    ctx.personality.dwell.preClickJitter,
+    ctx.personality,
+    ctx.speed,
+    ctx.rng,
+  );
+  if (beatMs > 0) await sleep(beatMs);
+  await ctx.page.keyboard.press('Delete');
 }
 
 /**

--- a/packages/playwright/src/recording/codegen.ts
+++ b/packages/playwright/src/recording/codegen.ts
@@ -98,7 +98,8 @@ function emitAction(e: TimelineEvent, opts: EmitOptions = {}): string {
       return `  await human.${e.type}(${code});${isPoint ? POINT_COMMENT : ''}`;
     }
     case 'check':
-    case 'uncheck': {
+    case 'uncheck':
+    case 'clear': {
       const { code } = targetArg(p.target);
       return `  await human.${e.type}(${code});`;
     }

--- a/packages/skill/templates/skill-body.md
+++ b/packages/skill/templates/skill-body.md
@@ -94,6 +94,7 @@ All await; selectors are strings or Playwright `Locator`s (`move`/`drag` also ac
 | `human.drag(from, to)` | Humanized drag; endpoints are selector / Locator / Point. |
 | `human.type(target, value)` | Click to focus, then realistic typing rhythm (+ optional typos/backspace). |
 | `human.paste(target, value)` | Cmd-V style insert — no per-char timing. |
+| `human.clear(target)` | Wipe a field — select-all + delete. Use before `type` to replace a value. |
 | `human.check(target)` / `human.uncheck(target)` | Tick/untick a checkbox or radio — clicks only if the state needs to change. |
 | `human.selectOption(target, values)` | Choose option(s) in a native `<select>` (cursor moves to it, then sets the value). |
 | `human.upload(target, files)` | Attach file(s) to a file input (no OS dialog). |


### PR DESCRIPTION
## What & why

Step 2 of the form-interaction work. Real flows don't just fill *empty* fields — they **edit existing values** (settings pages, "change your email", correcting a typo'd form). Until now you'd have to drop to raw Playwright (`locator.clear()` / `fill('')`) for that. `human.clear()` closes it.

## Behavior

A real keyboard gesture, not a silent value reset:
1. **Click to focus** (humanized, same implicit-click as `type`/`paste`)
2. **Select-all** — platform-aware `Mod+A` (`Meta+A` on macOS, `Control+A` elsewhere), via the same resolver `human.press` uses
3. a short personality/speed-scaled **beat** (so the selection visibly registers)
4. **Delete**

Fires the `keydown`/`up` + `input` events the page expects (validation, "dirty" state, etc.). Works for inputs, textareas, and contenteditable.

```ts
await human.clear('#email');
await human.type('#email', 'new@example.com');   // replace, don't append
```

In `speed: 'instant'`, delegates to Playwright's native `locator.clear()` — no visible gesture, consistent with the rest of instant mode.

## Surface (full parity)

- **`@humanjs/playwright`**: `human.clear(target)` (executor in the keyboard module, beside `type`/`paste`).
- **`@humanjs/mcp`**: `human_clear` tool.
- **Recorder codegen**: exports via `toPlaywright` / `toHumanJS`.
- **`@humanjs/core`**: new `'clear'` `KnownActionType`.
- **Skill** + **CLAUDE.md** API shape updated.

## Tests

Colocated tests cover the humanized gesture (focus click → select-all chord → Delete, no native clear) and the instant path (native `locator.clear()`, no gesture/motion). Gate green: lint · typecheck 9/9 · tests 8/8 · check:exports (publint) 11/11.

## Changeset

`minor` for `@humanjs/playwright` + `@humanjs/mcp` + `@humanjs/core`, `patch` for `@humanjs/skill`.