### PR TITLE
chore(deps): bump changesets/action from 1 to 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,18 @@ jobs:
         run: pnpm build
 
       - name: Create release PR or publish
-        uses: changesets/action@v1
+        uses: changesets/action@v2
         with:
           publish: pnpm release
           version: pnpm changeset version
           commit: "chore: version packages"
           title: "chore: version packages"
+          # v2 requires the GitHub credential as an explicit input. It no
+          # longer accepts the GITHUB_TOKEN environment variable, nor the
+          # credentials actions/checkout leaves in the git remote, so
+          # without this line the action cannot open the release PR or push
+          # tags. The env entry below stays for the changesets CLI itself.
+          github-token: ${{ secrets.GITHUB_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Two different consumers read the npm credential, under two different


### PR DESCRIPTION
Supersedes #102, which was a bare version bump and would have broken the release pipeline.

## Why the plain bump was not safe

`changesets/action@v2` changed how it receives the GitHub credential:

> Regardless of the push mode, custom GitHub tokens must be passed explicitly through the `github-token` input. The `GITHUB_TOKEN` environment variable and credentials configured by `actions/checkout` or embedded in remote URLs are not substitutes for this input.

`release.yml` passed it only via `env: GITHUB_TOKEN`, exactly the form v2 stopped accepting. #102 shows green CI, but that is misleading — **no check in this repo exercises the release workflow**, so the failure would only have appeared at the next publish, on `main`, after the version bump had already landed. That is the same shape as the outage we just worked through in #111.

This PR adds the `github-token` input alongside the bump.

## What else v2 changes, and why it is fine here

- **Release commits and tags now push through the GitHub API by default.** No configuration needed; the `contents: write` permission is already granted.
- **`commit-mode` was replaced by `push-with-git-cli`.** This workflow never set `commit-mode`, so there is nothing to migrate.
- **`.npmrc` handling was dropped when `NPM_TOKEN` is set,** in favour of trusted publishing. npm auth here already comes from `actions/setup-node`'s `registry-url` plus `NODE_AUTH_TOKEN`, which is the arrangement v2 expects. The `NPM_TOKEN` env entry stays because the changesets CLI reads it — removing it is what caused the silent OIDC fallback fixed in #111.

## Please merge this one deliberately

CI cannot prove this works; only a real release can. Worth merging when you can watch the next release run rather than letting it sit until a publish happens unattended. If it does fail, reverting to `@v1` restores the current known-good pipeline.

Related and **not** included: #109 (`@changesets/cli` 2 → 3) is blocked — v3 declares `"engines": { "pnpm": ">=10.0.0" }` and this repo is pinned to `pnpm@9.15.0` via `packageManager`. That needs a pnpm 9 → 10 upgrade first, which is its own change.