### PR TITLE
fix(release): pass NPM_TOKEN to changesets, and point the landing at v0.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,5 +46,17 @@ jobs:
           title: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Two different consumers read the npm credential, under two different
+          # names, and both are required:
+          #   NODE_AUTH_TOKEN -> the .npmrc that actions/setup-node writes.
+          #   NPM_TOKEN       -> changesets/action's own check. Without it the
+          #                      action logs "No NPM_TOKEN found" and silently
+          #                      falls back to OIDC trusted publishing, which
+          #                      fails with an opaque E404 if npm has no trusted
+          #                      publisher configured for these packages.
+          # The secret must be a classic *Automation* token (or a granular token
+          # with read-write on @humanjs/*). A classic "Publish" token does not
+          # bypass 2FA and dies in CI with EOTP.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"

--- a/apps/web/components/sections/Hero.tsx
+++ b/apps/web/components/sections/Hero.tsx
@@ -62,7 +62,7 @@ export function Hero() {
           animate={shouldReduceMotion ? undefined : 'visible'}
           className="mb-8 font-mono text-[11px] uppercase tracking-[0.32em] text-muted"
         >
-          <span className="text-accent">v0.10</span>
+          <span className="text-accent">v0.11</span>
           <span aria-hidden className="mx-3 text-muted/40">
             /
           </span>

--- a/apps/web/components/sections/HonestLimits.tsx
+++ b/apps/web/components/sections/HonestLimits.tsx
@@ -57,7 +57,7 @@ export function HonestLimits() {
                 <span aria-hidden className="mx-2 text-muted/40">
                   ·
                 </span>
-                latest <span className="text-accent">v0.10</span>
+                latest <span className="text-accent">v0.11</span>
               </p>
             </ScrollReveal>
           </div>


### PR DESCRIPTION
The #80 release never published. `main` says `@humanjs/playwright@0.11.0`; npm still serves `0.10.0`. Same for recorder (0.3.4 vs 0.3.3), mcp (0.4.2 vs 0.4.1) and generator (0.3.0 vs 0.2.0). No git tags and no GitHub releases were created for the new versions either — the run died before the tagging step.

### Two separate problems

**1. The workflow never passed the credential under the name changesets reads.** `changesets/action` checks the `NPM_TOKEN` environment variable. `release.yml` only set `NODE_AUTH_TOKEN`, which is what the `.npmrc` written by `actions/setup-node` consumes. So every run — including the successful ones back in June, which were no-ops with nothing to publish — logged:

```
No NPM_TOKEN found, but OIDC is available - using npm trusted publishing
```

and quietly took the OIDC path instead. With no trusted publisher configured on npm for these packages, that surfaces as a bare `E404 Not Found - PUT`, which is why the first failure looked like the package didn't exist. Fixed here by passing the secret under both names, with a comment so the next person does not have to re-derive it.

**2. The token is the wrong type.** The re-run (attempt 2, after the secret was updated) got a *different* error — and that is the useful part:

```
EOTP This operation requires a one-time password from your authenticator.
```

`EOTP` means npm authenticated the token fine, but the account requires 2FA for write actions and this token type does not bypass it. That is the signature of a classic **Publish** token. CI needs a classic **Automation** token, or a granular access token with read-write on `@humanjs/*`. This part cannot be fixed in the repo.

### Why the landing change rides along

`CLAUDE.md` requires the landing version pills to move in the same cycle as the release. They are held in this PR on purpose: merging it triggers `Release` on `main`, so `v0.11` goes live at the same moment npm actually serves 0.11.0 — rather than claiming a version that is not published yet.

`TrustStrip.tsx` is deliberately untouched: it pins `@humanjs/core@0.8.0`, and core is not part of this release.