### PR TITLE
chore(web): bump landing version refs to playwright v0.8 / core 0.7.0

### DIFF
--- a/apps/web/components/sections/Hero.tsx
+++ b/apps/web/components/sections/Hero.tsx
@@ -62,7 +62,7 @@ export function Hero() {
           animate={shouldReduceMotion ? undefined : 'visible'}
           className="mb-8 font-mono text-[11px] uppercase tracking-[0.32em] text-muted"
         >
-          <span className="text-accent">v0.6</span>
+          <span className="text-accent">v0.8</span>
           <span aria-hidden className="mx-3 text-muted/40">
             /
           </span>

--- a/apps/web/components/sections/HonestLimits.tsx
+++ b/apps/web/components/sections/HonestLimits.tsx
@@ -57,7 +57,7 @@ export function HonestLimits() {
                 <span aria-hidden className="mx-2 text-muted/40">
                   ·
                 </span>
-                latest <span className="text-accent">v0.6</span>
+                latest <span className="text-accent">v0.8</span>
               </p>
             </ScrollReveal>
           </div>

--- a/apps/web/components/sections/TrustStrip.tsx
+++ b/apps/web/components/sections/TrustStrip.tsx
@@ -12,13 +12,13 @@ interface Signal {
 const signals: Signal[] = [
   {
     label: 'Latest',
-    value: '@humanjs/core@0.6.0',
+    value: '@humanjs/core@0.7.0',
     href: 'https://www.npmjs.com/package/@humanjs/core',
     iconKind: 'external',
   },
   {
     label: 'Built on',
-    value: 'Playwright 1.40+',
+    value: 'Playwright 1.49+',
     href: 'https://playwright.dev',
     iconKind: 'external',
   },


### PR DESCRIPTION
Release-hygiene follow-up to the v0.8 release (#34 — form primitives, \`clear\`, \`outline\`, the \`@humanjs/playwright/test\` fixture).

Updates the hard-coded version references on the landing so they match what's now published on npm:

- **Hero.tsx** — eyebrow \`v0.6\` → \`v0.8\` (flagship \`@humanjs/playwright\`)
- **HonestLimits.tsx** — \`latest v0.6\` → \`latest v0.8\`
- **TrustStrip.tsx** — \`Latest\` pill \`@humanjs/core@0.6.0\` → \`@humanjs/core@0.7.0\`
- **TrustStrip.tsx** — \`Built on\` signal \`Playwright 1.40+\` → \`Playwright 1.49+\` (the \`outline\`/\`ariaSnapshot\` change raised the peer floor to 1.49.0, so the old claim was stale)

Durable phrasing kept (\`latest vX.Y\`, one version anchor per surface). README \`toPlaywright\` references already describe it as shipped — no README changes needed. No changeset: \`apps/web\` is private.

Verified: the release-hygiene grep now returns only the current values, and \`@humanjs/web\` lint + typecheck pass.