### PR TITLE
feat(mcp): observability, media emulation, and multi-match reads

### DIFF
--- a/.changeset/mcp-observability-and-media.md
+++ b/.changeset/mcp-observability-and-media.md
@@ -1,0 +1,13 @@
+---
+"@humanjs/mcp": minor
+---
+
+Add observability and media-emulation tools, and let the read tools sweep every match.
+
+`human_console_messages` and `human_network_requests` expose what the page reports about itself — console output, uncaught errors, response statuses, and requests that failed before responding. Neither a screenshot nor page text shows a CORS rejection or a 404 on an asset, so until now the only recourse was guessing, or checking with `curl` from outside the browser where the failure does not reproduce. Capture starts with the session, buffers hold the last 500 entries, and the number dropped is always reported so a quiet result is never mistaken for a clean page.
+
+`human_emulate_media` emulates `prefers-reduced-motion`, `prefers-color-scheme` and `forced-colors`. The reduced-motion path is otherwise untestable without changing OS settings, so it tends to ship unverified.
+
+`human_get_text`, `human_get_attribute` and `human_get_html` accept `all: true` to read every element a selector matches instead of only the first, with `limit` bounding the response. Extracting every image source on a page is now one call.
+
+`human_screenshot` now returns a line of text alongside the image. An image-only result was rendered as "Tool ran without output or errors" by clients that summarize from text content, which read as a failure even though the capture had succeeded.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -125,9 +125,21 @@ Click / rightClick / move / drag take a **selector or raw x/y coordinates** — 
 |---|---|
 | `human_screenshot` | Capture the page/element; returns the image to view, optionally saves it |
 | `human_page_text` | Visible text of the whole page |
-| `human_get_text` | Visible text of one element |
-| `human_get_attribute` | An element's attribute (`aria-label`, `href`, …) |
+| `human_outline` | Accessibility-tree outline — every interactive element by role + name |
+| `human_get_text` | Visible text of one element, or of every match with `all` |
+| `human_get_attribute` | An element's attribute (`aria-label`, `href`, …), or every match's with `all` |
 | `human_get_html` | An element's `outerHTML` — discover the real selector of a control |
+
+`human_get_text`, `human_get_attribute` and `human_get_html` read the first match by default. Pass `all: true` to sweep every match instead — every image `src`, every row label, every link `href` — with `limit` capping how many come back. Prefer `human_get_attribute` with `all` over `human_get_html` when you only need one attribute per element: same answer, a fraction of the tokens.
+
+**Observability** — what the page said about itself:
+
+| Tool | What it does |
+|---|---|
+| `human_console_messages` | Console output and uncaught page errors, filterable by regex or `onlyErrors` |
+| `human_network_requests` | Responses with method/URL/status/timing; `onlyFailures` covers 4xx/5xx *and* requests that never completed |
+
+Both start capturing when the session opens, so you can act first and ask afterwards — there is no "start capturing" call to forget. These are the only way to see a CORS rejection, a 404 on an asset, or a thrown `TypeError`: none of them appear in a screenshot or in page text. Buffers hold the last 500 entries and report how many were dropped, so a quiet result is never mistaken for a clean page. Pass `clear: true` to reset before an action and see only what that action caused.
 
 **Recording** — capture the session:
 
@@ -151,6 +163,9 @@ Click / rightClick / move / drag take a **selector or raw x/y coordinates** — 
 | `human_set_personality` | Switch preset or blend two presets at runtime |
 | `human_set_speed` | Switch humanization pace at runtime (`human` / `fast` / `instant`) |
 | `human_set_viewport` | Resize the viewport at runtime (bigger/crisper recording, responsive testing) |
+| `human_emulate_media` | Emulate `prefers-reduced-motion`, `prefers-color-scheme` and `forced-colors` |
+
+`human_emulate_media` is what makes accessibility paths testable. `reducedMotion: 'reduce'` is normally impossible to check without changing OS settings, so a site's reduced-motion path tends to ship unverified; here it is one call. Same for dark mode and Windows High Contrast. Settings persist across navigations until changed — pass `'system'` to stop emulating.
 
 **Browser:**
 
@@ -231,7 +246,7 @@ The server ships **built-in guidance** (sent to the agent on connect via MCP `in
 
 ## Security
 
-- **No arbitrary-JS `evaluate` tool.** Executing page-supplied JavaScript is a prompt-injection cliff — a malicious page could trick the agent into running code that exfiltrates data. The read-only inspection tools cover the legitimate "what's on the page" need.
+- **No arbitrary-JS `evaluate` tool.** Executing page-supplied JavaScript is a prompt-injection cliff — a malicious page could trick the agent into running code that exfiltrates data. The read-only inspection and observability tools cover the legitimate need instead: `human_get_attribute`/`human_get_text` with `all` sweep every match, `human_outline` maps what is actionable, and `human_console_messages`/`human_network_requests` expose what the page reported. Their internal `locator.evaluate` calls run fixed, hard-coded functions — never a string supplied by the model or the page.
 - **File-path safety.** Tools that write files accept a basename only; path components (`../`, absolute paths) are rejected, so a prompt-injected filename can't escape `HUMANJS_OUTPUT_DIR`.
 - **Upload path safety.** `human_upload` can attach a local file to a web form — a potential exfiltration path if a page prompt-injects the agent. So it reads files by **basename only** from `HUMANJS_UPLOAD_DIR` (default: the server's working dir); subdirectories, `../`, and absolute paths are rejected, so the agent can't reach (and send) files outside that folder. Point `HUMANJS_UPLOAD_DIR` at where your upload fixtures live.
 - **No credentials handling.** The server drives the browser; it doesn't manage logins, payment details, or secrets on your behalf.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -32,6 +32,7 @@ import { SessionManager } from './session';
 import { registerBrowserTools } from './tools/browser';
 import { registerConfigTools } from './tools/config';
 import { registerInspectionTools } from './tools/inspection';
+import { registerObservabilityTools } from './tools/observability';
 import { registerPrimitiveTools } from './tools/primitives';
 import { registerRecordingTools } from './tools/recording';
 import { registerSessionTools } from './tools/sessions';
@@ -57,6 +58,12 @@ Export as a test: human_stop_recording picks format by extension. A .spec.ts (or
 
 Captured input + passwords: typed/pasted text IS recorded into the timeline and code exports, so generated scripts/tests are runnable — EXCEPT password fields, which are always masked (emitted as an empty string with a "fill in" comment). This is intentional, not a bug; don't work around it by hand-editing the secret back in. If the user explicitly wants the flow to log in, edit the exported file to read the credential from an env var (e.g. process.env.APP_PASSWORD) and tell them to set it — never hardcode a real password into a file that may be committed.
 
+When something looks wrong and the screenshot doesn't explain it, read human_console_messages (onlyErrors: true) and human_network_requests (onlyFailures: true) before guessing. A CORS rejection, a 404 on an image, or an uncaught TypeError appears in neither the screenshot nor the page text — those two tools are the only place it shows up. Capture is always on, so you can act first and check afterwards. Do NOT reach for curl to debug a page: a request made outside the browser carries none of its origin, cookies, or headers, so the failure you are chasing won't reproduce.
+
+Accessibility and theming: human_emulate_media sets prefers-reduced-motion, prefers-color-scheme and forced-colors. Use reducedMotion: 'reduce' to verify a reduced-motion path — it is otherwise untestable without changing OS settings.
+
+Reading many elements at once: human_get_text, human_get_attribute and human_get_html take all: true to return every match instead of the first. For "every image source" or "every link target", human_get_attribute with all is far cheaper than dumping HTML.
+
 Dynamic UI: prefer specific selectors (role, aria-label) over text — the same visible text often matches several cards before a filter, or the wrong one after. If a click reports multiple matches, narrow the selector.
 
 Browser state: by default each run is a fresh, signed-out browser. If a flow needs a login, tell the user to enable persistence (human_enable_persistence or HUMANJS_PERSIST) or CDP attach — see human_browser_info.`;
@@ -73,6 +80,7 @@ async function main(): Promise<void> {
 
   registerPrimitiveTools(server, ctx);
   registerInspectionTools(server, ctx);
+  registerObservabilityTools(server, ctx);
   registerRecordingTools(server, ctx);
   registerSessionTools(server, ctx);
   registerConfigTools(server, ctx);

--- a/packages/mcp/src/observability.test.ts
+++ b/packages/mcp/src/observability.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type ConsoleEntry,
+  compilePattern,
+  formatConsole,
+  formatNetwork,
+  isFailure,
+  type NetworkEntry,
+  queryConsole,
+  queryNetwork,
+  RingBuffer,
+} from './observability';
+
+function consoleEntry(over: Partial<ConsoleEntry> = {}): ConsoleEntry {
+  return { level: 'log', text: 'hello', source: null, at: 0, ...over };
+}
+
+function networkEntry(over: Partial<NetworkEntry> = {}): NetworkEntry {
+  return {
+    method: 'GET',
+    url: 'https://example.com/a.png',
+    status: 200,
+    failure: null,
+    resourceType: 'image',
+    at: 0,
+    ms: 12,
+    ...over,
+  };
+}
+
+function fill<T>(limit: number, items: readonly T[]): RingBuffer<T> {
+  const buffer = new RingBuffer<T>(limit);
+  for (const item of items) buffer.push(item);
+  return buffer;
+}
+
+describe('RingBuffer', () => {
+  it('keeps every entry while under the limit', () => {
+    const buffer = fill(3, [1, 2]);
+    expect(buffer.toArray()).toEqual([1, 2]);
+    expect(buffer.dropped).toBe(0);
+    expect(buffer.size).toBe(2);
+  });
+
+  it('evicts the oldest entries once full and counts the drops', () => {
+    const buffer = fill(3, [1, 2, 3, 4, 5]);
+    expect(buffer.toArray()).toEqual([3, 4, 5]);
+    expect(buffer.dropped).toBe(2);
+    expect(buffer.size).toBe(3);
+  });
+
+  it('resets both entries and the drop count on clear', () => {
+    const buffer = fill(2, [1, 2, 3]);
+    buffer.clear();
+    expect(buffer.toArray()).toEqual([]);
+    expect(buffer.dropped).toBe(0);
+  });
+
+  it('rejects a nonsensical limit rather than silently misbehaving', () => {
+    expect(() => new RingBuffer(0)).toThrow(/limit must be >= 1/);
+  });
+});
+
+describe('compilePattern', () => {
+  it('matches case-insensitively', () => {
+    expect(compilePattern('cors').test('Blocked by CORS policy')).toBe(true);
+  });
+
+  it('explains how to fix a malformed pattern', () => {
+    expect(() => compilePattern('[unclosed')).toThrow(/Invalid `pattern`/);
+  });
+});
+
+describe('queryConsole', () => {
+  const buffer = fill(10, [
+    consoleEntry({ level: 'log', text: 'boot' }),
+    consoleEntry({ level: 'warn', text: 'deprecated api' }),
+    consoleEntry({ level: 'error', text: 'CORS blocked for logo.png' }),
+    consoleEntry({ level: 'pageerror', text: 'TypeError: x is not a function' }),
+  ]);
+
+  it('returns everything when unfiltered', () => {
+    const result = queryConsole(buffer, {});
+    expect(result.entries).toHaveLength(4);
+    expect(result.total).toBe(4);
+  });
+
+  it('treats uncaught page errors as errors, not just console.error', () => {
+    const result = queryConsole(buffer, { onlyErrors: true });
+    expect(result.entries.map((e) => e.level)).toEqual(['error', 'pageerror']);
+  });
+
+  it('filters by pattern against the message text', () => {
+    const result = queryConsole(buffer, { pattern: 'cors' });
+    expect(result.entries).toHaveLength(1);
+    expect(result.matched).toBe(1);
+    expect(result.total).toBe(4);
+  });
+
+  it('keeps the most recent entries when limiting, not the oldest', () => {
+    const result = queryConsole(buffer, { limit: 2 });
+    expect(result.entries.map((e) => e.level)).toEqual(['error', 'pageerror']);
+    expect(result.matched).toBe(4);
+  });
+});
+
+describe('queryNetwork', () => {
+  const buffer = fill(10, [
+    networkEntry({ url: 'https://example.com/ok.png', status: 200 }),
+    networkEntry({ url: 'https://cdn.example.com/missing.png', status: 404 }),
+    networkEntry({ url: 'https://api.example.com/data', status: null, failure: 'net::ERR_FAILED' }),
+  ]);
+
+  it('counts both 4xx/5xx and never-responded requests as failures', () => {
+    const result = queryNetwork(buffer, { onlyFailures: true });
+    expect(result.entries).toHaveLength(2);
+  });
+
+  it('filters by exact status', () => {
+    const result = queryNetwork(buffer, { status: 404 });
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]?.url).toContain('missing.png');
+  });
+
+  it('filters by pattern against the URL', () => {
+    const result = queryNetwork(buffer, { pattern: 'cdn\\.' });
+    expect(result.entries).toHaveLength(1);
+  });
+});
+
+describe('isFailure', () => {
+  it.each([
+    [networkEntry({ status: 200 }), false],
+    [networkEntry({ status: 302 }), false],
+    [networkEntry({ status: 404 }), true],
+    [networkEntry({ status: 500 }), true],
+    [networkEntry({ status: null, failure: 'net::ERR_ABORTED' }), true],
+  ])('classifies %o as failure=%s', (entry, expected) => {
+    expect(isFailure(entry)).toBe(expected);
+  });
+});
+
+describe('formatting', () => {
+  it('distinguishes an empty buffer from a filter that matched nothing', () => {
+    const empty = new RingBuffer<ConsoleEntry>(5);
+    expect(formatConsole(queryConsole(empty, {}))).toMatch(/No console messages captured yet/);
+
+    const populated = fill(5, [consoleEntry({ text: 'boot' })]);
+    expect(formatConsole(queryConsole(populated, { pattern: 'nope' }))).toMatch(
+      /No console messages matched the filter \(1 in the buffer\)/,
+    );
+  });
+
+  it('warns that dropped entries make a negative result inconclusive', () => {
+    const overflowed = fill(1, [consoleEntry({ text: 'a' }), consoleEntry({ text: 'b' })]);
+    const text = formatConsole(queryConsole(overflowed, { pattern: 'zzz' }));
+    expect(text).toMatch(/not proof they never happened/);
+  });
+
+  it('renders a console entry with its level and source', () => {
+    const buffer = fill(5, [consoleEntry({ level: 'error', text: 'boom', source: 'app.js:10:5' })]);
+    const text = formatConsole(queryConsole(buffer, {}));
+    expect(text).toContain('[error] boom  (app.js:10:5)');
+    expect(text).toContain('1 matching message of 1 captured');
+  });
+
+  it('renders a failed request without pretending it had a status', () => {
+    const buffer = fill(5, [networkEntry({ status: null, failure: 'net::ERR_FAILED', ms: null })]);
+    const text = formatNetwork(queryNetwork(buffer, {}));
+    expect(text).toContain('FAILED (net::ERR_FAILED) GET');
+    expect(text).not.toContain('null');
+  });
+
+  it('says when it is showing only the most recent slice', () => {
+    const buffer = fill(10, [
+      networkEntry({ url: 'https://a.test/1' }),
+      networkEntry({ url: 'https://a.test/2' }),
+      networkEntry({ url: 'https://a.test/3' }),
+    ]);
+    const text = formatNetwork(queryNetwork(buffer, { limit: 2 }));
+    expect(text).toContain('showing the 2 most recent of 3 matching requests');
+  });
+});

--- a/packages/mcp/src/observability.ts
+++ b/packages/mcp/src/observability.ts
@@ -1,0 +1,320 @@
+/**
+ * Per-session observability buffers — console messages and network activity.
+ *
+ * An agent driving the browser is otherwise blind to everything the page
+ * reports about itself: a failed image, a CORS rejection, an uncaught
+ * error. Screenshots don't show it and page text doesn't contain it, so
+ * without these the only recourse is guessing, or reaching for `curl`
+ * outside the browser — which doesn't reproduce the browser's own request
+ * context and so misses exactly the failures worth seeing.
+ *
+ * Both buffers are bounded ring buffers: a long session on a chatty page
+ * must not grow without limit. When the cap is hit the oldest entries are
+ * dropped and the drop count is reported alongside the results, because
+ * "no errors found" and "no errors left in the buffer" are very different
+ * answers and an agent must be able to tell them apart.
+ *
+ * These are read-only observers. They never execute page-supplied code —
+ * see the note at the top of `tools/inspection.ts`.
+ */
+
+import type { Page } from 'playwright';
+
+/** A console message, or an uncaught page error (level `'pageerror'`). */
+export interface ConsoleEntry {
+  /** Console type: `log`, `info`, `warn`, `error`, `debug`, … or `pageerror`. */
+  readonly level: string;
+  readonly text: string;
+  /** Source location (`file:line:col`) when the browser reports one. */
+  readonly source: string | null;
+  /** Epoch ms. */
+  readonly at: number;
+}
+
+/** A completed network response, or a request that failed before responding. */
+export interface NetworkEntry {
+  readonly method: string;
+  readonly url: string;
+  /** HTTP status, or `null` when the request failed before a response. */
+  readonly status: number | null;
+  /** Playwright's failure text (DNS, CORS, aborted, …), else `null`. */
+  readonly failure: string | null;
+  /** Playwright resource type: `document`, `xhr`, `fetch`, `image`, … */
+  readonly resourceType: string;
+  /** Epoch ms the response/failure was observed. */
+  readonly at: number;
+  /** Round-trip in ms, when the request start was observed. */
+  readonly ms: number | null;
+}
+
+/**
+ * Fixed-capacity FIFO buffer. Oldest entries fall off the front once the
+ * cap is reached; {@link dropped} counts how many were lost so callers can
+ * say so instead of silently under-reporting.
+ */
+export class RingBuffer<T> {
+  private items: T[] = [];
+  private droppedCount = 0;
+
+  constructor(private readonly limit: number) {
+    if (limit < 1) throw new Error(`RingBuffer limit must be >= 1, got ${limit}`);
+  }
+
+  push(item: T): void {
+    this.items.push(item);
+    if (this.items.length > this.limit) {
+      this.items.shift();
+      this.droppedCount += 1;
+    }
+  }
+
+  toArray(): readonly T[] {
+    return this.items;
+  }
+
+  /** Entries evicted because the buffer was full. */
+  get dropped(): number {
+    return this.droppedCount;
+  }
+
+  get size(): number {
+    return this.items.length;
+  }
+
+  clear(): void {
+    this.items = [];
+    this.droppedCount = 0;
+  }
+}
+
+/** How many entries each buffer holds before evicting the oldest. */
+export const CONSOLE_BUFFER_LIMIT = 500;
+export const NETWORK_BUFFER_LIMIT = 500;
+
+/** Console levels treated as "problems" by `onlyErrors`. */
+const ERROR_LEVELS = new Set(['error', 'pageerror']);
+
+/**
+ * Compiles an AI-supplied filter pattern into a case-insensitive regex.
+ * A malformed pattern is a caller mistake, not a server fault, so it fails
+ * with a message that says how to fix it rather than a raw regex error.
+ */
+export function compilePattern(pattern: string): RegExp {
+  try {
+    return new RegExp(pattern, 'i');
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Invalid \`pattern\` regular expression: ${detail}. Pass a valid JS regex (it is matched case-insensitively), or omit \`pattern\` to see everything.`,
+    );
+  }
+}
+
+export interface ConsoleQuery {
+  readonly pattern?: string;
+  readonly onlyErrors?: boolean;
+  readonly limit?: number;
+}
+
+export interface NetworkQuery {
+  readonly pattern?: string;
+  readonly onlyFailures?: boolean;
+  /** Keep only responses with this exact HTTP status. */
+  readonly status?: number;
+  readonly limit?: number;
+}
+
+/** Result of a buffer query: the slice to show, plus what it was drawn from. */
+export interface QueryResult<T> {
+  readonly entries: readonly T[];
+  /** Entries matching the filter, before `limit` was applied. */
+  readonly matched: number;
+  /** Entries in the buffer before filtering. */
+  readonly total: number;
+  /** Entries evicted from the buffer entirely. */
+  readonly dropped: number;
+}
+
+export function queryConsole(
+  buffer: RingBuffer<ConsoleEntry>,
+  query: ConsoleQuery,
+): QueryResult<ConsoleEntry> {
+  const all = buffer.toArray();
+  const regex = query.pattern ? compilePattern(query.pattern) : null;
+  const matches = all.filter((entry) => {
+    if (query.onlyErrors && !ERROR_LEVELS.has(entry.level)) return false;
+    if (regex && !regex.test(entry.text)) return false;
+    return true;
+  });
+  return {
+    entries: takeLast(matches, query.limit),
+    matched: matches.length,
+    total: all.length,
+    dropped: buffer.dropped,
+  };
+}
+
+export function queryNetwork(
+  buffer: RingBuffer<NetworkEntry>,
+  query: NetworkQuery,
+): QueryResult<NetworkEntry> {
+  const all = buffer.toArray();
+  const regex = query.pattern ? compilePattern(query.pattern) : null;
+  const matches = all.filter((entry) => {
+    if (query.onlyFailures && !isFailure(entry)) return false;
+    if (query.status !== undefined && entry.status !== query.status) return false;
+    if (regex && !regex.test(entry.url)) return false;
+    return true;
+  });
+  return {
+    entries: takeLast(matches, query.limit),
+    matched: matches.length,
+    total: all.length,
+    dropped: buffer.dropped,
+  };
+}
+
+/** A request that never responded, or answered 4xx/5xx. */
+export function isFailure(entry: NetworkEntry): boolean {
+  if (entry.failure !== null) return true;
+  return entry.status !== null && entry.status >= 400;
+}
+
+/**
+ * The most recent `limit` entries. Recency is what matters when
+ * debugging — the failure you just triggered is at the end, not the start.
+ */
+function takeLast<T>(items: readonly T[], limit: number | undefined): readonly T[] {
+  if (limit === undefined || items.length <= limit) return items;
+  return items.slice(items.length - limit);
+}
+
+/**
+ * Renders a console query as compact text for the agent.
+ *
+ * The footer is not decoration: it distinguishes "the page logged nothing"
+ * from "the buffer overflowed and the evidence is gone", which changes what
+ * the agent should do next.
+ */
+export function formatConsole(result: QueryResult<ConsoleEntry>): string {
+  if (result.entries.length === 0) return emptyMessage('console messages', result);
+  const lines = result.entries.map((entry) => {
+    const where = entry.source ? `  (${entry.source})` : '';
+    return `[${entry.level}] ${entry.text}${where}`;
+  });
+  return [...lines, '', summary('message', result)].join('\n');
+}
+
+/** Renders a network query as compact text for the agent. */
+export function formatNetwork(result: QueryResult<NetworkEntry>): string {
+  if (result.entries.length === 0) return emptyMessage('network requests', result);
+  const lines = result.entries.map((entry) => {
+    const status = entry.failure !== null ? `FAILED (${entry.failure})` : String(entry.status);
+    const timing = entry.ms === null ? '' : ` ${entry.ms}ms`;
+    return `${status} ${entry.method} ${entry.url} [${entry.resourceType}]${timing}`;
+  });
+  return [...lines, '', summary('request', result)].join('\n');
+}
+
+function emptyMessage(noun: string, result: QueryResult<unknown>): string {
+  if (result.total === 0 && result.dropped === 0) {
+    return `No ${noun} captured yet for this session.`;
+  }
+  const dropped =
+    result.dropped > 0
+      ? ` ${result.dropped} older ${noun} were dropped from the buffer, so this is not proof they never happened.`
+      : '';
+  return `No ${noun} matched the filter (${result.total} in the buffer).${dropped}`;
+}
+
+function summary(noun: string, result: QueryResult<unknown>): string {
+  const shown =
+    result.entries.length < result.matched
+      ? `showing the ${result.entries.length} most recent of ${result.matched} matching ${noun}s`
+      : `${result.matched} matching ${noun}${result.matched === 1 ? '' : 's'}`;
+  const dropped = result.dropped > 0 ? `; ${result.dropped} older dropped (buffer full)` : '';
+  return `— ${shown} of ${result.total} captured${dropped}`;
+}
+
+/** The pair of buffers a session observes through. */
+export interface SessionObservers {
+  readonly console: RingBuffer<ConsoleEntry>;
+  readonly network: RingBuffer<NetworkEntry>;
+}
+
+/**
+ * Subscribes to a page's console and network events, filling bounded
+ * buffers the inspection tools read from later.
+ *
+ * Listeners are attached once per session page and live as long as it
+ * does, so events raised between tool calls — which is most of them — are
+ * still captured. Playwright keeps page listeners across navigations, so
+ * a `goto` does not silently stop the recording.
+ *
+ * Request start times live in a `WeakMap` keyed by the request object: it
+ * gives round-trip timing without an unbounded Map of requests that never
+ * completed, since entries vanish when the request is garbage collected.
+ */
+export function attachObservers(page: Page): SessionObservers {
+  const consoleBuffer = new RingBuffer<ConsoleEntry>(CONSOLE_BUFFER_LIMIT);
+  const networkBuffer = new RingBuffer<NetworkEntry>(NETWORK_BUFFER_LIMIT);
+  const startedAt = new WeakMap<object, number>();
+
+  page.on('console', (message) => {
+    const location = message.location();
+    const source = location.url
+      ? `${location.url}:${location.lineNumber}:${location.columnNumber}`
+      : null;
+    consoleBuffer.push({
+      level: message.type(),
+      text: message.text(),
+      source,
+      at: Date.now(),
+    });
+  });
+
+  // An uncaught exception never reaches page.on('console'), and it is the
+  // single most useful thing to surface — so it is folded into the same
+  // buffer under its own level rather than needing a separate tool.
+  page.on('pageerror', (error) => {
+    consoleBuffer.push({
+      level: 'pageerror',
+      text: error.stack ?? `${error.name}: ${error.message}`,
+      source: null,
+      at: Date.now(),
+    });
+  });
+
+  page.on('request', (request) => {
+    startedAt.set(request, Date.now());
+  });
+
+  page.on('response', (response) => {
+    const request = response.request();
+    const start = startedAt.get(request);
+    networkBuffer.push({
+      method: request.method(),
+      url: response.url(),
+      status: response.status(),
+      failure: null,
+      resourceType: request.resourceType(),
+      at: Date.now(),
+      ms: start === undefined ? null : Date.now() - start,
+    });
+  });
+
+  page.on('requestfailed', (request) => {
+    const start = startedAt.get(request);
+    networkBuffer.push({
+      method: request.method(),
+      url: request.url(),
+      status: null,
+      failure: request.failure()?.errorText ?? 'request failed',
+      resourceType: request.resourceType(),
+      at: Date.now(),
+      ms: start === undefined ? null : Date.now() - start,
+    });
+  });
+
+  return { console: consoleBuffer, network: networkBuffer };
+}

--- a/packages/mcp/src/session.test.ts
+++ b/packages/mcp/src/session.test.ts
@@ -3,7 +3,7 @@ import type { BrowserConfig, McpEnv } from './env';
 
 // Fakes + mock fns, hoisted so the vi.mock factories below can use them.
 const m = vi.hoisted(() => {
-  const fakePage = {};
+  const fakePage = { on: vi.fn() };
   const fakeContext = { newPage: vi.fn(), pages: vi.fn(), close: vi.fn() };
   const fakeBrowser = { newContext: vi.fn(), contexts: vi.fn(), close: vi.fn() };
   return {
@@ -170,5 +170,25 @@ describe('SessionManager — runtime persistence override', () => {
     const s = await mgr.get();
     expect(s.mode).toBe('persistent');
     expect(m.launchPersistentContext).toHaveBeenCalledWith('/runtime-profile', expect.any(Object));
+  });
+});
+
+describe('SessionManager — observability', () => {
+  it('gives every session its own console and network buffers', async () => {
+    const mgr = new SessionManager(makeEnv());
+    const session = await mgr.get();
+    expect(session.observers.console.size).toBe(0);
+    expect(session.observers.network.size).toBe(0);
+  });
+
+  it('subscribes to the page events the inspection tools read from', async () => {
+    const mgr = new SessionManager(makeEnv());
+    await mgr.get();
+    const events = m.fakePage.on.mock.calls.map((call) => call[0]);
+    // pageerror matters as much as console: an uncaught exception never
+    // arrives as a console message, and it is the most useful signal.
+    expect(events).toEqual(
+      expect.arrayContaining(['console', 'pageerror', 'request', 'response', 'requestfailed']),
+    );
   });
 });

--- a/packages/mcp/src/session.ts
+++ b/packages/mcp/src/session.ts
@@ -26,6 +26,7 @@ import {
 } from '@humanjs/playwright';
 import { type Browser, type BrowserContext, chromium, type Page } from 'playwright';
 import { type BrowserConfig, DEFAULT_PERSIST_DIR, type McpEnv } from './env';
+import { attachObservers, type SessionObservers } from './observability';
 
 export const DEFAULT_SESSION_ID = 'default';
 
@@ -79,6 +80,8 @@ interface InternalSession {
   /** The browser mode this session was created under (drives cleanup). */
   readonly mode: BrowserMode;
   recording: RecordingState | null;
+  /** Console + network buffers, filled by page listeners from creation on. */
+  readonly observers: SessionObservers;
   readonly createdAt: number;
 }
 
@@ -162,6 +165,10 @@ export class SessionManager {
     const personality = options.personality ?? this.env.personality;
     const speed = options.speed ?? this.env.speed;
     const human = await createHuman(page, { personality, speed });
+    // Attached before the session is handed out so the very first navigation
+    // a caller makes is already being observed — a console error thrown on
+    // the first page load is exactly the kind worth catching.
+    const observers = attachObservers(page);
 
     const session: InternalSession = {
       id,
@@ -172,6 +179,7 @@ export class SessionManager {
       speed,
       mode: config.mode,
       recording: null,
+      observers,
       createdAt: Date.now(),
     };
     this.sessions.set(id, session);

--- a/packages/mcp/src/tools/config.ts
+++ b/packages/mcp/src/tools/config.ts
@@ -1,8 +1,8 @@
 /**
  * Config tools — runtime tweaks to how a session behaves: personality
  * (env var sets the default, this changes it mid-session), humanization
- * speed, and viewport size (resize the live page for a bigger/crisper
- * recording or to test responsive layouts).
+ * speed, viewport size (resize the live page for a bigger/crisper
+ * recording or to test responsive layouts), and emulated media features.
  */
 
 import { blend } from '@humanjs/core';
@@ -11,6 +11,16 @@ import { z } from 'zod';
 import type { ToolContext } from '../context';
 
 const preset = z.enum(['careful', 'fast', 'distracted', 'precise']);
+
+/**
+ * Playwright resets an emulated media feature with `null`. `'system'` is
+ * the clearer word for an agent choosing a value, so it is translated here
+ * rather than exposing `null` in the tool schema.
+ */
+function toMediaValue<T extends string>(value: T | 'system' | undefined): T | null | undefined {
+  if (value === undefined) return undefined;
+  return value === 'system' ? null : value;
+}
 
 export function registerConfigTools(server: McpServer, { sessions }: ToolContext): void {
   server.registerTool(
@@ -91,6 +101,59 @@ export function registerConfigTools(server: McpServer, { sessions }: ToolContext
       const { human } = await sessions.get(session);
       await human.setViewportSize({ width, height });
       return { content: [{ type: 'text', text: `viewport set to ${width}×${height}` }] };
+    },
+  );
+  server.registerTool(
+    'human_emulate_media',
+    {
+      title: 'Emulate media features',
+      description:
+        "Emulates CSS media features for a session so you can verify the accessibility and theming paths a real user would get. `reducedMotion: 'reduce'` is the important one: it is the only way to check that a site's prefers-reduced-motion path actually works, and it is normally impossible to test without changing OS settings. Settings persist across navigations until changed; pass 'system' to stop emulating a feature.",
+      inputSchema: {
+        reducedMotion: z
+          .enum(['reduce', 'no-preference', 'system'])
+          .optional()
+          .describe(
+            "Emulate prefers-reduced-motion. Use 'reduce' to verify the reduced-motion path renders and stays usable.",
+          ),
+        colorScheme: z
+          .enum(['light', 'dark', 'no-preference', 'system'])
+          .optional()
+          .describe('Emulate prefers-color-scheme, to check the light and dark themes.'),
+        forcedColors: z
+          .enum(['active', 'none', 'system'])
+          .optional()
+          .describe(
+            "Emulate forced-colors (Windows High Contrast). 'active' reveals content that disappears when the author's colors are overridden.",
+          ),
+        session: z.string().optional().describe('Session ID. Omit for the default session.'),
+      },
+    },
+    async ({ reducedMotion, colorScheme, forcedColors, session }) => {
+      if (reducedMotion === undefined && colorScheme === undefined && forcedColors === undefined) {
+        throw new Error(
+          'Pass at least one of `reducedMotion`, `colorScheme` or `forcedColors`. Use "system" to stop emulating one.',
+        );
+      }
+      const { page } = await sessions.get(session);
+      await page.emulateMedia({
+        reducedMotion: toMediaValue(reducedMotion),
+        colorScheme: toMediaValue(colorScheme),
+        forcedColors: toMediaValue(forcedColors),
+      });
+      const applied = [
+        reducedMotion && `prefers-reduced-motion: ${reducedMotion}`,
+        colorScheme && `prefers-color-scheme: ${colorScheme}`,
+        forcedColors && `forced-colors: ${forcedColors}`,
+      ].filter(Boolean);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `emulating ${applied.join(', ')} — re-render or navigate if the page only reads these at load`,
+          },
+        ],
+      };
     },
   );
 }

--- a/packages/mcp/src/tools/inspection.ts
+++ b/packages/mcp/src/tools/inspection.ts
@@ -23,6 +23,33 @@ const sessionArg = z
   .optional()
   .describe('Session ID to act on. Omit to use the default session.');
 
+const allArg = z
+  .boolean()
+  .optional()
+  .describe(
+    'Read every element the selector matches instead of just the first. Use it to sweep a page — all image sources, all row labels, all link hrefs — in one call.',
+  );
+
+/** Caps a sweep so one call can't blow the agent's context window. */
+function matchLimitArg(fallback: number) {
+  return z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      `With \`all\`, the maximum number of matches to return (default ${fallback}). The total number found is always reported.`,
+    );
+}
+
+/** Footer telling the agent when it is looking at a truncated sweep. */
+function sweepSummary(shown: number, total: number, selector: string): string {
+  if (shown >= total) {
+    return `— ${total} element${total === 1 ? '' : 's'} matched ${selector}`;
+  }
+  return `— showing the first ${shown} of ${total} elements matching ${selector}; raise \`limit\` to see more`;
+}
+
 export function registerInspectionTools(server: McpServer, ctx: ToolContext): void {
   server.registerTool(
     'human_screenshot',
@@ -56,9 +83,17 @@ export function registerInspectionTools(server: McpServer, ctx: ToolContext): vo
         ? await page.locator(selector).screenshot()
         : await human.screenshot({ fullPage: fullPage ?? false });
 
+      // Always pair the image with a line of text. An image-only result is
+      // rendered as "Tool ran without output or errors" by MCP clients that
+      // key their summary off text content, which reads as a failure even
+      // though the capture succeeded.
+      const scope = selector ? `element ${selector}` : fullPage ? 'full page' : 'viewport';
       const content: Array<
         { type: 'image'; data: string; mimeType: string } | { type: 'text'; text: string }
-      > = [{ type: 'image', data: buffer.toString('base64'), mimeType: 'image/png' }];
+      > = [
+        { type: 'image', data: buffer.toString('base64'), mimeType: 'image/png' },
+        { type: 'text', text: `captured ${scope} of ${page.url()}` },
+      ];
 
       if (filename) {
         const path = resolveOutputPath(ctx.env.outputDir, filename);
@@ -111,15 +146,28 @@ export function registerInspectionTools(server: McpServer, ctx: ToolContext): vo
     {
       title: "Get an element's text",
       description:
-        'Returns the visible innerText of the first element matching `selector`. Use to read a specific label, price, status, or message.',
+        "Returns the visible innerText of the first element matching `selector` — a specific label, price, status, or message. Set `all` to read every match instead, e.g. every row's title in a table.",
       inputSchema: {
         selector: z.string().describe('Selector of the element to read.'),
+        all: allArg,
+        limit: matchLimitArg(100),
         session: sessionArg,
       },
     },
-    async ({ selector, session }) => {
+    async ({ selector, all, limit, session }) => {
       const { page } = await ctx.sessions.get(session);
-      const text = await page.locator(selector).innerText();
+      if (!all) {
+        const text = await page.locator(selector).first().innerText();
+        return { content: [{ type: 'text', text }] };
+      }
+      const elements = await page.locator(selector).all();
+      const shown = elements.slice(0, limit ?? 100);
+      const values = await Promise.all(shown.map((element) => element.innerText()));
+      const body = values.map((value, index) => `[${index}] ${value}`).join('\n');
+      const text =
+        elements.length === 0
+          ? `No elements matched ${selector}`
+          : `${body}\n\n${sweepSummary(shown.length, elements.length, selector)}`;
       return { content: [{ type: 'text', text }] };
     },
   );
@@ -129,18 +177,37 @@ export function registerInspectionTools(server: McpServer, ctx: ToolContext): vo
     {
       title: "Get an element's attribute",
       description:
-        "Returns the value of an attribute on the first element matching `selector` (or reports it is absent). Handy for reading aria-label, data-*, href, value, disabled state, etc. — often how you confirm an icon-only button's purpose.",
+        "Returns the value of an attribute on the first element matching `selector` (or reports it is absent). Handy for reading aria-label, data-*, href, value, disabled state, etc. — often how you confirm an icon-only button's purpose. Set `all` to collect the attribute across every match, which is the compact way to extract every image source or link target on a page.",
       inputSchema: {
         selector: z.string().describe('Selector of the element.'),
         attribute: z.string().describe('Attribute name, e.g. "aria-label", "href", "data-state".'),
+        all: allArg,
+        limit: matchLimitArg(100),
         session: sessionArg,
       },
     },
-    async ({ selector, attribute, session }) => {
+    async ({ selector, attribute, all, limit, session }) => {
       const { page } = await ctx.sessions.get(session);
-      const value = await page.locator(selector).getAttribute(attribute);
+      if (!all) {
+        const value = await page.locator(selector).first().getAttribute(attribute);
+        const text =
+          value === null
+            ? `${selector} has no attribute "${attribute}"`
+            : `${attribute}="${value}"`;
+        return { content: [{ type: 'text', text }] };
+      }
+      const elements = await page.locator(selector).all();
+      const shown = elements.slice(0, limit ?? 100);
+      const values = await Promise.all(shown.map((element) => element.getAttribute(attribute)));
+      // A missing attribute is reported per element rather than dropped:
+      // "which of these has no href" is usually the interesting answer.
+      const body = values
+        .map((value, index) => `[${index}] ${value === null ? '(absent)' : value}`)
+        .join('\n');
       const text =
-        value === null ? `${selector} has no attribute "${attribute}"` : `${attribute}="${value}"`;
+        elements.length === 0
+          ? `No elements matched ${selector}`
+          : `${body}\n\n${sweepSummary(shown.length, elements.length, selector)}`;
       return { content: [{ type: 'text', text }] };
     },
   );
@@ -150,18 +217,40 @@ export function registerInspectionTools(server: McpServer, ctx: ToolContext): vo
     {
       title: "Get an element's HTML",
       description:
-        'Returns the outerHTML of the first element matching `selector` — the element plus its children, including its own attributes (class, aria-label, etc.). The go-to tool for discovering the real selector of a control with no obvious text. Target a specific region; full-page HTML is large.',
+        'Returns the outerHTML of the first element matching `selector` — the element plus its children, including its own attributes (class, aria-label, etc.). The go-to tool for discovering the real selector of a control with no obvious text. Target a specific region; full-page HTML is large. Set `all` to dump every match, but prefer human_get_attribute with `all` when you only need one attribute from each — it returns the same information for a fraction of the tokens.',
       inputSchema: {
         selector: z.string().describe('Selector of the region to dump. Target narrowly.'),
+        all: allArg,
+        limit: matchLimitArg(10),
         session: sessionArg,
       },
     },
-    async ({ selector, session }) => {
+    async ({ selector, all, limit, session }) => {
       const { page } = await ctx.sessions.get(session);
       // Fixed function, not AI-supplied — outerHTML isn't a Playwright
-      // locator method, so we read it via a constrained evaluate.
-      const html = await page.locator(selector).evaluate((el) => el.outerHTML);
-      return { content: [{ type: 'text', text: html }] };
+      // locator method, so we read it via a constrained evaluate. Written
+      // inline at both call sites so Playwright infers the element type;
+      // the repo's tsconfig has no DOM lib to annotate it with.
+      if (!all) {
+        const html = await page
+          .locator(selector)
+          .first()
+          .evaluate((el) => el.outerHTML);
+        return { content: [{ type: 'text', text: html }] };
+      }
+      // Capped tighter than the other sweeps: a handful of outerHTML dumps
+      // is already a lot of tokens.
+      const elements = await page.locator(selector).all();
+      const shown = elements.slice(0, limit ?? 10);
+      const values: string[] = await Promise.all(
+        shown.map((element) => element.evaluate((el) => el.outerHTML)),
+      );
+      const body = values.map((value, index) => `[${index}] ${value}`).join('\n\n');
+      const text =
+        elements.length === 0
+          ? `No elements matched ${selector}`
+          : `${body}\n\n${sweepSummary(shown.length, elements.length, selector)}`;
+      return { content: [{ type: 'text', text }] };
     },
   );
 }

--- a/packages/mcp/src/tools/observability.ts
+++ b/packages/mcp/src/tools/observability.ts
@@ -1,0 +1,122 @@
+/**
+ * Observability tools — what the page said about itself.
+ *
+ * Screenshots and page text show what rendered; they say nothing about a
+ * CORS rejection, a 404 on an asset, or an uncaught TypeError that left a
+ * component half-mounted. These two tools close that gap, which otherwise
+ * pushes an agent into guessing or into checking with `curl` from outside
+ * the browser — where the request has none of the browser's origin,
+ * cookies, or headers, so the failure being investigated does not even
+ * reproduce.
+ *
+ * Buffers start filling when the session is created, so an agent can act
+ * first and ask afterwards; there is no "start capturing" call to forget.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { ToolContext } from '../context';
+import { formatConsole, formatNetwork, queryConsole, queryNetwork } from '../observability';
+
+const sessionArg = z
+  .string()
+  .optional()
+  .describe('Session ID to read from. Omit to use the default session.');
+
+const patternArg = z
+  .string()
+  .optional()
+  .describe(
+    'Case-insensitive regular expression to filter by. Omit to see everything. Use it to cut noise on chatty pages, e.g. "cors|refused" or "\\\\.png$".',
+  );
+
+/** Keeps a single response token-bounded on pages that log or fetch constantly. */
+const DEFAULT_LIMIT = 50;
+
+const limitArg = z
+  .number()
+  .int()
+  .positive()
+  .optional()
+  .describe(
+    `Maximum entries to return, most recent first-in-list-last (default ${DEFAULT_LIMIT}). The count of everything that matched is always reported, so you can tell when you are seeing a slice.`,
+  );
+
+const clearArg = z
+  .boolean()
+  .optional()
+  .describe(
+    'Empty the buffer after returning these entries. Use it to get a clean slate before an action, so the next call shows only what that action caused.',
+  );
+
+export function registerObservabilityTools(server: McpServer, { sessions }: ToolContext): void {
+  server.registerTool(
+    'human_console_messages',
+    {
+      title: 'Read the browser console',
+      description:
+        "Returns console output and uncaught page errors captured for this session, newest last. Capture starts when the session is created, so this covers everything since — including errors thrown during the first page load. The go-to tool when something looks wrong on the page but the screenshot doesn't explain why: CORS rejections, failed asset loads, and thrown exceptions all surface here and nowhere else.",
+      inputSchema: {
+        pattern: patternArg,
+        onlyErrors: z
+          .boolean()
+          .optional()
+          .describe(
+            'Keep only console.error output and uncaught page errors, dropping log/info/warn/debug.',
+          ),
+        limit: limitArg,
+        clear: clearArg,
+        session: sessionArg,
+      },
+    },
+    async ({ pattern, onlyErrors, limit, clear, session }) => {
+      const { observers } = await sessions.get(session);
+      const result = queryConsole(observers.console, {
+        pattern,
+        onlyErrors,
+        limit: limit ?? DEFAULT_LIMIT,
+      });
+      const text = formatConsole(result);
+      if (clear) observers.console.clear();
+      return { content: [{ type: 'text', text }] };
+    },
+  );
+
+  server.registerTool(
+    'human_network_requests',
+    {
+      title: 'Inspect network activity',
+      description:
+        'Returns network responses captured for this session, newest last, with method, URL, HTTP status and round-trip time. Requests that never got a response (DNS failure, blocked by CORS, aborted) are included with the browser\'s failure reason instead of a status. Use `onlyFailures` to answer "what broke?" in one call — it covers both 4xx/5xx responses and requests that never completed.',
+      inputSchema: {
+        pattern: patternArg,
+        onlyFailures: z
+          .boolean()
+          .optional()
+          .describe(
+            'Keep only 4xx/5xx responses and requests that failed before responding. The fastest way to find a broken asset or API call.',
+          ),
+        status: z
+          .number()
+          .int()
+          .optional()
+          .describe('Keep only responses with this exact HTTP status, e.g. 404 or 500.'),
+        limit: limitArg,
+        clear: clearArg,
+        session: sessionArg,
+      },
+    },
+    async ({ pattern, onlyFailures, status, limit, clear, session }) => {
+      const { observers } = await sessions.get(session);
+      const result = queryNetwork(observers.network, {
+        pattern,
+        onlyFailures,
+        status,
+        limit: limit ?? DEFAULT_LIMIT,
+      });
+      const text = formatNetwork(result);
+      if (clear) observers.network.clear();
+      return { content: [{ type: 'text', text }] };
+    },
+  );
+}


### PR DESCRIPTION
Closes the gaps another session hit while using `@humanjs/mcp` for several hours of real work — building and verifying a landing page at 1440×900 and 390×844. Every item here is something that actually blocked that session, not something spotted by reading the code.

## What was blocking

**No way to emulate `prefers-reduced-motion`.** The page under test had a scroll-and-camera sequence whose reduced-motion path is mandatory. It could not be verified at all, and shipped with "this went untested, eyeball it." For a tool aimed at QA that is the wrong answer, and Playwright already exposes it in one call.

**No way to read the console.** Debugging a CORS problem where images failed to load meant guessing, then checking with `curl` — which carries none of the browser's origin, cookies or headers, so the failure being investigated does not reproduce.

**No network inspection.** Same family: no way to see which requests failed or with what status.

**`human_get_html` returned only the first match.** Needing every `<img>` on a page meant falling back to raw HTML over the network, which missed everything rendered by JS — on that site, nearly all of it.

**`human_screenshot` sometimes looked like it failed.** It returned an image content block and nothing else; clients that summarize a result from its text content render that as `Tool ran without output or errors`.

## What this adds

| Tool | Why |
|---|---|
| `human_console_messages` | Console output *and* uncaught page errors — an exception never arrives as a console message, and it is the most useful signal |
| `human_network_requests` | Method, URL, status, timing; `onlyFailures` covers 4xx/5xx **and** requests that never responded |
| `human_emulate_media` | `prefers-reduced-motion`, `prefers-color-scheme`, `forced-colors` |

Plus `all: true` on `human_get_text` / `human_get_attribute` / `human_get_html`, and a text line alongside every screenshot.

## Design notes

**Capture is always on.** Buffers attach when the session is created, so an agent can act first and ask afterwards — there is no "start capturing" call to forget, and an error thrown during the first page load is still caught.

**Bounded buffers that admit what they lost.** Each holds 500 entries and reports how many were evicted. "No errors found" and "no errors left in the buffer" are different answers, and an agent that cannot tell them apart will confidently report a clean page. The formatter says so explicitly: *"…so this is not proof they never happened."*

**Sweeps are capped and say so.** `all` is bounded by `limit` (10 for `outerHTML`, 100 for text and attributes) and always reports the true total, so a truncated sweep is never mistaken for a complete one. A missing attribute is reported per element as `(absent)` rather than dropped — "which of these has no `href`" is usually the question.

**Single reads are now explicitly `.first()`.** Previously these relied on locator strictness, which errors when a selector matches several elements. The documented "first element" behaviour is now what actually happens, and `all` is the opt-in for the rest.

## Deliberately not included

`human_evaluate` was the other session's third request. It is not here: `packages/mcp/README.md` documents the absence of an arbitrary-JS tool as a security decision — executing page-supplied JavaScript is a prompt-injection cliff — and `CLAUDE.md` lists it under features that require a capability the MCP surface deliberately does not expose.

The underlying need was real, so it is met the way that README says it should be: `all`-mode sweeps, `human_outline`, and the two observability tools. Every `locator.evaluate` here runs a fixed, hard-coded function — never a string from the model or the page. The Security section has been updated to name these as the alternatives.

## Verification

`pnpm install --frozen-lockfile`, `lint` (0), `typecheck` (10/10), `test` (9/9 tasks, 68 in `@humanjs/mcp` including 25 new), `build` (7/7), `check:exports` (13/13).

The README also gains `human_outline`, which was implemented but never listed.