### PR TITLE
feat(cli): add @humanjs/cli — demo and run commands

### DIFF
--- a/.changeset/cli-initial.md
+++ b/.changeset/cli-initial.md
@@ -1,0 +1,13 @@
+---
+"@humanjs/cli": minor
+---
+
+Initial release — the `humanjs` command line.
+
+`humanjs demo <url>` drives any page the way a person would skim it: land, read the heading, scroll in stages, drift the cursor over a link. It is the ten-second answer to "is the motion actually convincing?", with no project to create first. It never clicks, because it runs on your site rather than ours.
+
+`humanjs run <script>` executes a HumanJS flow with the browser and the `Human` instance already wired, so the script is only the flow. `.ts` files run directly with no build step.
+
+Both accept `--record <file>`, which dispatches on the extension — `.mp4`, `.webm`, `.gif`, `.json`, `.ts`, or `.spec.ts` for a committable Playwright test — plus `--personality`, `--speed`, `--seed`, `--viewport` and `--headless`.
+
+Note that the unscoped `humanjs` name on npm belongs to an unrelated 2022 package, so the CLI is reached as `npx @humanjs/cli`. Installed globally, the binary is plain `humanjs`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ Verified available on npm at project start: `@humanjs/core`, `@humanjs/playwrigh
 | `@humanjs/recorder` | Session recording → mp4 / Playwright code / JSON | v1 |
 | `@humanjs/mcp` | MCP server for runtime AI agents | v1 |
 | `@humanjs/skill` | Anthropic / Cursor / Codex skill for AI coding agents | v1 |
+| `@humanjs/cli` | `npx @humanjs/cli demo <url>` — watch it move, run flows, no project | v1 |
 | `@humanjs/generator` | `npx @humanjs/generator <url>` — visual recorder UI | v2 |
 | `@humanjs/recipes` | Pre-built common flows (login, checkout, etc.) | v2 |
 | `@humanjs/puppeteer` | Puppeteer adapter | v3 |

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gonzalo Muñoz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,86 @@
+# @humanjs/cli
+
+<p>
+  <a href="https://www.npmjs.com/package/@humanjs/cli"><img alt="npm" src="https://img.shields.io/npm/v/@humanjs/cli"></a>
+  <a href="https://www.npmjs.com/package/@humanjs/cli"><img alt="downloads" src="https://img.shields.io/npm/dt/@humanjs/cli"></a>
+  <a href="https://github.com/totigm/humanjs"><img alt="GitHub" src="https://img.shields.io/badge/GitHub-totigm%2Fhumanjs-181717?logo=github"></a>
+  <a href="https://github.com/totigm/humanjs/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/totigm/humanjs/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="https://github.com/totigm/humanjs/blob/main/LICENSE"><img alt="license" src="https://img.shields.io/npm/l/@humanjs/cli"></a>
+  <a href="https://humanjs.dev"><img alt="docs" src="https://img.shields.io/badge/docs-humanjs.dev-emerald"></a>
+</p>
+
+Command line for [HumanJS](https://humanjs.dev). Watch humanized browser automation on any page, and run HumanJS scripts, without creating a project.
+
+```bash
+npx @humanjs/cli demo https://example.com
+```
+
+A browser opens, lands on the page, reads the heading, scrolls in stages, and drifts the cursor over a link — the way a person skims. That is the whole pitch, in one command, before you write a line of code.
+
+> **On the command name.** The unscoped `humanjs` name on npm belongs to an unrelated package from 2022, so `npx humanjs` does **not** reach this CLI. Use `npx @humanjs/cli`. Installed (`npm i -g @humanjs/cli`), the binary is plain `humanjs`.
+
+## Commands
+
+### `demo <url>`
+
+Drives any page the way a person would skim it.
+
+```bash
+npx @humanjs/cli demo https://your-site.com
+npx @humanjs/cli demo https://your-site.com --record tour.gif
+```
+
+Every step is optional at runtime: a page with no heading, nothing to scroll, or no links simply gets fewer steps rather than an error. **It never clicks** — it runs on your site, not ours, so it will not navigate away, submit a form, or fire a side effect.
+
+### `run <script>`
+
+Runs a HumanJS flow with the browser and the `Human` instance already wired. The script is only the flow:
+
+```ts
+// flow.ts
+export default async (human) => {
+  await human.goto('https://example.com');
+  await human.type('#email', 'you@company.com');
+  await human.click('text=Sign in');
+};
+```
+
+```bash
+npx @humanjs/cli run flow.ts
+npx @humanjs/cli run flow.ts --record login.spec.ts --headless
+```
+
+`.ts` files run directly — no build step, no tsconfig. A named `run` export works as well as the default one. The flow receives `(human, page)`, so the raw Playwright `Page` is there when you need it.
+
+## Options
+
+| Option | Purpose |
+|---|---|
+| `--record <file>` | Also record the session. The extension picks the format: `.mp4` `.webm` `.gif` `.json` (timeline) `.ts` (HumanJS script) `.spec.ts` (Playwright test) |
+| `--personality <name>` | `careful` · `fast` · `distracted` · `precise` (default `careful`) |
+| `--speed <pace>` | `human` · `fast` · `instant` (default `human`) |
+| `--seed <string>` | Deterministic run — same seed, same trajectory, every time |
+| `--viewport <WxH>` | Browser size (default `1280x800`; `1440×900` works too) |
+| `--headless` | Run without a window. The default is headed, because the point of `demo` is watching it |
+| `-h`, `--help` | Usage |
+| `-v`, `--version` | Version |
+
+## Recording a flow as a test
+
+`--record` dispatches on the extension, so the same run can produce a video for a README or a committable test:
+
+```bash
+npx @humanjs/cli run checkout.ts --record checkout.spec.ts --headless
+```
+
+That writes a `@playwright/test` spec with assertions derived from the run. Typed text is captured so the test is runnable — **except password fields, which are always masked**. That is deliberate: read the value from an env var in the generated file rather than pasting the secret back in.
+
+## Honest limits
+
+- Built on Playwright — humanizes it, does not replace it. Will not defeat sophisticated bot detection, and is not meant to.
+- `demo` runs against pages it has never seen. It is defensive by design, so on an unusual layout it does less rather than failing.
+- Recording video or GIF needs `ffmpeg`, bundled via `@humanjs/recorder`. `.json` timelines and code exports have no such dependency.
+
+## License
+
+MIT

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@humanjs/cli",
+  "version": "0.0.0",
+  "description": "Command line for HumanJS — see humanized browser automation on any page, and run HumanJS scripts without setting up a project.",
+  "keywords": [
+    "humanjs",
+    "playwright",
+    "cli",
+    "browser-automation",
+    "humanize",
+    "e2e-testing",
+    "qa",
+    "screen-recording",
+    "demo"
+  ],
+  "author": "Gonzalo Muñoz <toti@eventurex.com.ar>",
+  "license": "MIT",
+  "homepage": "https://humanjs.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/totigm/humanjs.git",
+    "directory": "packages/cli"
+  },
+  "bugs": "https://github.com/totigm/humanjs/issues",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "humanjs": "./dist/index.js"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "sideEffects": false,
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "check:exports": "publint --strict",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@humanjs/core": "workspace:*",
+    "@humanjs/playwright": "workspace:*",
+    "@humanjs/recorder": "workspace:*",
+    "playwright": "^1.62.1",
+    "tsx": "^4.23.12"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/cli/src/args.test.ts
+++ b/packages/cli/src/args.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { parseArgs, parseViewport, UsageError } from './args';
+
+describe('parseArgs', () => {
+  it('defaults to help with no arguments', () => {
+    expect(parseArgs([]).command).toBe('help');
+  });
+
+  it('reads the command and its target', () => {
+    const parsed = parseArgs(['demo', 'https://example.com']);
+    expect(parsed.command).toBe('demo');
+    expect(parsed.target).toBe('https://example.com');
+  });
+
+  it('runs headed by default — the point of demo is watching it', () => {
+    expect(parseArgs(['demo', 'https://example.com']).options.headless).toBe(false);
+  });
+
+  it('accepts --flag value and --flag=value alike', () => {
+    const spaced = parseArgs(['demo', 'u', '--personality', 'fast']);
+    const inline = parseArgs(['demo', 'u', '--personality=fast']);
+    expect(spaced.options.personality).toBe('fast');
+    expect(inline.options.personality).toBe('fast');
+  });
+
+  it('lets --headless override the default', () => {
+    expect(parseArgs(['run', 'f.ts', '--headless']).options.headless).toBe(true);
+  });
+
+  it('collects every option in one pass', () => {
+    const { options } = parseArgs([
+      'run',
+      'flow.ts',
+      '--speed=fast',
+      '--seed=abc',
+      '--record=out.gif',
+      '--viewport=800x600',
+    ]);
+    expect(options.speed).toBe('fast');
+    expect(options.seed).toBe('abc');
+    expect(options.record).toBe('out.gif');
+    expect(options.viewport).toEqual({ width: 800, height: 600 });
+  });
+
+  it.each([['-h'], ['--help']])('treats %s as the help command', (flag) => {
+    expect(parseArgs([flag]).command).toBe('help');
+  });
+
+  it.each([['-v'], ['--version']])('treats %s as the version command', (flag) => {
+    expect(parseArgs([flag]).command).toBe('version');
+  });
+
+  describe('rejections name the bad value and the alternatives', () => {
+    it('rejects an unknown command', () => {
+      expect(() => parseArgs(['recrod'])).toThrow(/Unknown command "recrod".*demo, run/s);
+    });
+
+    it('rejects an unknown personality', () => {
+      expect(() => parseArgs(['demo', 'u', '--personality', 'grandma'])).toThrow(
+        /Unknown --personality "grandma".*careful, fast, distracted, precise/s,
+      );
+    });
+
+    it('rejects an unknown speed', () => {
+      expect(() => parseArgs(['demo', 'u', '--speed', 'turbo'])).toThrow(/human, fast, instant/);
+    });
+
+    it('rejects an unknown flag and points at help', () => {
+      expect(() => parseArgs(['demo', 'u', '--fast'])).toThrow(
+        /Unknown flag "--fast".*humanjs help/s,
+      );
+    });
+
+    it('rejects a flag with no value', () => {
+      expect(() => parseArgs(['demo', 'u', '--seed'])).toThrow(/--seed needs a value/);
+    });
+
+    it('does not swallow the next flag as a value', () => {
+      expect(() => parseArgs(['demo', 'u', '--seed', '--headless'])).toThrow(
+        /--seed needs a value/,
+      );
+    });
+
+    it('rejects a third positional argument', () => {
+      expect(() => parseArgs(['demo', 'a', 'b'])).toThrow(/Unexpected extra argument "b"/);
+    });
+
+    it('throws UsageError, so the entry point can skip the stack trace', () => {
+      expect(() => parseArgs(['nope'])).toThrow(UsageError);
+    });
+  });
+});
+
+describe('parseViewport', () => {
+  it('parses WIDTHxHEIGHT', () => {
+    expect(parseViewport('1440x900')).toEqual({ width: 1440, height: 900 });
+  });
+
+  it('accepts the multiplication sign, which is what design tools copy', () => {
+    expect(parseViewport('390×844')).toEqual({ width: 390, height: 844 });
+  });
+
+  it('tolerates spaces around the separator', () => {
+    expect(parseViewport(' 800 x 600 ')).toEqual({ width: 800, height: 600 });
+  });
+
+  it.each([['1440'], ['1440x'], ['axb'], ['0x600'], ['-1x9']])(
+    'rejects %s with an example of the right shape',
+    (bad) => {
+      expect(() => parseViewport(bad)).toThrow(/--viewport/);
+    },
+  );
+});

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -1,0 +1,180 @@
+/**
+ * Argument parsing for the `humanjs` command.
+ *
+ * Hand-rolled rather than pulled from a library: the surface is two
+ * commands and seven flags, and keeping it dependency-free means the
+ * parser is fully unit-testable — which matters more here than anywhere
+ * else in the repo, because on a CLI the error messages *are* the
+ * interface. Every rejection below names the offending value and lists
+ * what was expected instead.
+ */
+
+/** Humanization presets accepted by `--personality`. */
+export const PERSONALITIES = ['careful', 'fast', 'distracted', 'precise'] as const;
+export type Personality = (typeof PERSONALITIES)[number];
+
+/** Paces accepted by `--speed`. */
+export const SPEEDS = ['human', 'fast', 'instant'] as const;
+export type SpeedName = (typeof SPEEDS)[number];
+
+export type CommandName = 'demo' | 'run' | 'help' | 'version';
+
+export interface Viewport {
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface CliOptions {
+  readonly personality: Personality;
+  readonly speed: SpeedName;
+  readonly seed?: string;
+  readonly headless: boolean;
+  /** Output file for a recording; the extension picks the format. */
+  readonly record?: string;
+  readonly viewport: Viewport;
+}
+
+export interface ParsedArgs {
+  readonly command: CommandName;
+  /** URL for `demo`, script path for `run`. */
+  readonly target?: string;
+  readonly options: CliOptions;
+}
+
+const DEFAULTS: CliOptions = {
+  personality: 'careful',
+  speed: 'human',
+  // Headed by default and on purpose: the whole point of `demo` is to
+  // watch it. A headless default would make the first run look like it
+  // did nothing.
+  headless: false,
+  viewport: { width: 1280, height: 800 },
+};
+
+/** Raised for anything the user can fix by retyping the command. */
+export class UsageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UsageError';
+  }
+}
+
+function oneOf<T extends string>(value: string, allowed: readonly T[], flag: string): T {
+  if ((allowed as readonly string[]).includes(value)) return value as T;
+  throw new UsageError(`Unknown ${flag} "${value}". Expected one of: ${allowed.join(', ')}.`);
+}
+
+/**
+ * Parses `WIDTHxHEIGHT`. Accepts the ASCII `x` and the multiplication
+ * sign, because `1280×800` is what a person copying from a design tool
+ * will actually paste.
+ */
+export function parseViewport(value: string): Viewport {
+  const match = /^(\d+)\s*[x×]\s*(\d+)$/i.exec(value.trim());
+  if (!match) {
+    throw new UsageError(`Invalid --viewport "${value}". Expected WIDTHxHEIGHT, e.g. 1280x800.`);
+  }
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  if (width < 1 || height < 1) {
+    throw new UsageError(`Invalid --viewport "${value}". Both sides must be at least 1px.`);
+  }
+  return { width, height };
+}
+
+/** Reads the value for a flag, accepting both `--flag value` and `--flag=value`. */
+function takeValue(
+  flag: string,
+  inline: string | undefined,
+  argv: readonly string[],
+  index: number,
+): { value: string; nextIndex: number } {
+  if (inline !== undefined) {
+    if (inline === '') throw new UsageError(`${flag} needs a value, e.g. ${flag}=something.`);
+    return { value: inline, nextIndex: index };
+  }
+  const next = argv[index + 1];
+  if (next === undefined || next.startsWith('-')) {
+    throw new UsageError(`${flag} needs a value.`);
+  }
+  return { value: next, nextIndex: index + 1 };
+}
+
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  let command: CommandName | undefined;
+  let target: string | undefined;
+  let options: CliOptions = DEFAULTS;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i] as string;
+
+    if (!arg.startsWith('-')) {
+      if (command === undefined) {
+        command = oneOf(arg, ['demo', 'run', 'help', 'version'] as const, 'command');
+      } else if (target === undefined) {
+        target = arg;
+      } else {
+        throw new UsageError(`Unexpected extra argument "${arg}".`);
+      }
+      continue;
+    }
+
+    const [name, inline] = splitFlag(arg);
+    switch (name) {
+      case '--help':
+      case '-h':
+        command = 'help';
+        break;
+      case '--version':
+      case '-v':
+        command = 'version';
+        break;
+      case '--headed':
+        options = { ...options, headless: false };
+        break;
+      case '--headless':
+        options = { ...options, headless: true };
+        break;
+      case '--personality': {
+        const { value, nextIndex } = takeValue(name, inline, argv, i);
+        i = nextIndex;
+        options = { ...options, personality: oneOf(value, PERSONALITIES, '--personality') };
+        break;
+      }
+      case '--speed': {
+        const { value, nextIndex } = takeValue(name, inline, argv, i);
+        i = nextIndex;
+        options = { ...options, speed: oneOf(value, SPEEDS, '--speed') };
+        break;
+      }
+      case '--seed': {
+        const { value, nextIndex } = takeValue(name, inline, argv, i);
+        i = nextIndex;
+        options = { ...options, seed: value };
+        break;
+      }
+      case '--record': {
+        const { value, nextIndex } = takeValue(name, inline, argv, i);
+        i = nextIndex;
+        options = { ...options, record: value };
+        break;
+      }
+      case '--viewport': {
+        const { value, nextIndex } = takeValue(name, inline, argv, i);
+        i = nextIndex;
+        options = { ...options, viewport: parseViewport(value) };
+        break;
+      }
+      default:
+        throw new UsageError(`Unknown flag "${name}". Run \`humanjs help\` to see the options.`);
+    }
+  }
+
+  return { command: command ?? 'help', target, options };
+}
+
+function splitFlag(arg: string): [string, string | undefined] {
+  const eq = arg.indexOf('=');
+  if (eq === -1) return [arg, undefined];
+  return [arg.slice(0, eq), arg.slice(eq + 1)];
+}

--- a/packages/cli/src/commands/demo.ts
+++ b/packages/cli/src/commands/demo.ts
@@ -1,0 +1,111 @@
+/**
+ * `humanjs demo <url>` — the ten-second look at what the library does.
+ *
+ * Someone evaluating HumanJS should not have to write code to find out
+ * whether the motion is convincing. This drives a real page the way a
+ * person would skim it: land, read the heading, scroll in stages, drift
+ * the cursor over something clickable.
+ *
+ * It runs against an arbitrary URL, so every step here is defensive —
+ * a page may have no heading, no links, or nothing to scroll. Each step
+ * is skipped rather than fatal, because a demo that crashes on someone
+ * else's site is worse than one that does slightly less on it.
+ */
+
+import { chromium, createHuman, type Human, installMouseHelper } from '@humanjs/playwright';
+import { record } from '@humanjs/recorder';
+import type { Locator, Page } from 'playwright';
+import type { CliOptions } from '../args';
+
+/**
+ * First of `selectors` that resolves to something visible, as a locator
+ * already narrowed with `.first()`.
+ *
+ * Returning a locator rather than the selector string is the whole point:
+ * on a real page `a[href]` matches dozens of elements, and handing that
+ * string to a primitive trips Playwright's strict mode and hangs until it
+ * times out. Narrowing here means the caller cannot make that mistake.
+ */
+async function firstVisible(page: Page, selectors: readonly string[]): Promise<Locator | null> {
+  for (const selector of selectors) {
+    try {
+      const locator = page.locator(selector).first();
+      if (await locator.isVisible()) return locator;
+    } catch {
+      // An invalid or unsupported selector on an exotic page: try the next.
+    }
+  }
+  return null;
+}
+
+/**
+ * Whether the document is tall enough that scrolling means anything.
+ *
+ * Measured by comparing the body box to the viewport rather than through
+ * `page.evaluate`: the repo's tsconfig carries no DOM lib, so reaching for
+ * `document` here would mean widening it for one predicate.
+ */
+async function isScrollable(page: Page): Promise<boolean> {
+  try {
+    const viewport = page.viewportSize();
+    if (!viewport) return false;
+    const box = await page.locator('body').boundingBox();
+    return box !== null && box.height > viewport.height + 100;
+  } catch {
+    return false;
+  }
+}
+
+async function tour(human: Human, page: Page, url: string): Promise<void> {
+  await human.goto(url);
+  await human.sleep(600);
+
+  const heading = await firstVisible(page, ['h1', 'h2', 'main p', 'article p', 'p']);
+  if (heading) {
+    await human.read(heading);
+    await human.sleep(300);
+  }
+
+  if (await isScrollable(page)) {
+    // Three passes rather than one: the pause between them is where the
+    // motion reads as a person deciding whether to keep going.
+    for (let i = 0; i < 3; i += 1) {
+      await human.scroll('natural');
+      await human.sleep(500);
+    }
+  }
+
+  const clickable = await firstVisible(page, ['a[href]', 'button', '[role="button"]']);
+  if (clickable) {
+    // Hover, never click: this runs on someone else's site and must not
+    // navigate away, submit anything, or trigger a side effect.
+    await human.hover(clickable);
+    await human.sleep(700);
+  }
+}
+
+export async function runDemo(url: string, options: CliOptions): Promise<void> {
+  const { personality, speed, seed, headless, viewport, record: output } = options;
+
+  if (output) {
+    const rec = await record(
+      { output, name: `humanjs demo ${url}`, personality, seed, viewport, headless },
+      async (human, page) => {
+        await tour(human, page, url);
+      },
+    );
+    console.log(`Recorded ${rec.timeline.events.length} actions to ${output}`);
+    return;
+  }
+
+  const browser = await chromium.launch({ headless });
+  try {
+    const context = await browser.newContext({ viewport });
+    await installMouseHelper(context);
+    const page = await context.newPage();
+    const human = await createHuman(page, { personality, speed, seed });
+    await tour(human, page, url);
+  } finally {
+    await browser.close();
+  }
+}

--- a/packages/cli/src/commands/run.test.ts
+++ b/packages/cli/src/commands/run.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { UsageError } from '../args';
+import { selectFlow } from './run';
+
+describe('selectFlow', () => {
+  const flow = async (): Promise<void> => {};
+
+  it('prefers the default export', () => {
+    expect(selectFlow({ default: flow }, 'f.ts')).toBe(flow);
+  });
+
+  it('falls back to a named run export', () => {
+    expect(selectFlow({ run: flow }, 'f.ts')).toBe(flow);
+  });
+
+  it('prefers default when both are present', () => {
+    const other = async (): Promise<void> => {};
+    expect(selectFlow({ default: flow, run: other }, 'f.ts')).toBe(flow);
+  });
+
+  it('explains the expected shape instead of failing later on a call', () => {
+    expect(() => selectFlow({}, 'flow.ts')).toThrow(UsageError);
+    expect(() => selectFlow({}, 'flow.ts')).toThrow(
+      /flow.ts does not export a flow.*export default async \(human\)/s,
+    );
+  });
+
+  it('rejects a non-callable export rather than trusting it', () => {
+    expect(() => selectFlow({ default: { goto: true } }, 'f.ts')).toThrow(/does not export a flow/);
+  });
+});

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,0 +1,96 @@
+/**
+ * `humanjs run <script>` — execute a HumanJS script with no project setup.
+ *
+ * The browser, the `Human` instance and (optionally) the recording are
+ * wired here, so the script is only the flow:
+ *
+ *   export default async (human) => {
+ *     await human.goto('https://example.com');
+ *     await human.click('text=Sign in');
+ *   };
+ *
+ * A named `run` export is accepted too. TypeScript files are loaded
+ * through tsx, so a `.ts` script works without a build step — which is
+ * the point of running it this way rather than wiring tsx yourself.
+ */
+
+import { access } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { chromium, createHuman, type Human, installMouseHelper } from '@humanjs/playwright';
+import { record } from '@humanjs/recorder';
+import type { Page } from 'playwright';
+import { type CliOptions, UsageError } from '../args';
+
+/** The shape a script is expected to export. */
+export type Flow = (human: Human, page: Page) => Promise<void> | void;
+
+interface FlowModule {
+  readonly default?: unknown;
+  readonly run?: unknown;
+}
+
+/**
+ * Picks the exported flow, preferring `default` and falling back to a
+ * named `run`. The error path matters: "your file exported nothing
+ * callable" is the single most likely mistake, so it says exactly what
+ * shape was expected instead of failing with `x is not a function`.
+ */
+export function selectFlow(module: FlowModule, path: string): Flow {
+  const candidate = module.default ?? module.run;
+  if (typeof candidate !== 'function') {
+    throw new UsageError(
+      `${path} does not export a flow. Export an async function as the default export (or as \`run\`):\n\n` +
+        `  export default async (human) => {\n` +
+        `    await human.goto('https://example.com');\n` +
+        `  };`,
+    );
+  }
+  return candidate as Flow;
+}
+
+async function loadFlow(path: string): Promise<Flow> {
+  const absolute = resolve(path);
+  try {
+    await access(absolute);
+  } catch {
+    throw new UsageError(`Script not found: ${absolute}`);
+  }
+
+  if (/\.[cm]?tsx?$/.test(absolute)) {
+    // tsx registers a loader hook for the rest of the process; only paid
+    // for when the script actually is TypeScript.
+    const { register } = await import('tsx/esm/api');
+    register();
+  }
+
+  const module = (await import(pathToFileURL(absolute).href)) as FlowModule;
+  return selectFlow(module, path);
+}
+
+export async function runScript(path: string, options: CliOptions): Promise<void> {
+  const flow = await loadFlow(path);
+  const { personality, speed, seed, headless, viewport, record: output } = options;
+
+  if (output) {
+    const rec = await record(
+      { output, name: `humanjs run ${path}`, personality, seed, viewport, headless },
+      async (human, page) => {
+        await flow(human, page);
+      },
+    );
+    console.log(`Recorded ${rec.timeline.events.length} actions to ${output}`);
+    return;
+  }
+
+  const browser = await chromium.launch({ headless });
+  try {
+    const context = await browser.newContext({ viewport });
+    await installMouseHelper(context);
+    const page = await context.newPage();
+    const human = await createHuman(page, { personality, speed, seed });
+    await flow(human, page);
+  } finally {
+    await browser.close();
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,103 @@
+/**
+ * @humanjs/cli — the `humanjs` command.
+ *
+ * Two commands, both aimed at the same thing: getting from "I read the
+ * README" to "I watched it move" without creating a project.
+ *
+ *   humanjs demo <url>      drive any page the way a person would skim it
+ *   humanjs run <script>    run a HumanJS flow, browser already wired
+ *
+ * Note on invocation: the unscoped `humanjs` name on npm belongs to an
+ * unrelated package from 2022, so `npx humanjs` does NOT reach this CLI.
+ * Use `npx @humanjs/cli`, or install it and the `humanjs` binary is
+ * yours. The help text below says so, because someone will try.
+ */
+
+import { parseArgs, UsageError } from './args';
+import { runDemo } from './commands/demo';
+import { runScript } from './commands/run';
+
+// Replaced at build time by tsup's `define`. The fallback is what you
+// see when running from source, where no build step has substituted it.
+declare const __CLI_VERSION__: string | undefined;
+const VERSION = typeof __CLI_VERSION__ === 'string' ? __CLI_VERSION__ : '0.0.0-dev';
+
+const HELP = `humanjs — humanized browser automation
+
+USAGE
+  npx @humanjs/cli <command> [options]
+
+  Installed globally, the command is just \`humanjs\`. Note that plain
+  \`npx humanjs\` resolves to an unrelated 2022 package, not this one.
+
+COMMANDS
+  demo <url>       Drive a page the way a person would skim it: land, read
+                   the heading, scroll in stages, drift the cursor over a
+                   link. Never clicks — it runs on your site, not ours.
+  run <script>     Run a HumanJS flow. The browser and the Human instance
+                   are wired for you; the script exports just the flow:
+
+                     export default async (human) => {
+                       await human.goto('https://example.com');
+                       await human.click('text=Sign in');
+                     };
+
+                   .ts files run directly — no build step.
+
+OPTIONS
+  --record <file>       Also record the session. The extension picks the
+                        format: .mp4 .webm .gif .json (timeline)
+                        .ts (HumanJS script) .spec.ts (Playwright test)
+  --personality <name>  careful | fast | distracted | precise  (careful)
+  --speed <pace>        human | fast | instant                 (human)
+  --seed <string>       Make the run deterministic — same seed, same
+                        trajectory, every time
+  --viewport <WxH>      Browser size                           (1280x800)
+  --headless            Run without a window (default is headed, because
+                        the point of demo is watching it)
+  -h, --help            Show this
+  -v, --version         Show the version
+
+EXAMPLES
+  npx @humanjs/cli demo https://example.com
+  npx @humanjs/cli demo https://example.com --record tour.gif
+  npx @humanjs/cli run flow.ts --record login.spec.ts --headless
+
+Docs: https://humanjs.dev`;
+
+async function main(): Promise<void> {
+  const { command, target, options } = parseArgs(process.argv.slice(2));
+
+  switch (command) {
+    case 'help':
+      console.log(HELP);
+      return;
+    case 'version':
+      console.log(VERSION);
+      return;
+    case 'demo':
+      if (!target) {
+        throw new UsageError('demo needs a URL, e.g. `humanjs demo https://example.com`.');
+      }
+      await runDemo(target, options);
+      return;
+    case 'run':
+      if (!target) {
+        throw new UsageError('run needs a script path, e.g. `humanjs run flow.ts`.');
+      }
+      await runScript(target, options);
+      return;
+  }
+}
+
+main().catch((error: unknown) => {
+  // A usage mistake is not a crash. Printing a stack trace for a typo
+  // buries the one line that tells the user what to fix.
+  if (error instanceof UsageError) {
+    console.error(error.message);
+    console.error('\nRun `humanjs help` for usage.');
+    process.exit(2);
+  }
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'tsup';
+import pkg from './package.json' with { type: 'json' };
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  treeshake: true,
+  splitting: false,
+  // The bin entry needs a shebang so `humanjs` is directly executable.
+  banner: { js: '#!/usr/bin/env node' },
+  // Bake the real version in at build time. Reading package.json at
+  // runtime would mean resolving a path out of dist/, which differs
+  // between the ESM and CJS outputs; a CLI that misreports its own
+  // version is a support ticket waiting to happen.
+  define: { __CLI_VERSION__: JSON.stringify(pkg.version) },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,24 @@ importers:
         specifier: ^1.62.1
         version: 1.62.1
 
+  packages/cli:
+    dependencies:
+      '@humanjs/core':
+        specifier: workspace:*
+        version: link:../core
+      '@humanjs/playwright':
+        specifier: workspace:*
+        version: link:../playwright
+      '@humanjs/recorder':
+        specifier: workspace:*
+        version: link:../recorder
+      playwright:
+        specifier: ^1.62.1
+        version: 1.62.1
+      tsx:
+        specifier: ^4.23.12
+        version: 4.23.12
+
   packages/core: {}
 
   packages/generator:


### PR DESCRIPTION
Evaluating HumanJS currently requires writing code first. This closes that gap:

```bash
npx @humanjs/cli demo https://your-site.com
```

A browser opens, lands, reads the heading, scrolls in stages, and drifts the cursor over a link — the way a person skims. Ten seconds, nothing to set up.

## Two commands

**`demo <url>`** — the look-at-it command. **`run <script>`** — executes a HumanJS flow with the browser and `Human` already wired, so the file is only the flow:

```ts
export default async (human) => {
  await human.goto('https://example.com');
  await human.click('text=Sign in');
};
```

`.ts` runs directly through tsx, no build step. Both take `--record <file>` (extension picks the format, including `.spec.ts` for a committable Playwright test), `--personality`, `--speed`, `--seed`, `--viewport`, `--headless`.

## `npx humanjs` will not work, and that changes the pitch

The unscoped `humanjs` name on npm is taken — an unrelated CLI from 2022, `v1.0.1`, last published June 2022. `npx humanjs` fetches **that**, not this. So the entry point is `npx @humanjs/cli`; installed globally, the binary is plain `humanjs`.

This is called out in the help text and the README because people will try it. If the shorter form matters, claiming the dormant name through npm's dispute process is a separate decision and yours to make.

## Design notes

**`demo` runs on other people's sites.** Every step degrades instead of failing — no heading, nothing to scroll, no links each just means fewer steps. And it **hovers, never clicks**: it must not navigate away, submit a form, or fire a side effect on a site it was pointed at.

**Selector lookups return locators already narrowed with `.first()`.** The first real run against a live page hung: a bare `a[href]` matches dozens of elements, trips Playwright's strict mode, and waits out the timeout. Returning a narrowed locator rather than a selector string means a caller cannot reintroduce that.

**The version is injected at build time** via tsup's `define`. Reading `package.json` at runtime means resolving a path out of `dist/`, which differs between the ESM and CJS outputs — and a CLI that misreports its own version is a support ticket waiting to happen.

**Arg parsing is hand-rolled and unit-tested.** On a CLI the error messages *are* the interface, so every rejection names the bad value and lists what was expected. `--viewport` accepts `1440×900` as well as `1440x800`, because that is what gets pasted from a design tool.

## Package checklist (per `CLAUDE.md`)

`version: 0.0.0` + `publishConfig.access: public` so the first changeset publishes `0.1.0`; tsconfig and tsup config mirrored from `packages/mcp`; badge row on the README; regular `dependencies` rather than peers, since a `npx`-launched package has no host app to supply them; Packages table updated.

## Verification

31 unit tests. Whole suite green with the package wired in: `lint`, `typecheck` (11/11), `test` (10/10), `build` (8/8), `check:exports` (15/15).

Smoke-tested from `dist/`: help, `--version`, a usage error (clean message, exit 2, no stack), and `demo https://example.com --record t.gif --headless`, which recorded 6 actions to a GIF.

## Found while dogfooding

`demo` against `https://humanjs.dev` fails — but upstream, not here. A single transient `Page.captureScreenshot` protocol error permanently stops the capture loop in `packages/playwright/src/recording/capture.ts`, so zero frames are captured and the export dies with "No frames were captured". A dropped frame should not cost the whole recording. Fix coming in its own PR.