### PR TITLE
chore(deps): bump playwright + @playwright/test to 1.61.1 (and group them)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,14 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     groups:
+      # playwright (prod dep) and @playwright/test (dev dep) MUST bump together:
+      # @humanjs/playwright's test fixture bridges both, and a version skew makes
+      # their playwright-core Page types incompatible (typecheck fails). Listed
+      # first so @playwright/test joins this group, not dev-dependencies.
+      playwright:
+        patterns:
+          - "playwright"
+          - "@playwright/*"
       dev-dependencies:
         dependency-type: development
         update-types:

--- a/examples/package.json
+++ b/examples/package.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "@humanjs/playwright": "workspace:*",
     "@humanjs/recorder": "workspace:*",
-    "playwright": "^1.60.0"
+    "playwright": "^1.61.1"
   }
 }

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@humanjs/core": "workspace:*",
     "@humanjs/playwright": "workspace:*",
-    "playwright": "^1.60.0",
+    "playwright": "^1.61.1",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -71,7 +71,7 @@
     "@humanjs/playwright": "workspace:*",
     "@humanjs/recorder": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "playwright": "^1.60.0",
+    "playwright": "^1.61.1",
     "zod": "^4.4.3"
   },
   "publishConfig": {

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -89,7 +89,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@playwright/test": "^1.60.0",
-    "playwright": "^1.60.0"
+    "@playwright/test": "^1.61.1",
+    "playwright": "^1.61.1"
   }
 }

--- a/packages/recorder/package.json
+++ b/packages/recorder/package.json
@@ -70,7 +70,7 @@
     "playwright": ">=1.40.0"
   },
   "devDependencies": {
-    "playwright": "^1.60.0"
+    "playwright": "^1.61.1"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,10 +52,10 @@ importers:
         version: link:../../packages/core
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.9(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.1(next@16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.9(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.0(next@16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -67,7 +67,7 @@ importers:
         version: 1.21.0(react@19.2.7)
       next:
         specifier: ^16.2.9
-        version: 16.2.9(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -106,8 +106,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/recorder
       playwright:
-        specifier: ^1.60.0
-        version: 1.60.0
+        specifier: ^1.61.1
+        version: 1.61.1
 
   packages/core: {}
 
@@ -120,8 +120,8 @@ importers:
         specifier: workspace:*
         version: link:../playwright
       playwright:
-        specifier: ^1.60.0
-        version: 1.60.0
+        specifier: ^1.61.1
+        version: 1.61.1
       ws:
         specifier: ^8.18.0
         version: 8.21.0
@@ -169,8 +169,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
       playwright:
-        specifier: ^1.60.0
-        version: 1.60.0
+        specifier: ^1.61.1
+        version: 1.61.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -185,11 +185,11 @@ importers:
         version: 5.3.0
     devDependencies:
       '@playwright/test':
-        specifier: ^1.60.0
-        version: 1.60.0
+        specifier: ^1.61.1
+        version: 1.61.1
       playwright:
-        specifier: ^1.60.0
-        version: 1.60.0
+        specifier: ^1.61.1
+        version: 1.61.1
 
   packages/recorder:
     dependencies:
@@ -198,8 +198,8 @@ importers:
         version: link:../playwright
     devDependencies:
       playwright:
-        specifier: ^1.60.0
-        version: 1.60.0
+        specifier: ^1.61.1
+        version: 1.61.1
 
   packages/skill:
     devDependencies:
@@ -1237,8 +1237,8 @@ packages:
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
 
-  '@playwright/test@1.60.0':
-    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2719,13 +2719,13 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
-  playwright-core@1.60.0:
-    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.60.0:
-    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4201,9 +4201,9 @@ snapshots:
 
   '@oxc-project/types@0.130.0': {}
 
-  '@playwright/test@1.60.0':
+  '@playwright/test@1.61.1':
     dependencies:
-      playwright: 1.60.0
+      playwright: 1.61.1
 
   '@publint/pack@0.1.4': {}
 
@@ -4491,14 +4491,14 @@ snapshots:
     dependencies:
       '@types/node': 25.9.1
 
-  '@vercel/analytics@2.0.1(next@16.2.9(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@vercel/analytics@2.0.1(next@16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     optionalDependencies:
-      next: 16.2.9(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
 
-  '@vercel/speed-insights@2.0.0(next@16.2.9(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@vercel/speed-insights@2.0.0(next@16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     optionalDependencies:
-      next: 16.2.9(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3))':
@@ -5382,7 +5382,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next@16.2.9(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -5401,7 +5401,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.9
       '@next/swc-win32-arm64-msvc': 16.2.9
       '@next/swc-win32-x64-msvc': 16.2.9
-      '@playwright/test': 1.60.0
+      '@playwright/test': 1.61.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -5490,11 +5490,11 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  playwright-core@1.60.0: {}
+  playwright-core@1.61.1: {}
 
-  playwright@1.60.0:
+  playwright@1.61.1:
     dependencies:
-      playwright-core: 1.60.0
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
Adopts **playwright 1.61.1** the right way — bumping `playwright` and `@playwright/test` **together** — and fixes the dependabot config so they can never split again. Supersedes **#72** and **#73**.

## The problem (diagnosed from #72/#73's red CI)
`@humanjs/playwright`'s test fixture (`src/test/index.ts`) feeds `@playwright/test`'s `page` into `createHuman` (typed by `playwright`). Both resolve `playwright-core`'s `Page` — but only line up when the two are the **same version**. Dependabot split the pair:
- **#72** bumped `playwright` only → left `@playwright/test` at 1.60.0
- **#73**'s dev-deps group bumped `@playwright/test` only → left `playwright` at 1.60.0

Either half-bump leaves **two `playwright-core` versions** in the tree → incompatible `Page` types → `typecheck` fails (exactly what both PRs hit).

## The fix
- **(a)** Bump `playwright` + `@playwright/test` → `^1.61.1` together across every package that pins them (peer ranges `>=1.49.0` / `>=1.40.0` stay wide). One `playwright-core@1.61.1` → typecheck clean.
- **(b)** Add a dependabot `playwright` group (listed first) so `playwright` + `@playwright/*` always travel in one PR. The old config grouped only `dependency-type: development`, which is *why* the prod `playwright` and dev `@playwright/test` split.

## Verified
Reproduced #72's exact failure (checked out its tree, frozen install → the `Page` mismatch), then confirmed the combined bump is green: **single `playwright-core@1.61.1`**, typecheck 8/8, lint, tests (236 + 40 + 43), build.

## Notes
- **No changeset** — follows the repo's dependabot-bump convention (dep bumps ride into the next feature release; the published `playwright` floor in generator/mcp updates then).
- After this lands, **#72 and #73 can be closed** (dependabot will auto-close them on its next run once the deps are already current).
