### PR TITLE
chore: upgrade pnpm from 9 to 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "testing"
   ],
   "type": "module",
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@11.25.0",
   "engines": {
     "node": ">=20"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,23 @@ packages:
   - "packages/*"
   - "apps/*"
   - "examples"
+
+# pnpm 10 stopped running dependency install scripts unless they are allowed
+# explicitly, and pnpm 11 renamed the setting from the `onlyBuiltDependencies`
+# list to this `allowBuilds` map. Each entry below genuinely needs its script,
+# and every failure mode here is silent:
+#
+#   esbuild        fetches its platform binary; tsup and vite are dead without it.
+#   ffmpeg-static  fetches the ffmpeg binary @humanjs/recorder shells out to for
+#                  video and GIF export. Skipping it leaves the library importable
+#                  and every export broken only at runtime.
+#   lefthook       installs the git hook binary the repo's pre-commit relies on.
+#
+# Adding a dependency that ships an install script? pnpm refuses to run it and
+# prints ERR_PNPM_IGNORED_BUILDS. Decide deliberately, then add it here —
+# `pnpm approve-builds` will do it for you, but it rewrites this file and drops
+# these comments, so put them back.
+allowBuilds:
+  esbuild: true
+  ffmpeg-static: true
+  lefthook: true


### PR DESCRIPTION
Unblocks #109. `@changesets/cli@3` declares `"engines": { "pnpm": ">=10.0.0" }` and this repo pins `pnpm@9.15.0` via `packageManager`, so that bump cannot land until pnpm moves. Went to 11 rather than the minimum 10 because the whole suite was verifiable locally and there is no reason to do this twice.

## The migration is two files, but it is not a no-op

`package.json` and `pnpm-workspace.yaml`. The lockfile stays at `lockfileVersion: 9.0` and needs no regeneration — `--frozen-lockfile` passes untouched.

The part that matters is that **pnpm 10 stopped running dependency install scripts unless they are allowed explicitly**, and **pnpm 11 renamed that setting** from the `onlyBuiltDependencies` list to the `allowBuilds` map. A clean install reports:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts:
  esbuild@0.27.7, esbuild@0.28.1, ffmpeg-static@5.3.0, lefthook@2.1.10
```

All three packages genuinely need their script, and all three fail quietly:

| Package | What its script does | What breaks without it |
|---|---|---|
| `esbuild` | fetches the platform binary | `tsup` and `vite` — the whole build |
| `ffmpeg-static` | fetches the `ffmpeg` binary | `@humanjs/recorder` video and GIF export. **The library still imports and every export fails at runtime** |
| `lefthook` | installs the git hook binary | the repo's pre-commit |

`ffmpeg-static` is the dangerous one. Nothing in `lint`/`typecheck`/`test`/`build` touches it, so a migration that skipped this would go green in CI and ship a recorder that cannot export.

## Verification

Full suite on pnpm 11 after a clean install (`node_modules` deleted, `--frozen-lockfile`): `lint`, `typecheck` (10/10), `test` (9/9), `build` (7/7), `check:exports` (13/13).

Then, because the check suite provably cannot catch the `ffmpeg-static` failure, `pnpm demo:record` end to end — which produced a 562 KB mp4, a 3.2 MB GIF, a timeline, and both code exports. That is the real proof.

## Notes

- No workflow changes needed: all four use `pnpm/action-setup@v6`, which reads the version from `packageManager`.
- The `allowBuilds` block carries a comment explaining why each entry is there, and warns that `pnpm approve-builds` rewrites the file and drops those comments.
- After this lands, #109 needs a rebase and should go green.